### PR TITLE
feat: adding a new linter for message size

### DIFF
--- a/.changeset/fast-crabs-wink.md
+++ b/.changeset/fast-crabs-wink.md
@@ -1,0 +1,5 @@
+---
+"@rethinkhealth/hl7v2-lint-max-message-size": patch
+---
+
+New lint rule that warns when an HL7v2 message exceeds a configurable maximum size in bytes or number of segments.

--- a/packages/hl7v2-lint-max-message-size/README.md
+++ b/packages/hl7v2-lint-max-message-size/README.md
@@ -1,0 +1,89 @@
+# @rethinkhealth/hl7v2-lint-max-message-size
+
+A [`unified`][github-unified] lint rule that warns when an HL7v2 message exceeds a configurable maximum size in bytes or number of segments.
+
+- **Default max size:** 10,000,000 bytes (10MB)
+- **Optional:** Limit the number of segments
+
+## What is this?
+
+This package validates the **maximum message size** in HL7v2 syntax trees produced by parsers like [`@rethinkhealth/hl7v2-parser`][github-hl7v2-parser].  
+
+It reports a message when the HL7v2 message exceeds a configurable maximum size in bytes (default: 1,000,000 bytes) or, optionally, a maximum number of segments.
+
+## When should I use this?
+
+Use this rule to enforce a maximum HL7v2 message size (in bytes) and/or segment count, helping to prevent oversized messages that may cause downstream processing issues or violate system constraints.
+
+This linter is useful for:
+- Ensuring HL7v2 messages do not exceed a safe or expected size limit (default: 10MB).
+- Optionally restricting the number of segments in a message to catch unusually large or malformed messages.
+- Improving reliability and performance by catching messages that could cause resource exhaustion or be rejected by receivers.
+
+Configure the rule to match your system's requirements for message size and segment count.
+
+## Install
+
+This package is **ESM only**. In Node.js (v16+), install with npm:
+
+```sh
+npm install @rethinkhealth/hl7v2-lint-max-message-size
+````
+
+## Use
+
+On the API:
+
+```js
+import { unified } from 'unified'
+import { hl7v2Parse } from '@rethinkhealth/hl7v2-parser'
+import hl7v2LintMaxMessageSize from '@rethinkhealth/hl7v2-lint-max-message-size'
+import { reporter } from 'vfile-reporter'
+
+const msg = `MSH|^~\\&|...`
+const file = await unified()
+  .use(hl7v2Parse)
+  .use(hl7v2LintMaxMessageSize)
+  .process(msg)
+
+console.error(reporter([file]))
+```
+
+## API
+
+### `unified().use(hl7v2LintMaxMessageSize[, options])`
+
+Warns when the HL7v2 message exceeds a configurable maximum size in bytes (default: 10,000,000 bytes) or, optionally, a maximum number of segments.  
+Reports a message if the message is too large or has too many segments.
+
+###### Returns
+
+A `unified` Transformer that adds messages to the file.
+
+## Security
+
+This plugin only transforms AST nodes and does not execute code. Ensure you trust the source of HL7v2 messages before processing.
+
+
+## Contributing
+
+We welcome contributions! Please see our [Contributing Guide](../../CONTRIBUTING.md) for more details.
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## Code of Conduct
+
+To ensure a welcoming and positive environment, we have a [Code of Conduct](../../CODE_OF_CONDUCT.md) that all contributors and participants are expected to adhere to.
+
+## License
+
+Copyright 2025 Rethink Health, SUARL. All rights reserved.
+
+This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE](../../LICENSE) file for details.
+
+[github-unified]: https://github.com/unifiedjs/unified
+[github-hl7v2-parser]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-parser

--- a/packages/hl7v2-lint-max-message-size/package.json
+++ b/packages/hl7v2-lint-max-message-size/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@rethinkhealth/hl7v2-lint-max-message-size",
+  "description": "hl7v2-lint rule to warn when message size exceeds the maximum allowed size",
+  "version": "0.0.1",
+  "license": "MIT",
+  "author": {
+    "name": "Melek Somai",
+    "email": "melek@rethinkhealth.io"
+  },
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsup && tsc --emitDeclarationOnly",
+    "check-types": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "unified": "11.0.1",
+    "unified-lint-rule": "^3.0.0",
+    "unist-util-visit-parents": "^6.0.1"
+  },
+  "devDependencies": {
+    "@rethinkhealth/hl7v2": "workspace:*",
+    "@rethinkhealth/hl7v2-ast": "workspace:*",
+    "@rethinkhealth/testing": "workspace:*",
+    "@rethinkhealth/tsconfig": "workspace:*",
+    "@types/node": "22.15.31",
+    "@types/unist": "^3.0.3",
+    "@vitest/coverage-c8": "^0.33.0",
+    "@vitest/coverage-v8": "^3.2.4",
+    "tsup": "8.5.0",
+    "typescript": "^5.8.3",
+    "vfile-reporter": "^8.1.1",
+    "vitest": "^3.2.4"
+  },
+  "repository": "rethinkhealth/hl7v2.git",
+  "homepage": "https://www.rethinkhealth.io/hl7v2/docs",
+  "keywords": [
+    "hl7",
+    "hl7v2",
+    "nodejs",
+    "typescript",
+    "definition",
+    "lint",
+    "hl7v2-lint",
+    "hl7v2-lint-rule",
+    "rule"
+  ],
+  "packageManager": "pnpm@10.12.1",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/hl7v2-lint-max-message-size/src/index.ts
+++ b/packages/hl7v2-lint-max-message-size/src/index.ts
@@ -1,0 +1,69 @@
+import type { Node, Root } from '@rethinkhealth/hl7v2-ast';
+import { lintRule } from 'unified-lint-rule';
+import { SKIP, visitParents } from 'unist-util-visit-parents';
+
+export interface MaxMessageSizeOptions {
+  /** Max allowed size of the HL7v2 message in bytes (UTF-8). Default: 1_000_000 (1MB). */
+  maxBytes?: number;
+  /**
+   * Max allowed number of segments (counts nodes with `type: "segment"`).
+   * Default: undefined (disabled). Set to a number to enable.
+   */
+  maxSegments?: number;
+}
+
+const defaultOptions: Required<Omit<MaxMessageSizeOptions, 'maxSegments'>> & {
+  maxSegments?: number;
+} = {
+  maxBytes: 10_000_000, // 10MB
+  maxSegments: undefined,
+};
+
+/**
+ * hl7v2-lint rule to warn when message size exceeds the maximum allowed size.
+ *
+ * This rule is useful for ensuring that HL7v2 messages do not exceed a safe
+ * or expected size limit (default: 10MB).
+ */
+const hl7v2LintMaxMessageSize = lintRule<Node, MaxMessageSizeOptions>(
+  {
+    origin: 'hl7v2-lint:max-message-size',
+    url: 'https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-max-message-size#readme',
+  },
+  (tree, file, opts) => {
+    const options = { ...defaultOptions, ...opts };
+
+    // Byte length of the message
+    const byteLength = Buffer.byteLength(String(file.value), 'utf8');
+    if (byteLength > options.maxBytes) {
+      file.message(
+        `Message size ${byteLength.toLocaleString()} B exceeds limit ${(options.maxBytes).toLocaleString()} B`,
+        {
+          ancestors: [tree],
+          place: tree.position,
+        }
+      );
+    }
+
+    visitParents(tree, (node, parents) => {
+      // Message count at the root level
+      if (node.type === 'root') {
+        const totalSegments = (node as Root).children.length;
+
+        if (options.maxSegments && totalSegments > options.maxSegments) {
+          file.message(
+            `Message has ${totalSegments} segments, exceeds limit ${options.maxSegments}`,
+            {
+              ancestors: [...parents, node],
+              place: node.position,
+            }
+          );
+        }
+        return SKIP;
+      }
+      return SKIP;
+    });
+  }
+);
+
+export default hl7v2LintMaxMessageSize;

--- a/packages/hl7v2-lint-max-message-size/tests/index.test.ts
+++ b/packages/hl7v2-lint-max-message-size/tests/index.test.ts
@@ -1,0 +1,92 @@
+import { parseHL7v2 } from '@rethinkhealth/hl7v2';
+import { reporter } from 'vfile-reporter';
+import { describe, expect, it } from 'vitest';
+import hl7v2LintMaxMessageSize from '../src';
+
+describe('hl7v2-lint:max-message-size', () => {
+  it('should have no issues for a small message', async () => {
+    const msg = [
+      // MSH
+      'MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5',
+      // PID
+      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      // OBX
+      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
+    ].join('\r');
+
+    const output = await parseHL7v2().use(hl7v2LintMaxMessageSize).process(msg);
+
+    const report = reporter(output);
+
+    expect(report).toEqual('no issues found');
+  });
+
+  it('warns when message size exceeds the limit', async () => {
+    // Message size is ~440 bytes
+    const msg = [
+      // MSH
+      'MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5',
+      // PID
+      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      // OBX
+      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
+    ].join('\r');
+
+    const output = await parseHL7v2()
+      .use(hl7v2LintMaxMessageSize, { maxBytes: 100 })
+      .process(msg);
+
+    const report = reporter(output);
+
+    expect(report).not.toEqual('no issues found');
+    expect(report).toContain('Message size 441 B exceeds limit 100 B');
+  });
+
+  it('warns when message has too many segments', async () => {
+    // Message size is ~440 bytes
+    const msg = [
+      // MSH
+      'MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5',
+      // PID
+      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      // OBX
+      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
+    ].join('\r');
+
+    const output = await parseHL7v2()
+      .use(hl7v2LintMaxMessageSize, { maxSegments: 1 })
+      .process(msg);
+
+    const report = reporter(output);
+
+    expect(report).not.toEqual('no issues found');
+    expect(report).toContain('Message has 3 segments, exceeds limit 1');
+  });
+
+  it('warns when message has too many segments and size exceeds the limit', async () => {
+    // Message size is ~440 bytes
+    const msg = [
+      // MSH
+      'MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5',
+      // PID
+      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      // OBX
+      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
+    ].join('\r');
+
+    const file = await parseHL7v2()
+      .use(hl7v2LintMaxMessageSize, { maxSegments: 1, maxBytes: 100 })
+      .process(msg);
+
+    const report = reporter(file);
+
+    expect(report).not.toEqual('no issues found');
+    expect(file.messages).toHaveLength(2);
+    expect(file.messages[0].message).toContain(
+      'Message size 441 B exceeds limit 100 B'
+    );
+    expect(file.messages[1].message).toContain(
+      'Message has 3 segments, exceeds limit 1'
+    );
+  });
+});

--- a/packages/hl7v2-lint-max-message-size/tsconfig.json
+++ b/packages/hl7v2-lint-max-message-size/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@rethinkhealth/tsconfig/library.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/hl7v2-lint-max-message-size/tsup.config.ts
+++ b/packages/hl7v2-lint-max-message-size/tsup.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    /**
+     * Directories and files should be bundled so that the resulting files line
+     * up with the TSC generated type definitions.
+     */
+    index: 'src/index.ts',
+    // "utils/index": "src/utils/index.ts",
+  },
+  format: ['esm'],
+  target: 'es2022',
+  sourcemap: true,
+  // treeshake: true,
+
+  /**
+   * Do not use tsup for generating d.ts files because it can not generate type
+   * the definition maps required for go-to-definition to work in our IDE. We
+   * use tsc for that.
+   */
+});

--- a/packages/hl7v2-lint-max-message-size/vitest.config.ts
+++ b/packages/hl7v2-lint-max-message-size/vitest.config.ts
@@ -1,0 +1,11 @@
+import { baseConfig } from '@rethinkhealth/testing';
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      name: 'hl7-parser',
+    },
+  })
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,55 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.31)(@vitest/ui@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
 
+  packages/hl7v2-lint-max-message-size:
+    dependencies:
+      unified:
+        specifier: 11.0.1
+        version: 11.0.1
+      unified-lint-rule:
+        specifier: ^3.0.0
+        version: 3.0.1
+      unist-util-visit-parents:
+        specifier: ^6.0.1
+        version: 6.0.1
+    devDependencies:
+      '@rethinkhealth/hl7v2':
+        specifier: workspace:*
+        version: link:../hl7v2
+      '@rethinkhealth/hl7v2-ast':
+        specifier: workspace:*
+        version: link:../hl7v2-ast
+      '@rethinkhealth/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@rethinkhealth/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: 22.15.31
+        version: 22.15.31
+      '@types/unist':
+        specifier: ^3.0.3
+        version: 3.0.3
+      '@vitest/coverage-c8':
+        specifier: ^0.33.0
+        version: 0.33.0(vitest@3.2.4)
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4)
+      tsup:
+        specifier: 8.5.0
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vfile-reporter:
+        specifier: ^8.1.1
+        version: 8.1.1
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.31)(@vitest/ui@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+
   packages/hl7v2-lint-required-message-header:
     dependencies:
       unified:


### PR DESCRIPTION
This pull request introduces a new lint rule package, `@rethinkhealth/hl7v2-lint-max-message-size`, for HL7v2 messages. The rule warns when a message exceeds a configurable maximum size in bytes or number of segments, helping enforce message size constraints and prevent processing issues. The implementation includes configuration, documentation, and tests to ensure correct behavior.

### New HL7v2 lint rule package

* Added new package `@rethinkhealth/hl7v2-lint-max-message-size` that provides a lint rule to warn when HL7v2 message size exceeds a configurable maximum in bytes or segments. [[1]](diffhunk://#diff-f4b8ba80aa83fde20434aca71f706650d94d7f23c4f0adf57217a786d3134b5dR1-R5) [[2]](diffhunk://#diff-db4a574757e31e2dc47c5f3342eb83b9f8aafb51439754a9f4dcb48e5506f08fR1-R61) [[3]](diffhunk://#diff-97f7eaf8713811e68760083ad897f9460c8c2967df98286de325b864d8ea085eR1-R69)

### Documentation and configuration

* Created comprehensive documentation in `README.md` explaining usage, configuration options, and installation instructions for the new lint rule.
* Added TypeScript and build configuration files (`tsconfig.json`, `tsup.config.ts`) for package setup and bundling. [[1]](diffhunk://#diff-735c5964494043d08de74d487b5fe01ccdc52333a586ea81847608976e60faa6R1-R7) [[2]](diffhunk://#diff-23358ea3a94773704cf54a2696c07d3a1b6e651beefab7bd01bb0e247493fb82R1-R22)
* Added Vitest configuration for testing the package.

### Testing

* Implemented tests in `index.test.ts` to verify that the rule correctly warns for messages exceeding byte size or segment count limits, and passes for valid messages.

### Dependency management

* Registered all necessary dependencies and devDependencies in `package.json` and updated `pnpm-lock.yaml` to include the new package and its requirements. [[1]](diffhunk://#diff-db4a574757e31e2dc47c5f3342eb83b9f8aafb51439754a9f4dcb48e5506f08fR1-R61) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR213-R261)