### PR TITLE
chore: refactoring and fixing 

### DIFF
--- a/.changeset/purple-sides-refuse.md
+++ b/.changeset/purple-sides-refuse.md
@@ -1,0 +1,6 @@
+---
+"@rethinkhealth/hl7v2-decode-escapes": patch
+"@rethinkhealth/hl7v2-parser": patch
+---
+
+Minor fix to the delimiters and carriage return for segments.

--- a/packages/hl7v2-ast/index.d.ts
+++ b/packages/hl7v2-ast/index.d.ts
@@ -14,7 +14,7 @@ export type Delimiters = {
   subcomponent: string;
   repetition: string;
   escape: string;
-  segment: string; // now always a string
+  segment: string;
 };
 
 // ## Abstract nodes

--- a/packages/hl7v2-ast/index.d.ts
+++ b/packages/hl7v2-ast/index.d.ts
@@ -8,7 +8,7 @@ import type {
 /**
  * HL7v2 Delimiters type
  */
-export type HL7v2Delimiters = {
+export type Delimiters = {
   field: string;
   component: string;
   subcomponent: string;
@@ -169,7 +169,7 @@ export interface Root extends Parent {
  * Info associated with HL7v2 root nodes by the ecosystem.
  */
 export interface RootData extends Data {
-  delimiters: HL7v2Delimiters;
+  delimiters: Delimiters;
 }
 
 /**

--- a/packages/hl7v2-ast/index.d.ts
+++ b/packages/hl7v2-ast/index.d.ts
@@ -5,6 +5,18 @@ import type {
   Parent as UnistParent,
 } from 'unist';
 
+/**
+ * HL7v2 Delimiters type
+ */
+export type HL7v2Delimiters = {
+  field: string;
+  component: string;
+  subcomponent: string;
+  repetition: string;
+  escape: string;
+  segment: string; // now always a string
+};
+
 // ## Abstract nodes
 
 /**
@@ -156,7 +168,9 @@ export interface Root extends Parent {
 /**
  * Info associated with HL7v2 root nodes by the ecosystem.
  */
-export interface RootData extends Data {}
+export interface RootData extends Data {
+  delimiters: HL7v2Delimiters;
+}
 
 /**
  * HL7v2 segment.

--- a/packages/hl7v2-decode-escapes/src/index.ts
+++ b/packages/hl7v2-decode-escapes/src/index.ts
@@ -1,8 +1,9 @@
-import type { Root, Subcomponent } from '@rethinkhealth/hl7v2-ast';
-import {
-  DEFAULT_DELIMITERS,
-  type HL7v2Delimiters,
-} from '@rethinkhealth/hl7v2-utils';
+import type {
+  HL7v2Delimiters,
+  Root,
+  Subcomponent,
+} from '@rethinkhealth/hl7v2-ast';
+import { DEFAULT_DELIMITERS } from '@rethinkhealth/hl7v2-utils';
 import type { Plugin } from 'unified';
 import { visit } from 'unist-util-visit';
 

--- a/packages/hl7v2-decode-escapes/src/index.ts
+++ b/packages/hl7v2-decode-escapes/src/index.ts
@@ -81,7 +81,7 @@ function decode(value: string, d: typeof DEFAULT_DELIMITERS): string {
           decoded += d.escape;
           break;
         case '.br':
-          decoded += '\r'; // or '\n' if you prefer LF
+          decoded += d.segment;
           break;
         case 'H':
         case 'N':

--- a/packages/hl7v2-decode-escapes/src/index.ts
+++ b/packages/hl7v2-decode-escapes/src/index.ts
@@ -1,14 +1,10 @@
-import type {
-  HL7v2Delimiters,
-  Root,
-  Subcomponent,
-} from '@rethinkhealth/hl7v2-ast';
+import type { Delimiters, Root, Subcomponent } from '@rethinkhealth/hl7v2-ast';
 import { DEFAULT_DELIMITERS } from '@rethinkhealth/hl7v2-utils';
 import type { Plugin } from 'unified';
 import { visit } from 'unist-util-visit';
 
 export type HL7v2DecodeOptions = {
-  delimiters?: Partial<HL7v2Delimiters>;
+  delimiters?: Partial<Delimiters>;
 };
 
 /**
@@ -24,7 +20,7 @@ export const hl7v2DecodeEscapes: Plugin<[HL7v2DecodeOptions?], Root, Root> = (
 ) => {
   return (tree: Root) => {
     const delimiters =
-      (tree.data as { delimiters?: Partial<HL7v2Delimiters> })?.delimiters ||
+      (tree.data as { delimiters?: Partial<Delimiters> })?.delimiters ||
       options?.delimiters;
 
     visit(tree, 'subcomponent', (node: Subcomponent) => {

--- a/packages/hl7v2-decode-escapes/tests/index.test.ts
+++ b/packages/hl7v2-decode-escapes/tests/index.test.ts
@@ -1,14 +1,11 @@
-import type { Root, Subcomponent } from '@rethinkhealth/hl7v2-ast';
-import {
-  DEFAULT_DELIMITERS,
-  type HL7v2Delimiters,
-} from '@rethinkhealth/hl7v2-utils';
+import type { Delimiters, Root, Subcomponent } from '@rethinkhealth/hl7v2-ast';
+import { DEFAULT_DELIMITERS } from '@rethinkhealth/hl7v2-utils';
 import { unified } from 'unified';
 import { visit } from 'unist-util-visit';
 import { describe, expect, it } from 'vitest';
 import { hl7v2DecodeEscapes } from '../src/index';
 
-function makeTree(value: string, delimiters?: Partial<HL7v2Delimiters>): Root {
+function makeTree(value: string, delimiters?: Delimiters): Root {
   return {
     type: 'root',
     children: [
@@ -37,7 +34,7 @@ function makeTree(value: string, delimiters?: Partial<HL7v2Delimiters>): Root {
         ],
       },
     ],
-    data: delimiters ? { delimiters } : {},
+    data: { delimiters: delimiters ?? DEFAULT_DELIMITERS },
   };
 }
 
@@ -61,7 +58,8 @@ describe('hl7v2DecodeEscapes plugin', () => {
       repetition: '%',
       subcomponent: '@',
       escape: '\\',
-    };
+      segment: '\n',
+    } satisfies Delimiters;
     const tree = makeTree('Test\\F\\Custom\\S\\Delims', customDelimiters);
 
     await unified().use(hl7v2DecodeEscapes).run(tree);

--- a/packages/hl7v2-decode-escapes/tests/index.test.ts
+++ b/packages/hl7v2-decode-escapes/tests/index.test.ts
@@ -1,5 +1,8 @@
 import type { Root, Subcomponent } from '@rethinkhealth/hl7v2-ast';
-import type { HL7v2Delimiters } from '@rethinkhealth/hl7v2-utils';
+import {
+  DEFAULT_DELIMITERS,
+  type HL7v2Delimiters,
+} from '@rethinkhealth/hl7v2-utils';
 import { unified } from 'unified';
 import { visit } from 'unist-util-visit';
 import { describe, expect, it } from 'vitest';
@@ -68,13 +71,13 @@ describe('hl7v2DecodeEscapes plugin', () => {
     });
   });
 
-  it('decodes .br into carriage return', async () => {
+  it('decodes .br into the default segment delimiter', async () => {
     const tree = makeTree('Line1\\.br\\Line2');
 
     await unified().use(hl7v2DecodeEscapes).run(tree);
 
     visit(tree, 'subcomponent', (node: Subcomponent) => {
-      expect(node.value).toBe('Line1\rLine2');
+      expect(node.value).toBe(`Line1${DEFAULT_DELIMITERS.segment}Line2`);
     });
   });
 

--- a/packages/hl7v2-parser/CHANGELOG.md
+++ b/packages/hl7v2-parser/CHANGELOG.md
@@ -105,4 +105,4 @@
 
   - Removed regex-based segment splitting in favor of optimized string split for performance.
   - Refactored parser core to allow plugins such as validation, annotation, and transformation stages.
-  - Added `HL7v2Delimiters` type and default constants.
+  - Added `Delimiters` type and default constants.

--- a/packages/hl7v2-parser/src/parser.ts
+++ b/packages/hl7v2-parser/src/parser.ts
@@ -4,8 +4,13 @@ import type { Plugin } from 'unified';
 import { defaultPreprocessors, runPreprocessors } from './preprocessor';
 import { parseHL7v2FromIterator } from './processor';
 import { HL7v2Tokenizer } from './tokenizer';
-import type { ParseOptions, ParserContext } from './types';
-import { iterateTokenizerSync } from './utils';
+import type { ParseOptions, ParserContext, Token, Tokenizer } from './types';
+
+function* iterateTokenizerSync(t: Tokenizer): Iterable<Token> {
+  for (let tok = t.next(); tok; tok = t.next()) {
+    yield tok;
+  }
+}
 
 export function parseHL7v2(input: string, opts: ParseOptions): Root {
   let ctx: ParserContext = {

--- a/packages/hl7v2-parser/src/parser.ts
+++ b/packages/hl7v2-parser/src/parser.ts
@@ -24,7 +24,7 @@ export function parseHL7v2(input: string, opts: ParseOptions): Root {
   // Reset tokenizer.
   tokenizer.reset(ctx);
   // Parse
-  return parseHL7v2FromIterator(iterateTokenizerSync(tokenizer));
+  return parseHL7v2FromIterator(iterateTokenizerSync(tokenizer), ctx);
 }
 
 const hl7v2Parser: Plugin<[ParseOptions?], string, Root> = function (

--- a/packages/hl7v2-parser/src/preprocessor.ts
+++ b/packages/hl7v2-parser/src/preprocessor.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_DELIMITERS } from '@rethinkhealth/hl7v2-utils';
 import type { ParserContext, PreprocessorStep } from './types';
 
 // PreprocessorStep is declared in `types.ts` to avoid circular imports
@@ -13,10 +14,10 @@ export const stripBOM: PreprocessorStep = (ctx) => {
 };
 
 /**
- * Step: normalize newlines to CR (\r).
+ * Step: normalize newlines to the default delimiters.
  */
 export const normalizeNewlines: PreprocessorStep = (ctx) => {
-  ctx.input = ctx.input.replace(/\r?\n/g, '\r');
+  ctx.input = ctx.input.replace(/\r?\n/g, ctx.delimiters.segment);
   return ctx;
 };
 
@@ -25,20 +26,21 @@ export const normalizeNewlines: PreprocessorStep = (ctx) => {
  */
 export const detectDelimiters: PreprocessorStep = (ctx) => {
   if (ctx.input.startsWith('MSH')) {
-    const fieldDelim = ctx.input.charAt(3) || '|';
+    const field = ctx.input.charAt(3) || DEFAULT_DELIMITERS.field;
     const enc = ctx.input.slice(4, 8);
-    const component = enc.charAt(0) || '^';
-    const repetition = enc.charAt(1) || '~';
-    const _escape = enc.charAt(2) || '\\';
-    const subcomponent = enc.charAt(3) || '&';
+    const component = enc.charAt(0) || DEFAULT_DELIMITERS.component;
+    const repetition = enc.charAt(1) || DEFAULT_DELIMITERS.repetition;
+    const _escape = enc.charAt(2) || DEFAULT_DELIMITERS.escape;
+    const subcomponent = enc.charAt(3) || DEFAULT_DELIMITERS.subcomponent;
+    const segment = DEFAULT_DELIMITERS.segment;
 
     ctx.delimiters = {
-      field: fieldDelim,
+      field,
       component,
       repetition,
       escape: _escape,
       subcomponent,
-      segment: '\r',
+      segment,
     };
   }
   return ctx;

--- a/packages/hl7v2-parser/src/processor.ts
+++ b/packages/hl7v2-parser/src/processor.ts
@@ -9,11 +9,17 @@ import type {
   Subcomponent,
 } from '@rethinkhealth/hl7v2-ast';
 import { isEmptyNode } from '@rethinkhealth/hl7v2-utils';
-import type { Position, Token } from './types';
+import type { ParserContext, Position, Token } from './types';
 
 // Shared core: process a single token into mutable parse state
-function createParserCore() {
-  const root: Root = { type: 'root', children: [] };
+function createParserCore(ctx: ParserContext) {
+  const root: Root = {
+    type: 'root',
+    children: [],
+    data: {
+      delimiters: ctx.delimiters,
+    },
+  };
 
   let seg: Segment | null = null;
   let field: Field | null = null;
@@ -243,8 +249,11 @@ function createParserCore() {
 }
 
 // Sync convenience wrapper over a sync Iterable token source
-export function parseHL7v2FromIterator(tokens: Iterable<Token>): Root {
-  const core = createParserCore();
+export function parseHL7v2FromIterator(
+  tokens: Iterable<Token>,
+  ctx: ParserContext
+): Root {
+  const core = createParserCore(ctx);
   for (const tok of tokens) {
     core.processToken(tok);
   }

--- a/packages/hl7v2-parser/src/tokenizer.ts
+++ b/packages/hl7v2-parser/src/tokenizer.ts
@@ -159,7 +159,7 @@ export class HL7v2Tokenizer implements Tokenizer, Iterable<Token> {
   }
 
   private _fastAdvance(chunk: string) {
-    const parts = chunk.split('\r');
+    const parts = chunk.split(this.delims.segment);
     if (parts.length > 1) {
       this.line += parts.length - 1;
       this.col = (parts.at(-1)?.length ?? 0) + 1;
@@ -190,6 +190,4 @@ export class HL7v2Tokenizer implements Tokenizer, Iterable<Token> {
       },
     };
   }
-
-  // Async iteration support removed to keep the API synchronous.
 }

--- a/packages/hl7v2-parser/src/tokenizer.ts
+++ b/packages/hl7v2-parser/src/tokenizer.ts
@@ -1,5 +1,5 @@
 // src/tokenizer.ts
-import type { HL7v2Delimiters } from '@rethinkhealth/hl7v2-utils';
+import type { HL7v2Delimiters } from '@rethinkhealth/hl7v2-ast';
 import type {
   ParserContext,
   Position,

--- a/packages/hl7v2-parser/src/tokenizer.ts
+++ b/packages/hl7v2-parser/src/tokenizer.ts
@@ -1,5 +1,5 @@
 // src/tokenizer.ts
-import type { HL7v2Delimiters } from '@rethinkhealth/hl7v2-ast';
+import type { Delimiters } from '@rethinkhealth/hl7v2-ast';
 import type {
   ParserContext,
   Position,
@@ -20,7 +20,7 @@ export class HL7v2Tokenizer implements Tokenizer, Iterable<Token> {
   private i = 0;
   private line = 1;
   private col = 1;
-  private delims!: HL7v2Delimiters;
+  private delims!: Delimiters;
 
   // Only-run-once MSH bootstrap at the start of the file
   private didMshBootstrap = false;

--- a/packages/hl7v2-parser/src/types.ts
+++ b/packages/hl7v2-parser/src/types.ts
@@ -1,18 +1,18 @@
-import type { HL7v2Delimiters } from '@rethinkhealth/hl7v2-ast';
+import type { Delimiters } from '@rethinkhealth/hl7v2-ast';
 
 // Forward declaration to avoid circular import at runtime
 // Consumers provide functions with compatible signature from `preprocessor.ts`
 export type PreprocessorStep = (ctx: ParserContext) => ParserContext;
 
 export type ParseOptions = {
-  delimiters?: HL7v2Delimiters;
+  delimiters?: Delimiters;
   // Configure the preprocessing pipeline.
   preprocess?: PreprocessorStep[];
 };
 
 export type ParserContext = {
   input: string;
-  delimiters: HL7v2Delimiters;
+  delimiters: Delimiters;
   metadata?: Record<string, unknown>;
 };
 

--- a/packages/hl7v2-parser/src/types.ts
+++ b/packages/hl7v2-parser/src/types.ts
@@ -1,4 +1,4 @@
-import type { HL7v2Delimiters } from '@rethinkhealth/hl7v2-utils';
+import type { HL7v2Delimiters } from '@rethinkhealth/hl7v2-ast';
 
 // Forward declaration to avoid circular import at runtime
 // Consumers provide functions with compatible signature from `preprocessor.ts`

--- a/packages/hl7v2-parser/src/utils.ts
+++ b/packages/hl7v2-parser/src/utils.ts
@@ -1,9 +1,0 @@
-import type { Token, Tokenizer } from './types';
-
-export function* iterateTokenizerSync(t: Tokenizer): Iterable<Token> {
-  for (let tok = t.next(); tok; tok = t.next()) {
-    yield tok;
-  }
-}
-
-// Removed async stream support; the parser now operates synchronously only.

--- a/packages/hl7v2-parser/test/__snapshots__/parser.test.ts.snap
+++ b/packages/hl7v2-parser/test/__snapshots__/parser.test.ts.snap
@@ -4886,6 +4886,17 @@ exports[`HL7v2 parser > multiple segments > parses multiple segments with MSH as
       "type": "segment",
     },
   ],
+  "data": {
+    "delimiters": {
+      "component": "^",
+      "escape": "\\",
+      "field": "|",
+      "repetition": "~",
+      "segment": "
+",
+      "subcomponent": "&",
+    },
+  },
   "type": "root",
 }
 `;
@@ -8872,6 +8883,17 @@ exports[`HL7v2 parser > multiple segments > parses multiple segments without MSH
       "type": "segment",
     },
   ],
+  "data": {
+    "delimiters": {
+      "component": "^",
+      "escape": "\\",
+      "field": "|",
+      "repetition": "~",
+      "segment": "
+",
+      "subcomponent": "&",
+    },
+  },
   "type": "root",
 }
 `;
@@ -9099,6 +9121,17 @@ OBX",
       "type": "segment",
     },
   ],
+  "data": {
+    "delimiters": {
+      "component": "^",
+      "escape": "\\",
+      "field": "|",
+      "repetition": "~",
+      "segment": "
+",
+      "subcomponent": "&",
+    },
+  },
   "type": "root",
 }
 `;
@@ -9308,7 +9341,473 @@ exports[`HL7v2 parser > single segment > handles leading double field delimiters
       "type": "segment",
     },
   ],
+  "data": {
+    "delimiters": {
+      "component": "^",
+      "escape": "\\",
+      "field": "|",
+      "repetition": "~",
+      "segment": "
+",
+      "subcomponent": "&",
+    },
+  },
   "type": "root",
+}
+`;
+
+exports[`HL7v2 parser > single segment > parses MSH with custom delimiters) 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 4,
+                      "line": 1,
+                      "offset": 3,
+                    },
+                    "start": {
+                      "column": 1,
+                      "line": 1,
+                      "offset": 0,
+                    },
+                  },
+                  "type": "subcomponent",
+                  "value": "MSH",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 4,
+                  "line": 1,
+                  "offset": 3,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "type": "component",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 4,
+              "line": 1,
+              "offset": 3,
+            },
+            "start": {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "field-repetition",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 4,
+          "line": 1,
+          "offset": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "field",
+    },
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 5,
+                      "line": 1,
+                      "offset": 4,
+                    },
+                    "start": {
+                      "column": 4,
+                      "line": 1,
+                      "offset": 3,
+                    },
+                  },
+                  "type": "subcomponent",
+                  "value": "$",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 5,
+                  "line": 1,
+                  "offset": 4,
+                },
+                "start": {
+                  "column": 4,
+                  "line": 1,
+                  "offset": 3,
+                },
+              },
+              "type": "component",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+            "start": {
+              "column": 4,
+              "line": 1,
+              "offset": 3,
+            },
+          },
+          "type": "field-repetition",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 5,
+          "line": 1,
+          "offset": 4,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+          "offset": 3,
+        },
+      },
+      "type": "field",
+    },
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 9,
+                      "line": 1,
+                      "offset": 8,
+                    },
+                    "start": {
+                      "column": 5,
+                      "line": 1,
+                      "offset": 4,
+                    },
+                  },
+                  "type": "subcomponent",
+                  "value": "%*\\#",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 9,
+                  "line": 1,
+                  "offset": 8,
+                },
+                "start": {
+                  "column": 5,
+                  "line": 1,
+                  "offset": 4,
+                },
+              },
+              "type": "component",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 9,
+              "line": 1,
+              "offset": 8,
+            },
+            "start": {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+          },
+          "type": "field-repetition",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 9,
+          "line": 1,
+          "offset": 8,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+          "offset": 4,
+        },
+      },
+      "type": "field",
+    },
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 16,
+                      "line": 1,
+                      "offset": 15,
+                    },
+                    "start": {
+                      "column": 10,
+                      "line": 1,
+                      "offset": 9,
+                    },
+                  },
+                  "type": "subcomponent",
+                  "value": "SENDER",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 16,
+                  "line": 1,
+                  "offset": 15,
+                },
+                "start": {
+                  "column": 10,
+                  "line": 1,
+                  "offset": 9,
+                },
+              },
+              "type": "component",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 16,
+              "line": 1,
+              "offset": 15,
+            },
+            "start": {
+              "column": 10,
+              "line": 1,
+              "offset": 9,
+            },
+          },
+          "type": "field-repetition",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 16,
+          "line": 1,
+          "offset": 15,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+          "offset": 9,
+        },
+      },
+      "type": "field",
+    },
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 19,
+                      "line": 1,
+                      "offset": 18,
+                    },
+                    "start": {
+                      "column": 17,
+                      "line": 1,
+                      "offset": 16,
+                    },
+                  },
+                  "type": "subcomponent",
+                  "value": "12",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 19,
+                  "line": 1,
+                  "offset": 18,
+                },
+                "start": {
+                  "column": 17,
+                  "line": 1,
+                  "offset": 16,
+                },
+              },
+              "type": "component",
+            },
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 22,
+                      "line": 1,
+                      "offset": 21,
+                    },
+                    "start": {
+                      "column": 20,
+                      "line": 1,
+                      "offset": 19,
+                    },
+                  },
+                  "type": "subcomponent",
+                  "value": "34",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 22,
+                  "line": 1,
+                  "offset": 21,
+                },
+                "start": {
+                  "column": 20,
+                  "line": 1,
+                  "offset": 19,
+                },
+              },
+              "type": "component",
+            },
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 26,
+                      "line": 1,
+                      "offset": 25,
+                    },
+                    "start": {
+                      "column": 23,
+                      "line": 1,
+                      "offset": 22,
+                    },
+                  },
+                  "type": "subcomponent",
+                  "value": "abc",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 26,
+                  "line": 1,
+                  "offset": 25,
+                },
+                "start": {
+                  "column": 23,
+                  "line": 1,
+                  "offset": 22,
+                },
+              },
+              "type": "component",
+            },
+            {
+              "children": [
+                {
+                  "position": {
+                    "end": {
+                      "column": 31,
+                      "line": 1,
+                      "offset": 30,
+                    },
+                    "start": {
+                      "column": 27,
+                      "line": 1,
+                      "offset": 26,
+                    },
+                  },
+                  "type": "subcomponent",
+                  "value": "abc
+",
+                },
+              ],
+              "position": {
+                "end": {
+                  "column": 31,
+                  "line": 1,
+                  "offset": 30,
+                },
+                "start": {
+                  "column": 27,
+                  "line": 1,
+                  "offset": 26,
+                },
+              },
+              "type": "component",
+            },
+          ],
+          "position": {
+            "end": {
+              "column": 31,
+              "line": 1,
+              "offset": 30,
+            },
+            "start": {
+              "column": 17,
+              "line": 1,
+              "offset": 16,
+            },
+          },
+          "type": "field-repetition",
+        },
+      ],
+      "position": {
+        "end": {
+          "column": 31,
+          "line": 1,
+          "offset": 30,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+          "offset": 16,
+        },
+      },
+      "type": "field",
+    },
+  ],
+  "position": {
+    "end": {
+      "column": 31,
+      "line": 1,
+      "offset": 30,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "segment",
 }
 `;
 
@@ -9467,6 +9966,17 @@ exports[`HL7v2 parser > single segment > parses a segment ending with a field de
       "type": "segment",
     },
   ],
