### PR TITLE
fix: fix jsonify type

### DIFF
--- a/.changeset/angry-ads-count.md
+++ b/.changeset/angry-ads-count.md
@@ -1,0 +1,5 @@
+---
+"@rethinkhealth/hl7v2-jsonify": patch
+---
+
+Fixed a small bug with typing of jsonify

--- a/packages/hl7v2-jsonify/src/index.ts
+++ b/packages/hl7v2-jsonify/src/index.ts
@@ -17,7 +17,7 @@ type SegmentJSON = {
   fields: (FieldValue | FieldValue[])[]; // Nested arrays for fields/repetitions/components
 };
 
-export const hl7v2Jsonify: Plugin<[], Nodes, string> = function (): void {
+export const hl7v2Jsonify: Plugin<[], Root, string> = function (): void {
   // biome-ignore lint/complexity/noUselessThisAlias: this is a plugin
   const self = this;
 


### PR DESCRIPTION
This pull request addresses a minor typing issue in the `hl7v2-jsonify` package. The main change ensures the plugin function uses the correct root node type, which improves type safety and resolves the bug.

Type safety and bug fix:

* Updated the type of the first parameter in the `hl7v2Jsonify` plugin function from `Nodes` to `Root` in `packages/hl7v2-jsonify/src/index.ts`, fixing a typing bug and ensuring proper type usage.
* Added a patch changelog entry describing the bug fix in `.changeset/angry-ads-count.md`.