+  "data": {
+    "delimiters": {
+      "component": "^",
+      "escape": "\\",
+      "field": "|",
+      "repetition": "~",
+      "segment": "
+",
+      "subcomponent": "&",
+    },
+  },
   "type": "root",
 }
 `;
@@ -9826,6 +10336,17 @@ exports[`HL7v2 parser > single segment > parses a segment ending with multiple f
       "type": "segment",
     },
   ],
+  "data": {
+    "delimiters": {
+      "component": "^",
+      "escape": "\\",
+      "field": "|",
+      "repetition": "~",
+      "segment": "
+",
+      "subcomponent": "&",
+    },
+  },
   "type": "root",
 }
 `;
@@ -10185,6 +10706,17 @@ exports[`HL7v2 parser > single segment > parses a segment ending with multiple f
       "type": "segment",
     },
   ],
+  "data": {
+    "delimiters": {
+      "component": "^",
+      "escape": "\\",
+      "field": "|",
+      "repetition": "~",
+      "segment": "
+",
+      "subcomponent": "&",
+    },
+  },
   "type": "root",
 }
 `;
@@ -10394,6 +10926,17 @@ exports[`HL7v2 parser > single segment > parses a segment ending with two field 
       "type": "segment",
     },
   ],
+  "data": {
+    "delimiters": {
+      "component": "^",
+      "escape": "\\",
+      "field": "|",
+      "repetition": "~",
+      "segment": "
+",
+      "subcomponent": "&",
+    },
+  },
   "type": "root",
 }
 `;
@@ -10553,6 +11096,17 @@ exports[`HL7v2 parser > single segment > parses a single segment with two fields
       "type": "segment",
     },
   ],
+  "data": {
+    "delimiters": {
+      "component": "^",
+      "escape": "\\",
+      "field": "|",
+      "repetition": "~",
+      "segment": "
+",
+      "subcomponent": "&",
+    },
+  },
   "type": "root",
 }
 `;
@@ -10728,6 +11282,17 @@ exports[`HL7v2 parser > single segment > preserves trailing component delimiter 
       "type": "segment",
     },
   ],
+  "data": {
+    "delimiters": {
+      "component": "^",
+      "escape": "\\",
+      "field": "|",
+      "repetition": "~",
+      "segment": "
+",
+      "subcomponent": "&",
+    },
+  },
   "type": "root",
 }
 `;
@@ -10954,6 +11519,17 @@ exports[`HL7v2 parser > single segment > runs custom preprocessors 1`] = `
       "type": "segment",
     },
   ],
+  "data": {
+    "delimiters": {
+      "component": "^",
+      "escape": "\\",
+      "field": "|",
+      "repetition": "~",
+      "segment": "
+",
+      "subcomponent": "&",
+    },
+  },
   "type": "root",
 }
 `;
@@ -11398,6 +11974,17 @@ exports[`HL7v2 parser > single segment > runs default preprocessors 1`] = `
       "type": "segment",
     },
   ],
+  "data": {
+    "delimiters": {
+      "component": "^",
+      "escape": "\\",
+      "field": "|",
+      "repetition": "~",
+      "segment": "
+",
+      "subcomponent": "&",
+    },
+  },
   "type": "root",
 }
 `;

--- a/packages/hl7v2-parser/test/parser.test.ts
+++ b/packages/hl7v2-parser/test/parser.test.ts
@@ -8,6 +8,7 @@ import type {
 } from '@rethinkhealth/hl7v2-ast';
 import type { HL7v2Delimiters } from '@rethinkhealth/hl7v2-utils';
 import { describe, expect, it } from 'vitest';
+// import { u } from 'unist-builder';
 import { parseHL7v2 } from '../src/parser';
 import type { PreprocessorStep } from '../src/types';
 
@@ -308,6 +309,24 @@ describe('HL7v2 parser', () => {
       // Without normalization, the tokenizer will not see a segment delimiter, so only one segment is produced
       expect(root.children).toHaveLength(1);
       expect(root).toMatchSnapshot();
+    });
+
+    it('parses MSH with custom delimiters)', () => {
+      const randomMessage = 'MSH$%*\\#$SENDER$12%34%abc%abc\n';
+      const root = parseHL7v2(randomMessage, {
+        delimiters: {
+          segment: '\n',
+          component: '%',
+          escape: '\\',
+          field: '$',
+          repetition: '*',
+          subcomponent: '#',
+        },
+      });
+      const seg = asSeg(root.children[0]);
+      expect(seg.children).toHaveLength(5);
+      // MSH Header
+      expect(seg).toMatchSnapshot();
     });
   });
 

--- a/packages/hl7v2-parser/test/parser.test.ts
+++ b/packages/hl7v2-parser/test/parser.test.ts
@@ -1,8 +1,8 @@
 import type {
   Component,
+  Delimiters,
   Field,
   FieldRepetition,
-  HL7v2Delimiters,
   Root,
   Segment,
   Subcomponent,
@@ -12,7 +12,7 @@ import { describe, expect, it } from 'vitest';
 import { parseHL7v2 } from '../src/parser';
 import type { PreprocessorStep } from '../src/types';
 
-const delims: HL7v2Delimiters = {
+const delims: Delimiters = {
   field: '|',
   component: '^',
   repetition: '~',

--- a/packages/hl7v2-parser/test/parser.test.ts
+++ b/packages/hl7v2-parser/test/parser.test.ts
@@ -2,11 +2,11 @@ import type {
   Component,
   Field,
   FieldRepetition,
+  HL7v2Delimiters,
   Root,
   Segment,
   Subcomponent,
 } from '@rethinkhealth/hl7v2-ast';
-import type { HL7v2Delimiters } from '@rethinkhealth/hl7v2-utils';
 import { describe, expect, it } from 'vitest';
 // import { u } from 'unist-builder';
 import { parseHL7v2 } from '../src/parser';
@@ -327,6 +327,7 @@ describe('HL7v2 parser', () => {
       expect(seg.children).toHaveLength(5);
       // MSH Header
       expect(seg).toMatchSnapshot();
+      expect(root.data?.delimiters).toBeDefined();
     });
   });
 

--- a/packages/hl7v2-utils/src/index.ts
+++ b/packages/hl7v2-utils/src/index.ts
@@ -4,18 +4,6 @@ import type { Nodes } from '@rethinkhealth/hl7v2-ast';
 // Delimiters
 // -------------
 
-/**
- * HL7v2 Delimiters type
- */
-export type HL7v2Delimiters = {
-  field: string;
-  component: string;
-  subcomponent: string;
-  repetition: string;
-  escape: string;
-  segment: string; // now always a string
-};
-
 export const DEFAULT_DELIMITERS = {
   field: '|',
   component: '^',


### PR DESCRIPTION
This pull request makes minor but important fixes to HL7v2 parsing and decoding, focusing on proper handling of delimiters and segment (carriage return) characters. The main changes ensure that both the parser and decode-escapes plugin consistently use the configured segment delimiter, improve type usage, and update tests to reflect these changes.

**Delimiter and segment handling improvements:**

* The HL7v2 decode-escapes plugin now uses the configured segment delimiter (from `Delimiters`) for `.br` escape sequences, instead of hardcoding carriage return (`\r`). [[1]](diffhunk://#diff-9aef929dbd3ff5f81624ebbd466396109b94a8e44648ff8fb45a6131971dc96bL84-R81) [[2]](diffhunk://#diff-2cefeab91061b800ed326530263422c5b98dcff3460d08d3a728b3b545900095L71-R78)
* The parser and tokenizer consistently use the `segment` delimiter from the `Delimiters` type, including in preprocessor normalization and segment splitting. [[1]](diffhunk://#diff-03192562be8a9d9c9a9b6bb9c730516b0abbabb62a3902a46dd73e20ed2a71a5L16-R20) [[2]](diffhunk://#diff-03192562be8a9d9c9a9b6bb9c730516b0abbabb62a3902a46dd73e20ed2a71a5L28-R43) [[3]](diffhunk://#diff-48de56c765ddcfc68b387c72f18c6b4df1bed1a37c6c29b99252c130d13516a5L162-R162)

**Type and API consistency:**

* All references to `HL7v2Delimiters` have been replaced with `Delimiters` from `@rethinkhealth/hl7v2-ast`, improving type consistency across the codebase and tests. [[1]](diffhunk://#diff-9aef929dbd3ff5f81624ebbd466396109b94a8e44648ff8fb45a6131971dc96bL1-R7) [[2]](diffhunk://#diff-2cefeab91061b800ed326530263422c5b98dcff3460d08d3a728b3b545900095L1-R8) [[3]](diffhunk://#diff-91bda50634d14a82f0bde4db586c207d865084c8cf25c4add227c47be2ba6e8cL1-R15) [[4]](diffhunk://#diff-af9c88b79675de586c637bed5b3cebba0e3366b61768490ded4bcc618b62b720L108-R108) [[5]](diffhunk://#diff-48de56c765ddcfc68b387c72f18c6b4df1bed1a37c6c29b99252c130d13516a5L2-R2) [[6]](diffhunk://#diff-8e3a202a352b56c33fd92f7ac707e1b97fd39198b29a6512cfe90deecc2025bdR3-R15)
* The parser core and processor functions now receive and propagate delimiter configuration via the context object, ensuring parsed trees include delimiter metadata. [[1]](diffhunk://#diff-48b8463a0987db2a39393229e1a678c012c36f5db10a2eb77010e5c38eda40cdL12-R22) [[2]](diffhunk://#diff-48b8463a0987db2a39393229e1a678c012c36f5db10a2eb77010e5c38eda40cdL246-R256) [[3]](diffhunk://#diff-821e679c688a17165f2536e630ecbb99653368d56e3aa356e219a1e7dc5bfee3L22-R27)

**Test updates and coverage:**

* Tests for both decode-escapes and parser modules have been updated to use the new delimiter type, verify correct segment delimiter handling, and add coverage for custom delimiter scenarios. [[1]](diffhunk://#diff-2cefeab91061b800ed326530263422c5b98dcff3460d08d3a728b3b545900095L37-R37) [[2]](diffhunk://#diff-2cefeab91061b800ed326530263422c5b98dcff3460d08d3a728b3b545900095L61-R62) [[3]](diffhunk://#diff-8e3a202a352b56c33fd92f7ac707e1b97fd39198b29a6512cfe90deecc2025bdR313-R331) [[4]](diffhunk://#diff-45d55ddb521bd96c807bd61ec6684f8c9d0b3b6983daff6b6255c262e85a80f0R58-R62) [[5]](diffhunk://#diff-45d55ddb521bd96c807bd61ec6684f8c9d0b3b6983daff6b6255c262e85a80f0L64-R71) [[6]](diffhunk://#diff-45d55ddb521bd96c807bd61ec6684f8c9d0b3b6983daff6b6255c262e85a80f0L85-R92) [[7]](diffhunk://#diff-45d55ddb521bd96c807bd61ec6684f8c9d0b3b6983daff6b6255c262e85a80f0L112-R119) [[8]](diffhunk://#diff-45d55ddb521bd96c807bd61ec6684f8c9d0b3b6983daff6b6255c262e85a80f0L131-R138) [[9]](diffhunk://#diff-45d55ddb521bd96c807bd61ec6684f8c9d0b3b6983daff6b6255c262e85a80f0L144-R158) [[10]](diffhunk://#diff-45d55ddb521bd96c807bd61ec6684f8c9d0b3b6983daff6b6255c262e85a80f0L164-R171)

**Code cleanup:**

* Removed unused or redundant code, such as the old `iterateTokenizerSync` utility and async iteration support in the tokenizer. [[1]](diffhunk://#diff-821e679c688a17165f2536e630ecbb99653368d56e3aa356e219a1e7dc5bfee3L7-R13) [[2]](diffhunk://#diff-42a73382d65e6a6bff8923e4b82861c63fbe0400bccfc7281d67419a2ef66240L1-L9) [[3]](diffhunk://#diff-48de56c765ddcfc68b387c72f18c6b4df1bed1a37c6c29b99252c130d13516a5L193-L194)

**Changelog and metadata:**

* Updated changelogs and changeset metadata to reflect the switch to `Delimiters` and the minor fix to segment/carriage return handling. (.changeset/purple-sides-refuse.md [[1]](diffhunk://#diff-6bc66cc7e71e569246557b2e6a94d8f4ef53fc4ed2757691198256adf8583d3aR1-R6) [[2]](diffhunk://#diff-af9c88b79675de586c637bed5b3cebba0e3366b61768490ded4bcc618b62b720L108-R108)

Let me know if you want to dive deeper into any specific change or see how these fixes impact HL7v2 message parsing in practice!