### PR TITLE
chore: update packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         node-version:
           - 20.x
           - 22.x
+          - 24.x
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           version: 8
 
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "rimraf": "^6.0.1",
     "turbo": "^2.5.6",
     "typescript": "^5.8.3",
-    "ultracite": "5.2.17"
+    "ultracite": "5.4.5"
   },
   "engines": {
     "node": ">=18"

--- a/packages/hl7v2-ast/index.d.ts
+++ b/packages/hl7v2-ast/index.d.ts
@@ -3,7 +3,7 @@ import type {
   Literal as UnistLiteral,
   Node as UnistNode,
   Parent as UnistParent,
-} from 'unist';
+} from "unist";
 
 /**
  * HL7v2 Delimiters type
@@ -158,7 +158,7 @@ export interface Root extends Parent {
   /**
    * Node type of HL7v2 root.
    */
-  type: 'root';
+  type: "root";
   /**
    * Data associated with the mdast root.
    */
@@ -179,7 +179,7 @@ export interface Segment extends Parent {
   /**
    * Node type of HL7v2 segment.
    */
-  type: 'segment';
+  type: "segment";
   /**
    * Children of block quote.
    */
@@ -208,7 +208,7 @@ export interface Group extends Parent {
   /**
    * Node type of HL7v2 segment.
    */
-  type: 'group';
+  type: "group";
   /**
    * Children of block quote.
    */
@@ -231,7 +231,7 @@ export interface Field extends Parent {
   /**
    * Node type of HL7v2 field.
    */
-  type: 'field';
+  type: "field";
   /**
    * Children of field.
    */
@@ -254,7 +254,7 @@ export interface FieldRepetition extends Parent {
   /**
    * Node type of HL7v2 field repetition.
    */
-  type: 'field-repetition';
+  type: "field-repetition";
   /**
    * Children of field repetition.
    */
@@ -277,7 +277,7 @@ export interface Component extends Parent {
   /**
    * Node type of HL7v2 component.
    */
-  type: 'component';
+  type: "component";
   /**
    * Children of component.
    */
@@ -300,7 +300,7 @@ export interface Subcomponent extends Literal {
   /**
    * Node type of HL7v2 subcomponent.
    */
-  type: 'subcomponent';
+  type: "subcomponent";
 
   /**
    * Data associated with the mdast block quote.

--- a/packages/hl7v2-ast/package.json
+++ b/packages/hl7v2-ast/package.json
@@ -14,18 +14,15 @@
   "scripts": {
     "check-types": "tsc ./index.d.ts --noEmit"
   },
-  "dependencies": {
-    "@types/unist": "3.0.3"
-  },
   "devDependencies": {
     "@rethinkhealth/tsconfig": "workspace:*",
-    "typescript": "^5.8.3",
-    "unist-builder": "^4.0.0",
-    "@types/node": "24.3.0",
-    "@types/unist": "^3.0.2",
+    "@types/node": "24.5.2",
+    "@types/unist": "^3.0.3",
     "@vitest/coverage-v8": "^3.2.4",
     "tsup": "8.5.0",
+    "typescript": "^5.8.3",
     "unified": "^11.0.5",
+    "unist-builder": "^4.0.0",
     "vitest": "^3.2.4"
   },
   "repository": "rethinkhealth/hl7v2.git",

--- a/packages/hl7v2-builder/package.json
+++ b/packages/hl7v2-builder/package.json
@@ -32,7 +32,6 @@
     "@rethinkhealth/tsconfig": "workspace:*",
     "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "tsup": "8.5.0",
     "typescript": "^5.8.3",

--- a/packages/hl7v2-builder/package.json
+++ b/packages/hl7v2-builder/package.json
@@ -24,20 +24,20 @@
   },
   "dependencies": {
     "@rethinkhealth/hl7v2-ast": "workspace:*",
-    "unist-builder": "^4.0.0"
+    "unist-builder": "4.0.0"
   },
   "devDependencies": {
+    "@rethinkhealth/hl7v2-to-hl7v2": "workspace:*",
     "@rethinkhealth/testing": "workspace:*",
     "@rethinkhealth/tsconfig": "workspace:*",
-    "@types/node": "24.3.0",
+    "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
-    "unified": "11.0.5",
     "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "tsup": "8.5.0",
     "typescript": "^5.8.3",
-    "vitest": "^3.2.4",
-    "@rethinkhealth/hl7v2-to-hl7v2": "workspace:*"
+    "unified": "^11.0.5",
+    "vitest": "^3.2.4"
   },
   "repository": "rethinkhealth/hl7v2.git",
   "homepage": "https://www.rethinkhealth.io/hl7v2/docs",

--- a/packages/hl7v2-builder/src/index.ts
+++ b/packages/hl7v2-builder/src/index.ts
@@ -6,15 +6,15 @@ import type {
   Root,
   RootContent,
   Segment,
-} from '@rethinkhealth/hl7v2-ast';
-import { u } from 'unist-builder';
+} from "@rethinkhealth/hl7v2-ast";
+import { u } from "unist-builder";
 
 export function m(...children: RootContent[]): Root {
-  return u('root', children);
+  return u("root", children);
 }
 
 export function s(...fields: Field[]): Segment {
-  return u('segment', fields);
+  return u("segment", fields);
 }
 
 type FieldValue = FieldRepetition | Component | string;
@@ -26,15 +26,15 @@ function flatten<T>(values: Flattenable<T>[]): T[] {
 
 function isFieldRepetition(value: FieldValue): value is FieldRepetition {
   return (
-    typeof value === 'object' &&
+    typeof value === "object" &&
     value !== null &&
-    value.type === 'field-repetition'
+    value.type === "field-repetition"
   );
 }
 
 function isComponent(value: FieldValue): value is Component {
   return (
-    typeof value === 'object' && value !== null && value.type === 'component'
+    typeof value === "object" && value !== null && value.type === "component"
   );
 }
 
@@ -43,12 +43,12 @@ export function f(): Field;
 export function f(...values: Flattenable<FieldValue>[]): Field;
 export function f(...values: Flattenable<FieldValue>[]): Field {
   if (values.length === 0) {
-    return u('field', [r()]);
+    return u("field", [r()]);
   }
 
   const flat = flatten<FieldValue>(values);
   if (flat.length === 0) {
-    return u('field', [r()]);
+    return u("field", [r()]);
   }
 
   const repetitions: FieldRepetition[] = [];
@@ -69,7 +69,7 @@ export function f(...values: Flattenable<FieldValue>[]): Field {
       continue;
     }
 
-    if (isComponent(value) || typeof value === 'string') {
+    if (isComponent(value) || typeof value === "string") {
       pendingComponents.push(value);
     }
   }
@@ -77,10 +77,10 @@ export function f(...values: Flattenable<FieldValue>[]): Field {
   flushPending();
 
   if (repetitions.length === 0) {
-    return u('field', [r()]);
+    return u("field", [r()]);
   }
 
-  return u('field', repetitions);
+  return u("field", repetitions);
 }
 
 export function r(): FieldRepetition;
@@ -91,17 +91,17 @@ export function r(
   ...components: Flattenable<Component | string>[]
 ): FieldRepetition {
   if (components.length === 0) {
-    return u('field-repetition', [c()]);
+    return u("field-repetition", [c()]);
   }
 
   const flat = flatten<Component | string>(components);
   if (flat.length === 0) {
-    return u('field-repetition', [c()]);
+    return u("field-repetition", [c()]);
   }
 
   return u(
-    'field-repetition',
-    flat.map((value) => (typeof value === 'string' ? c(value) : value))
+    "field-repetition",
+    flat.map((value) => (typeof value === "string" ? c(value) : value))
   );
 }
 
@@ -109,16 +109,16 @@ export function c(): Component;
 export function c(...values: Flattenable<string>[]): Component;
 export function c(...values: Flattenable<string>[]): Component {
   if (values.length === 0) {
-    return u('component', [u('subcomponent', '')]);
+    return u("component", [u("subcomponent", "")]);
   }
 
   const flat = flatten<string>(values);
   if (flat.length === 0) {
-    return u('component', [u('subcomponent', '')]);
+    return u("component", [u("subcomponent", "")]);
   }
 
   return u(
-    'component',
-    flat.map((subcomponent) => u('subcomponent', subcomponent))
+    "component",
+    flat.map((subcomponent) => u("subcomponent", subcomponent))
   );
 }

--- a/packages/hl7v2-builder/tests/index.test.ts
+++ b/packages/hl7v2-builder/tests/index.test.ts
@@ -1,51 +1,51 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { toHl7v2 } from '@rethinkhealth/hl7v2-to-hl7v2';
-import { describe, expect, it } from 'vitest';
-import { c, f, m, r, s } from '../src';
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { toHl7v2 } from "@rethinkhealth/hl7v2-to-hl7v2";
+import { describe, expect, it } from "vitest";
+import { c, f, m, r, s } from "../src";
 
-describe('builder', () => {
-  describe('root', () => {
-    it('should build a simple root', () => {
+describe("builder", () => {
+  describe("root", () => {
+    it("should build a simple root", () => {
       const root = m();
       expect(root).toEqual({
-        type: 'root',
+        type: "root",
         children: [],
       });
     });
 
-    it('should build a root with a single segment', () => {
-      const root = m(s(f('MSH'), f('another value')));
+    it("should build a root with a single segment", () => {
+      const root = m(s(f("MSH"), f("another value")));
       expect(root).toEqual({
-        type: 'root',
+        type: "root",
         children: [
           {
-            type: 'segment',
+            type: "segment",
             children: [
               {
-                type: 'field',
+                type: "field",
                 children: [
                   {
-                    type: 'field-repetition',
+                    type: "field-repetition",
                     children: [
                       {
-                        type: 'component',
-                        children: [{ type: 'subcomponent', value: 'MSH' }],
+                        type: "component",
+                        children: [{ type: "subcomponent", value: "MSH" }],
                       },
                     ],
                   },
                 ],
               },
               {
-                type: 'field',
+                type: "field",
                 children: [
                   {
-                    type: 'field-repetition',
+                    type: "field-repetition",
                     children: [
                       {
-                        type: 'component',
+                        type: "component",
                         children: [
-                          { type: 'subcomponent', value: 'another value' },
+                          { type: "subcomponent", value: "another value" },
                         ],
                       },
                     ],
@@ -58,38 +58,38 @@ describe('builder', () => {
       });
     });
 
-    it('should build a root with a multiple segments', () => {
-      const root = m(s(f('MSH'), f('another value')), s(f('PID'), f('12345')));
+    it("should build a root with a multiple segments", () => {
+      const root = m(s(f("MSH"), f("another value")), s(f("PID"), f("12345")));
       expect(root).toEqual({
-        type: 'root',
+        type: "root",
         children: [
           {
-            type: 'segment',
+            type: "segment",
             children: [
               {
-                type: 'field',
+                type: "field",
                 children: [
                   {
-                    type: 'field-repetition',
+                    type: "field-repetition",
                     children: [
                       {
-                        type: 'component',
-                        children: [{ type: 'subcomponent', value: 'MSH' }],
+                        type: "component",
+                        children: [{ type: "subcomponent", value: "MSH" }],
                       },
                     ],
                   },
                 ],
               },
               {
-                type: 'field',
+                type: "field",
                 children: [
                   {
-                    type: 'field-repetition',
+                    type: "field-repetition",
                     children: [
                       {
-                        type: 'component',
+                        type: "component",
                         children: [
-                          { type: 'subcomponent', value: 'another value' },
+                          { type: "subcomponent", value: "another value" },
                         ],
                       },
                     ],
@@ -99,31 +99,31 @@ describe('builder', () => {
             ],
           },
           {
-            type: 'segment',
+            type: "segment",
             children: [
               {
-                type: 'field',
+                type: "field",
                 children: [
                   {
-                    type: 'field-repetition',
+                    type: "field-repetition",
                     children: [
                       {
-                        type: 'component',
-                        children: [{ type: 'subcomponent', value: 'PID' }],
+                        type: "component",
+                        children: [{ type: "subcomponent", value: "PID" }],
                       },
                     ],
                   },
                 ],
               },
               {
-                type: 'field',
+                type: "field",
                 children: [
                   {
-                    type: 'field-repetition',
+                    type: "field-repetition",
                     children: [
                       {
-                        type: 'component',
-                        children: [{ type: 'subcomponent', value: '12345' }],
+                        type: "component",
+                        children: [{ type: "subcomponent", value: "12345" }],
                       },
                     ],
                   },
@@ -136,37 +136,37 @@ describe('builder', () => {
     });
   });
 
-  describe('segment', () => {
-    it('should build a segment with a single-value field', () => {
-      const segment = s(f('MSH'), f('another value'));
+  describe("segment", () => {
+    it("should build a segment with a single-value field", () => {
+      const segment = s(f("MSH"), f("another value"));
 
       expect(segment).toEqual({
-        type: 'segment',
+        type: "segment",
         children: [
           {
-            type: 'field',
+            type: "field",
             children: [
               {
-                type: 'field-repetition',
+                type: "field-repetition",
                 children: [
                   {
-                    type: 'component',
-                    children: [{ type: 'subcomponent', value: 'MSH' }],
+                    type: "component",
+                    children: [{ type: "subcomponent", value: "MSH" }],
                   },
                 ],
               },
             ],
           },
           {
-            type: 'field',
+            type: "field",
             children: [
               {
-                type: 'field-repetition',
+                type: "field-repetition",
                 children: [
                   {
-                    type: 'component',
+                    type: "component",
                     children: [
-                      { type: 'subcomponent', value: 'another value' },
+                      { type: "subcomponent", value: "another value" },
                     ],
                   },
                 ],
@@ -177,35 +177,35 @@ describe('builder', () => {
       });
     });
 
-    it('should build a segment with an array of fields', () => {
-      const segment = s(f('MSH'), f('another value'), f('another value 2'));
+    it("should build a segment with an array of fields", () => {
+      const segment = s(f("MSH"), f("another value"), f("another value 2"));
       expect(segment).toEqual({
-        type: 'segment',
+        type: "segment",
         children: [
           {
-            type: 'field',
+            type: "field",
             children: [
               {
-                type: 'field-repetition',
+                type: "field-repetition",
                 children: [
                   {
-                    type: 'component',
-                    children: [{ type: 'subcomponent', value: 'MSH' }],
+                    type: "component",
+                    children: [{ type: "subcomponent", value: "MSH" }],
                   },
                 ],
               },
             ],
           },
           {
-            type: 'field',
+            type: "field",
             children: [
               {
-                type: 'field-repetition',
+                type: "field-repetition",
                 children: [
                   {
-                    type: 'component',
+                    type: "component",
                     children: [
-                      { type: 'subcomponent', value: 'another value' },
+                      { type: "subcomponent", value: "another value" },
                     ],
                   },
                 ],
@@ -213,15 +213,15 @@ describe('builder', () => {
             ],
           },
           {
-            type: 'field',
+            type: "field",
             children: [
               {
-                type: 'field-repetition',
+                type: "field-repetition",
                 children: [
                   {
-                    type: 'component',
+                    type: "component",
                     children: [
-                      { type: 'subcomponent', value: 'another value 2' },
+                      { type: "subcomponent", value: "another value 2" },
                     ],
                   },
                 ],
@@ -233,18 +233,18 @@ describe('builder', () => {
     });
   });
 
-  describe('field', () => {
-    it('should build an empty field', () => {
+  describe("field", () => {
+    it("should build an empty field", () => {
       const field = f();
       expect(field).toEqual({
-        type: 'field',
+        type: "field",
         children: [
           {
-            type: 'field-repetition',
+            type: "field-repetition",
             children: [
               {
-                type: 'component',
-                children: [{ type: 'subcomponent', value: '' }],
+                type: "component",
+                children: [{ type: "subcomponent", value: "" }],
               },
             ],
           },
@@ -252,17 +252,17 @@ describe('builder', () => {
       });
     });
 
-    it('should build a single value field', () => {
-      const field = f('hello world');
+    it("should build a single value field", () => {
+      const field = f("hello world");
       expect(field).toEqual({
-        type: 'field',
+        type: "field",
         children: [
           {
-            type: 'field-repetition',
+            type: "field-repetition",
             children: [
               {
-                type: 'component',
-                children: [{ type: 'subcomponent', value: 'hello world' }],
+                type: "component",
+                children: [{ type: "subcomponent", value: "hello world" }],
               },
             ],
           },
@@ -270,17 +270,17 @@ describe('builder', () => {
       });
     });
 
-    it('should build a field with a single component', () => {
-      const field = f(c('hello world!'));
+    it("should build a field with a single component", () => {
+      const field = f(c("hello world!"));
       expect(field).toEqual({
-        type: 'field',
+        type: "field",
         children: [
           {
-            type: 'field-repetition',
+            type: "field-repetition",
             children: [
               {
-                type: 'component',
-                children: [{ type: 'subcomponent', value: 'hello world!' }],
+                type: "component",
+                children: [{ type: "subcomponent", value: "hello world!" }],
               },
             ],
           },
@@ -288,26 +288,26 @@ describe('builder', () => {
       });
     });
 
-    it('should build a field with an array of components', () => {
-      const field = f([c('A'), c('B'), c('C')]);
+    it("should build a field with an array of components", () => {
+      const field = f([c("A"), c("B"), c("C")]);
 
       expect(field).toEqual({
-        type: 'field',
+        type: "field",
         children: [
           {
-            type: 'field-repetition',
+            type: "field-repetition",
             children: [
               {
-                type: 'component',
-                children: [{ type: 'subcomponent', value: 'A' }],
+                type: "component",
+                children: [{ type: "subcomponent", value: "A" }],
               },
               {
-                type: 'component',
-                children: [{ type: 'subcomponent', value: 'B' }],
+                type: "component",
+                children: [{ type: "subcomponent", value: "B" }],
               },
               {
-                type: 'component',
-                children: [{ type: 'subcomponent', value: 'C' }],
+                type: "component",
+                children: [{ type: "subcomponent", value: "C" }],
               },
             ],
           },
@@ -315,49 +315,49 @@ describe('builder', () => {
       });
     });
 
-    it('should build a field with an array of repeated components (field repetition)', () => {
+    it("should build a field with an array of repeated components (field repetition)", () => {
       // Given
       const field = f([
-        r([c('A'), c(['B.1', 'B.2'])]),
-        r([c('C')]),
-        r([c('D')]),
+        r([c("A"), c(["B.1", "B.2"])]),
+        r([c("C")]),
+        r([c("D")]),
       ]);
 
       // Then
       expect(field).toEqual({
-        type: 'field',
+        type: "field",
         children: [
           {
-            type: 'field-repetition',
+            type: "field-repetition",
             children: [
               {
-                type: 'component',
-                children: [{ type: 'subcomponent', value: 'A' }],
+                type: "component",
+                children: [{ type: "subcomponent", value: "A" }],
               },
               {
-                type: 'component',
+                type: "component",
                 children: [
-                  { type: 'subcomponent', value: 'B.1' },
-                  { type: 'subcomponent', value: 'B.2' },
+                  { type: "subcomponent", value: "B.1" },
+                  { type: "subcomponent", value: "B.2" },
                 ],
               },
             ],
           },
           {
-            type: 'field-repetition',
+            type: "field-repetition",
             children: [
               {
-                type: 'component',
-                children: [{ type: 'subcomponent', value: 'C' }],
+                type: "component",
+                children: [{ type: "subcomponent", value: "C" }],
               },
             ],
           },
           {
-            type: 'field-repetition',
+            type: "field-repetition",
             children: [
               {
-                type: 'component',
-                children: [{ type: 'subcomponent', value: 'D' }],
+                type: "component",
+                children: [{ type: "subcomponent", value: "D" }],
               },
             ],
           },
@@ -365,152 +365,152 @@ describe('builder', () => {
       });
     });
 
-    it('should build the same results using a single repetition or component(s)', () => {
-      const fieldWithRepetition = f(r(c('A'), c(['B.1', 'B.2'])));
+    it("should build the same results using a single repetition or component(s)", () => {
+      const fieldWithRepetition = f(r(c("A"), c(["B.1", "B.2"])));
 
-      const fieldWithComponents = f(c('A'), c(['B.1', 'B.2']));
+      const fieldWithComponents = f(c("A"), c(["B.1", "B.2"]));
 
       expect(fieldWithRepetition).toEqual(fieldWithComponents);
     });
   });
 
-  describe('component', () => {
-    it('should build an empty component', () => {
+  describe("component", () => {
+    it("should build an empty component", () => {
       const component = c();
       expect(component).toEqual({
-        type: 'component',
-        children: [{ type: 'subcomponent', value: '' }],
+        type: "component",
+        children: [{ type: "subcomponent", value: "" }],
       });
     });
 
-    it('should build a component with a single value', () => {
-      const component = c('hello world!');
+    it("should build a component with a single value", () => {
+      const component = c("hello world!");
       expect(component).toEqual({
-        type: 'component',
-        children: [{ type: 'subcomponent', value: 'hello world!' }],
+        type: "component",
+        children: [{ type: "subcomponent", value: "hello world!" }],
       });
     });
 
-    it('should build a component with an array of values', () => {
-      const component = c(['hello world!', 'hello world 2!']);
+    it("should build a component with an array of values", () => {
+      const component = c(["hello world!", "hello world 2!"]);
       expect(component).toEqual({
-        type: 'component',
+        type: "component",
         children: [
-          { type: 'subcomponent', value: 'hello world!' },
-          { type: 'subcomponent', value: 'hello world 2!' },
+          { type: "subcomponent", value: "hello world!" },
+          { type: "subcomponent", value: "hello world 2!" },
         ],
       });
     });
   });
 
-  describe('complex scenarios', () => {
-    it('should build a segment with an array of fields, each with an array of components', () => {
+  describe("complex scenarios", () => {
+    it("should build a segment with an array of fields, each with an array of components", () => {
       const message = m(
         // MSH Segment
         s(
-          f('MSH'),
+          f("MSH"),
           f(),
           f(),
-          f('1234'),
-          f([c(['A', 'A.2', 'A.3']), c('B'), c('C')])
+          f("1234"),
+          f([c(["A", "A.2", "A.3"]), c("B"), c("C")])
         ),
         // PID Segment
-        s(f('PID'), f('12345'), f([c('DOE'), c('JOHN')]))
+        s(f("PID"), f("12345"), f([c("DOE"), c("JOHN")]))
       );
 
       expect(message).toMatchSnapshot();
     });
 
-    it('should build a message from a fixture', () => {
+    it("should build a message from a fixture", () => {
       const original = readFileSync(
-        join(__dirname, 'fixtures', 'sample.hl7v2'),
-        'utf8'
+        join(__dirname, "fixtures", "sample.hl7v2"),
+        "utf8"
       );
 
       const constructed = m(
         s(
-          f('MSH'),
-          f('|'),
-          f('^~\\&'),
-          f(c('SNDAPP'), c('COMP')),
-          f('SNDFAC'),
-          f('RCVAPP'),
-          f('RCVFAC'),
-          f('20250205123045-0500'),
+          f("MSH"),
+          f("|"),
+          f("^~\\&"),
+          f(c("SNDAPP"), c("COMP")),
+          f("SNDFAC"),
+          f("RCVAPP"),
+          f("RCVFAC"),
+          f("20250205123045-0500"),
           f(),
-          f(c('ORU'), c('R01'), c('ORU_R01')),
-          f('MSG12345'),
-          f('P'),
-          f('2.5.1'),
+          f(c("ORU"), c("R01"), c("ORU_R01")),
+          f("MSG12345"),
+          f("P"),
+          f("2.5.1"),
           f(),
           f(),
-          f('AL'),
-          f('AL')
+          f("AL"),
+          f("AL")
         ),
-        s(f('EVN'), f('R01'), f('202502051229'), f(), f(), f()),
+        s(f("EVN"), f("R01"), f("202502051229"), f(), f(), f()),
         s(
-          f('PID'),
-          f('1'),
+          f("PID"),
+          f("1"),
           f(),
           f(
-            r(c('123456'), c(), c(), c('HOSP'), c('MR')),
-            r(c('A123456'), c(), c(), c('HOSP'), c('AN'))
+            r(c("123456"), c(), c(), c("HOSP"), c("MR")),
+            r(c("A123456"), c(), c(), c("HOSP"), c("AN"))
           ),
           f(),
-          f(c('Doe'), c('John'), c('A'), c('III'), c(), c('L')),
+          f(c("Doe"), c("John"), c("A"), c("III"), c(), c("L")),
           f(),
-          f('19800101'),
-          f('M'),
+          f("19800101"),
+          f("M"),
           f(),
           f(),
           f(
-            c('123 Main St'),
+            c("123 Main St"),
             c(),
-            c('Metropolis'),
-            c('NY'),
-            c('10101'),
-            c('USA'),
-            c('H'),
-            c('BLD'),
+            c("Metropolis"),
+            c("NY"),
+            c("10101"),
+            c("USA"),
+            c("H"),
+            c("BLD"),
             c(),
             c(),
             c()
           ),
           f(
-            r(c(), c(), c(), c('NY'), c('10001')),
-            r(c(), c(), c(), c('NY'), c('10002'))
+            r(c(), c(), c(), c("NY"), c("10001")),
+            r(c(), c(), c(), c("NY"), c("10002"))
           ),
           f(),
-          f('EN'),
-          f('S'),
-          f('123456789'),
-          f(c('987654'), c(), c(), c('SSA'), c('SS')),
+          f("EN"),
+          f("S"),
+          f("123456789"),
+          f(c("987654"), c(), c(), c("SSA"), c("SS")),
           f(),
-          f('EN'),
-          f('C'),
-          f('USA'),
-          f(c('N'), c('Not Hispanic'), c(), c('HL70189')),
-          f('Y'),
-          f('Y'),
+          f("EN"),
+          f("C"),
+          f("USA"),
+          f(c("N"), c("Not Hispanic"), c(), c("HL70189")),
+          f("Y"),
+          f("Y"),
           f(),
           f(),
-          f(r(c('20250101120000-0500')), r(c('20250102120000-0500'))),
+          f(r(c("20250101120000-0500")), r(c("20250102120000-0500"))),
           f(),
           f(),
           f()
         ),
         s(
-          f('PD1'),
+          f("PD1"),
           f(),
           f(),
           f(
-            c('PCP'),
-            c('Primary'),
-            c('Physician'),
-            c('MD'),
+            c("PCP"),
+            c("Primary"),
+            c("Physician"),
+            c("MD"),
             c(),
             c(),
-            c(['NPI', '1234567890', 'NPI'])
+            c(["NPI", "1234567890", "NPI"])
           ),
           f(),
           f(),
@@ -518,61 +518,61 @@ describe('builder', () => {
           f(),
           f(),
           f(),
-          f('20241231')
+          f("20241231")
         ),
         s(
-          f('OBX'),
-          f('1'),
-          f('ST'),
-          f(c('88304'), c('Pathology Test'), c('CPT')),
-          f('1'),
-          f('Sample text with escaped\\F\\ pipe'),
-          f('mg/dL'),
-          f('70-110'),
-          f('H'),
-          f('A'),
-          f('F'),
+          f("OBX"),
+          f("1"),
+          f("ST"),
+          f(c("88304"), c("Pathology Test"), c("CPT")),
+          f("1"),
+          f("Sample text with escaped\\F\\ pipe"),
+          f("mg/dL"),
+          f("70-110"),
+          f("H"),
+          f("A"),
+          f("F"),
           f(),
           f(),
-          f('202502041900'),
-          f(c('RX'), c('Pharmacy'), c('HL70369'))
+          f("202502041900"),
+          f(c("RX"), c("Pharmacy"), c("HL70369"))
         ),
         s(
-          f('OBX'),
-          f('2'),
-          f('CWE'),
-          f(c('2345-7'), c('Result Code'), c('LN')),
-          f('1'),
-          f(r(c('A'), c('Alpha&Primary')), r(c('B'), c('Beta\\R\\Return'))),
+          f("OBX"),
+          f("2"),
+          f("CWE"),
+          f(c("2345-7"), c("Result Code"), c("LN")),
+          f("1"),
+          f(r(c("A"), c("Alpha&Primary")), r(c("B"), c("Beta\\R\\Return"))),
           f(c(), c(), c(), c()),
           f(c(), c(), c(), c()),
-          f('N'),
+          f("N"),
           f(),
           f(),
-          f('F'),
+          f("F"),
           f(),
           f(),
-          f('202502041905')
+          f("202502041905")
         ),
         s(
-          f('ZPD'),
-          f('1'),
-          f(c('Consent'), c('Signed')),
-          f('20240115'),
+          f("ZPD"),
+          f("1"),
+          f(c("Consent"), c("Signed")),
+          f("20240115"),
           f(
-            c('Note'),
-            c('Parent'),
-            c('signature'),
-            c('captured'),
-            c('via'),
-            c('tablet', 'ModelX', 'HW')
+            c("Note"),
+            c("Parent"),
+            c("signature"),
+            c("captured"),
+            c("via"),
+            c("tablet", "ModelX", "HW")
           )
         )
       );
 
       // When
       const compiled = toHl7v2(constructed, {
-        segment: '\n',
+        segment: "\n",
       });
 
       // Then

--- a/packages/hl7v2-builder/tsup.config.ts
+++ b/packages/hl7v2-builder/tsup.config.ts
@@ -1,10 +1,10 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
-    index: 'src/index.ts',
+    index: "src/index.ts",
   },
-  format: ['esm'],
-  target: 'es2022',
+  format: ["esm"],
+  target: "es2022",
   sourcemap: true,
 });

--- a/packages/hl7v2-builder/vitest.config.ts
+++ b/packages/hl7v2-builder/vitest.config.ts
@@ -1,11 +1,11 @@
-import { baseConfig } from '@rethinkhealth/testing';
-import { defineConfig, mergeConfig } from 'vitest/config';
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
 
 export default mergeConfig(
   baseConfig,
   defineConfig({
     test: {
-      name: 'hl7v2-util-query',
+      name: "hl7v2-util-query",
     },
   })
 );

--- a/packages/hl7v2-cli/package.json
+++ b/packages/hl7v2-cli/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@rethinkhealth/tsconfig": "workspace:*",
-    "@types/node": "24.3.0",
+    "@types/node": "24.5.2",
     "tsup": "8.5.0",
     "typescript": "^5.8.3"
   },

--- a/packages/hl7v2-cli/src/cli.ts
+++ b/packages/hl7v2-cli/src/cli.ts
@@ -1,14 +1,14 @@
-import { parseHL7v2 } from '@rethinkhealth/hl7v2';
-import { args } from 'unified-args';
+import { parseHL7v2 } from "@rethinkhealth/hl7v2";
+import { args } from "unified-args";
 
 args({
-  description: 'Command line interface to inspect and change HL7v2 messages',
-  extensions: ['hl7v2', 'hl7', 'txt'],
-  ignoreName: '.hl7v2ignore',
-  name: 'hl7v2',
-  packageField: 'hl7v2',
-  pluginPrefix: 'hl7v2',
+  description: "Command line interface to inspect and change HL7v2 messages",
+  extensions: ["hl7v2", "hl7", "txt"],
+  ignoreName: ".hl7v2ignore",
+  name: "hl7v2",
+  packageField: "hl7v2",
+  pluginPrefix: "hl7v2",
   processor: parseHL7v2,
-  rcName: '.hl7v2rc',
-  version: '1.0.0',
+  rcName: ".hl7v2rc",
+  version: "1.0.0",
 });

--- a/packages/hl7v2-cli/tsup.config.ts
+++ b/packages/hl7v2-cli/tsup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
@@ -6,11 +6,11 @@ export default defineConfig({
      * Directories and files should be bundled so that the resulting files line
      * up with the TSC generated type definitions.
      */
-    cli: 'src/cli.ts',
+    cli: "src/cli.ts",
     // "utils/index": "src/utils/index.ts",
   },
-  format: ['esm'],
-  target: 'es2022',
+  format: ["esm"],
+  target: "es2022",
   sourcemap: true,
   // treeshake: true,
 

--- a/packages/hl7v2-decode-escapes/package.json
+++ b/packages/hl7v2-decode-escapes/package.json
@@ -34,7 +34,6 @@
     "@rethinkhealth/tsconfig": "workspace:*",
     "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "tsup": "8.5.0",
     "typescript": "^5.8.3",

--- a/packages/hl7v2-decode-escapes/package.json
+++ b/packages/hl7v2-decode-escapes/package.json
@@ -32,7 +32,7 @@
     "@rethinkhealth/hl7v2-ast": "workspace:*",
     "@rethinkhealth/testing": "workspace:*",
     "@rethinkhealth/tsconfig": "workspace:*",
-    "@types/node": "24.3.0",
+    "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
     "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",

--- a/packages/hl7v2-decode-escapes/src/index.ts
+++ b/packages/hl7v2-decode-escapes/src/index.ts
@@ -1,8 +1,9 @@
-import type { Delimiters, Root, Subcomponent } from '@rethinkhealth/hl7v2-ast';
-import { DEFAULT_DELIMITERS } from '@rethinkhealth/hl7v2-utils';
-import type { Plugin } from 'unified';
-import { visit } from 'unist-util-visit';
+import type { Delimiters, Root, Subcomponent } from "@rethinkhealth/hl7v2-ast";
+import { DEFAULT_DELIMITERS } from "@rethinkhealth/hl7v2-utils";
+import type { Plugin } from "unified";
+import { visit } from "unist-util-visit";
 
+// biome-ignore lint/style/useNamingConvention: HL7v2 is a special case
 export type HL7v2DecodeOptions = {
   delimiters?: Partial<Delimiters>;
 };
@@ -15,15 +16,13 @@ export type HL7v2DecodeOptions = {
  * - Handles \.br\ line breaks
  * - Uses delimiters from Root.data.delimiters if available
  */
-export const hl7v2DecodeEscapes: Plugin<[HL7v2DecodeOptions?], Root, Root> = (
-  options
-) => {
-  return (tree: Root) => {
+export const hl7v2DecodeEscapes: Plugin<[HL7v2DecodeOptions?], Root, Root> =
+  (options) => (tree: Root) => {
     const delimiters =
       (tree.data as { delimiters?: Partial<Delimiters> })?.delimiters ||
       options?.delimiters;
 
-    visit(tree, 'subcomponent', (node: Subcomponent) => {
+    visit(tree, "subcomponent", (node: Subcomponent) => {
       const raw = node.value;
       node.value = decode(raw, {
         ...DEFAULT_DELIMITERS,
@@ -33,7 +32,6 @@ export const hl7v2DecodeEscapes: Plugin<[HL7v2DecodeOptions?], Root, Root> = (
 
     return tree;
   };
-};
 
 /**
  * Decode HL7v2 escape sequences according to HL7 v2.8 spec.
@@ -48,7 +46,7 @@ function decode(value: string, d: typeof DEFAULT_DELIMITERS): string {
     return value;
   }
 
-  let decoded = '';
+  let decoded = "";
   let i = 0;
 
   while (i < value.length) {
@@ -62,30 +60,30 @@ function decode(value: string, d: typeof DEFAULT_DELIMITERS): string {
       const code = value.slice(i + 1, end);
 
       switch (code) {
-        case 'F':
+        case "F":
           decoded += d.field;
           break;
-        case 'S':
+        case "S":
           decoded += d.component;
           break;
-        case 'R':
+        case "R":
           decoded += d.repetition;
           break;
-        case 'T':
+        case "T":
           decoded += d.subcomponent;
           break;
-        case 'E':
+        case "E":
           decoded += d.escape;
           break;
-        case '.br':
+        case ".br":
           decoded += d.segment;
           break;
-        case 'H':
-        case 'N':
+        case "H":
+        case "N":
           // Highlight start/end: ignored for now
           break;
         default:
-          if (code.startsWith('X') && code.length > 1) {
+          if (code.startsWith("X") && code.length > 1) {
             decoded += decodeHexSequence(code.slice(1));
           } else {
             // Unknown escape: preserve as-is
@@ -107,7 +105,7 @@ function decode(value: string, d: typeof DEFAULT_DELIMITERS): string {
  * Decode HL7 \Xdddd\ hexadecimal escape sequences into characters.
  */
 function decodeHexSequence(hex: string): string {
-  let result = '';
+  let result = "";
   for (let i = 0; i < hex.length; i += 2) {
     const byte = hex.slice(i, i + 2);
     const codePoint = Number.parseInt(byte, 16);

--- a/packages/hl7v2-decode-escapes/tests/index.test.ts
+++ b/packages/hl7v2-decode-escapes/tests/index.test.ts
@@ -1,28 +1,28 @@
-import type { Delimiters, Root, Subcomponent } from '@rethinkhealth/hl7v2-ast';
-import { DEFAULT_DELIMITERS } from '@rethinkhealth/hl7v2-utils';
-import { unified } from 'unified';
-import { visit } from 'unist-util-visit';
-import { describe, expect, it } from 'vitest';
-import { hl7v2DecodeEscapes } from '../src/index';
+import type { Delimiters, Root, Subcomponent } from "@rethinkhealth/hl7v2-ast";
+import { DEFAULT_DELIMITERS } from "@rethinkhealth/hl7v2-utils";
+import { unified } from "unified";
+import { visit } from "unist-util-visit";
+import { describe, expect, it } from "vitest";
+import { hl7v2DecodeEscapes } from "../src/index";
 
 function makeTree(value: string, delimiters?: Delimiters): Root {
   return {
-    type: 'root',
+    type: "root",
     children: [
       {
-        type: 'segment',
+        type: "segment",
         children: [
           {
-            type: 'field',
+            type: "field",
             children: [
               {
-                type: 'field-repetition',
+                type: "field-repetition",
                 children: [
                   {
-                    type: 'component',
+                    type: "component",
                     children: [
                       {
-                        type: 'subcomponent',
+                        type: "subcomponent",
                         value,
                       } as Subcomponent,
                     ],
@@ -38,74 +38,74 @@ function makeTree(value: string, delimiters?: Delimiters): Root {
   };
 }
 
-describe('hl7v2DecodeEscapes plugin', () => {
-  it('decodes standard delimiter escapes with default delimiters', async () => {
+describe("hl7v2DecodeEscapes plugin", () => {
+  it("decodes standard delimiter escapes with default delimiters", async () => {
     const tree = makeTree(
-      'Value\\F\\More\\S\\Stuff\\R\\Again\\T\\Sub\\E\\Escaped'
+      "Value\\F\\More\\S\\Stuff\\R\\Again\\T\\Sub\\E\\Escaped"
     );
 
     await unified().use(hl7v2DecodeEscapes).run(tree);
 
-    visit(tree, 'subcomponent', (node: Subcomponent) => {
-      expect(node.value).toBe('Value|More^Stuff~Again&Sub\\Escaped');
+    visit(tree, "subcomponent", (node: Subcomponent) => {
+      expect(node.value).toBe("Value|More^Stuff~Again&Sub\\Escaped");
     });
   });
 
-  it('decodes using custom delimiters from Root.data.delimiters', async () => {
+  it("decodes using custom delimiters from Root.data.delimiters", async () => {
     const customDelimiters = {
-      field: '*',
-      component: '$',
-      repetition: '%',
-      subcomponent: '@',
-      escape: '\\',
-      segment: '\n',
+      field: "*",
+      component: "$",
+      repetition: "%",
+      subcomponent: "@",
+      escape: "\\",
+      segment: "\n",
     } satisfies Delimiters;
-    const tree = makeTree('Test\\F\\Custom\\S\\Delims', customDelimiters);
+    const tree = makeTree("Test\\F\\Custom\\S\\Delims", customDelimiters);
 
     await unified().use(hl7v2DecodeEscapes).run(tree);
 
-    visit(tree, 'subcomponent', (node: Subcomponent) => {
-      expect(node.value).toBe('Test*Custom$Delims');
+    visit(tree, "subcomponent", (node: Subcomponent) => {
+      expect(node.value).toBe("Test*Custom$Delims");
     });
   });
 
-  it('decodes .br into the default segment delimiter', async () => {
-    const tree = makeTree('Line1\\.br\\Line2');
+  it("decodes .br into the default segment delimiter", async () => {
+    const tree = makeTree("Line1\\.br\\Line2");
 
     await unified().use(hl7v2DecodeEscapes).run(tree);
 
-    visit(tree, 'subcomponent', (node: Subcomponent) => {
+    visit(tree, "subcomponent", (node: Subcomponent) => {
       expect(node.value).toBe(`Line1${DEFAULT_DELIMITERS.segment}Line2`);
     });
   });
 
-  it('decodes hex escapes', async () => {
-    const tree = makeTree('Hello\\X0A\\World\\X0D\\Done');
+  it("decodes hex escapes", async () => {
+    const tree = makeTree("Hello\\X0A\\World\\X0D\\Done");
 
     await unified().use(hl7v2DecodeEscapes).run(tree);
 
-    visit(tree, 'subcomponent', (node: Subcomponent) => {
-      expect(node.value).toBe('Hello\nWorld\rDone');
+    visit(tree, "subcomponent", (node: Subcomponent) => {
+      expect(node.value).toBe("Hello\nWorld\rDone");
     });
   });
 
-  it('leaves unknown escapes untouched', async () => {
-    const tree = makeTree('Unknown\\ABC\\Value');
+  it("leaves unknown escapes untouched", async () => {
+    const tree = makeTree("Unknown\\ABC\\Value");
 
     await unified().use(hl7v2DecodeEscapes).run(tree);
 
-    visit(tree, 'subcomponent', (node: Subcomponent) => {
-      expect(node.value).toBe('Unknown\\ABC\\Value');
+    visit(tree, "subcomponent", (node: Subcomponent) => {
+      expect(node.value).toBe("Unknown\\ABC\\Value");
     });
   });
 
-  it('does nothing when there are no escapes', async () => {
-    const tree = makeTree('PlainValue');
+  it("does nothing when there are no escapes", async () => {
+    const tree = makeTree("PlainValue");
 
     await unified().use(hl7v2DecodeEscapes).run(tree);
 
-    visit(tree, 'subcomponent', (node: Subcomponent) => {
-      expect(node.value).toBe('PlainValue');
+    visit(tree, "subcomponent", (node: Subcomponent) => {
+      expect(node.value).toBe("PlainValue");
     });
   });
 });

--- a/packages/hl7v2-decode-escapes/tsup.config.ts
+++ b/packages/hl7v2-decode-escapes/tsup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
@@ -6,11 +6,11 @@ export default defineConfig({
      * Directories and files should be bundled so that the resulting files line
      * up with the TSC generated type definitions.
      */
-    index: 'src/index.ts',
+    index: "src/index.ts",
     // "utils/index": "src/utils/index.ts",
   },
-  format: ['esm'],
-  target: 'es2022',
+  format: ["esm"],
+  target: "es2022",
   sourcemap: true,
   // treeshake: true,
 

--- a/packages/hl7v2-decode-escapes/vitest.config.ts
+++ b/packages/hl7v2-decode-escapes/vitest.config.ts
@@ -1,11 +1,11 @@
-import { baseConfig } from '@rethinkhealth/testing';
-import { defineConfig, mergeConfig } from 'vitest/config';
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
 
 export default mergeConfig(
   baseConfig,
   defineConfig({
     test: {
-      name: 'hl7-parser',
+      name: "hl7-parser",
     },
   })
 );

--- a/packages/hl7v2-jsonify/package.json
+++ b/packages/hl7v2-jsonify/package.json
@@ -33,7 +33,6 @@
     "@rethinkhealth/tsconfig": "workspace:*",
     "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "tsup": "8.5.0",
     "typescript": "^5.8.3",

--- a/packages/hl7v2-jsonify/package.json
+++ b/packages/hl7v2-jsonify/package.json
@@ -31,7 +31,7 @@
     "@rethinkhealth/hl7v2-ast": "workspace:*",
     "@rethinkhealth/testing": "workspace:*",
     "@rethinkhealth/tsconfig": "workspace:*",
-    "@types/node": "24.3.0",
+    "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
     "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",

--- a/packages/hl7v2-jsonify/src/index.ts
+++ b/packages/hl7v2-jsonify/src/index.ts
@@ -6,13 +6,13 @@ import type {
   Root,
   Segment,
   Subcomponent,
-} from '@rethinkhealth/hl7v2-ast';
-import type { Plugin } from 'unified';
-import type { Node } from 'unist';
+} from "@rethinkhealth/hl7v2-ast";
+import type { Plugin } from "unified";
+import type { Node } from "unist";
 
 type FieldValue = string | string[];
 
-type SegmentJSON = {
+type SegmentJson = {
   segment: string;
   fields: (FieldValue | FieldValue[])[]; // Nested arrays for fields/repetitions/components
 };
@@ -28,9 +28,9 @@ export const hl7v2Jsonify: Plugin<[], Root, string> = function (): void {
   self.compiler = compiler;
 };
 
-export function toJson(root: Nodes): SegmentJSON[] {
+export function toJson(root: Nodes): SegmentJson[] {
   const r = root as Root;
-  const out: SegmentJSON[] = [];
+  const out: SegmentJson[] = [];
 
   for (const s of r.children as Segment[]) {
     const segmentName = getSegmentName(s);
@@ -54,31 +54,31 @@ function getSegmentName(segment: Segment): string {
     // Navigate: segment -> field[0] -> fieldRepetition[0] -> component[0] -> subcomponent[0]
     const firstField = segment.children[0] as Field | undefined;
     if (!firstField) {
-      return 'UNKNOWN';
+      return "UNKNOWN";
     }
 
     const firstRepetition = firstField.children[0] as
       | FieldRepetition
       | undefined;
     if (!firstRepetition) {
-      return 'UNKNOWN';
+      return "UNKNOWN";
     }
 
     const firstComponent = firstRepetition.children[0] as Component | undefined;
     if (!firstComponent) {
-      return 'UNKNOWN';
+      return "UNKNOWN";
     }
 
     const firstSubcomponent = firstComponent.children[0] as
       | Subcomponent
       | undefined;
     if (!firstSubcomponent) {
-      return 'UNKNOWN';
+      return "UNKNOWN";
     }
 
-    return firstSubcomponent.value || 'UNKNOWN';
+    return firstSubcomponent.value || "UNKNOWN";
   } catch {
-    return 'UNKNOWN';
+    return "UNKNOWN";
   }
 }
 
@@ -86,7 +86,7 @@ function getSegmentName(segment: Segment): string {
 function materializeField(field: Field): FieldValue | FieldValue[] {
   const toComponent = (c: Component): FieldValue => {
     if (c.children.length === 0) {
-      return '';
+      return "";
     }
     if (c.children.length === 1) {
       return (c.children[0] as Subcomponent).value;
@@ -94,9 +94,8 @@ function materializeField(field: Field): FieldValue | FieldValue[] {
     return c.children.map((sc) => (sc as Subcomponent).value);
   };
 
-  const toRepetitionArray = (r: FieldRepetition): FieldValue[] => {
-    return r.children.map((c) => toComponent(c as Component));
-  };
+  const toRepetitionArray = (r: FieldRepetition): FieldValue[] =>
+    r.children.map((c) => toComponent(c as Component));
 
   const repetitions = field.children as FieldRepetition[];
 
@@ -104,7 +103,7 @@ function materializeField(field: Field): FieldValue | FieldValue[] {
     const rep = repetitions[0];
 
     if (!rep) {
-      throw new Error('Expected a field repetition');
+      throw new Error("Expected a field repetition");
     }
 
     if (rep.children.length === 1) {

--- a/packages/hl7v2-jsonify/tests/index.test.ts
+++ b/packages/hl7v2-jsonify/tests/index.test.ts
@@ -5,60 +5,60 @@ import type {
   Root,
   Segment,
   Subcomponent,
-} from '@rethinkhealth/hl7v2-ast';
-import { unified } from 'unified';
-import type { Node } from 'unist';
-import { describe, expect, it } from 'vitest';
-import { hl7v2Jsonify, toJson } from '../src';
+} from "@rethinkhealth/hl7v2-ast";
+import { unified } from "unified";
+import type { Node } from "unist";
+import { describe, expect, it } from "vitest";
+import { hl7v2Jsonify, toJson } from "../src";
 
 // Strongly-typed helpers
-const sc = (value: string): Subcomponent => ({ type: 'subcomponent', value });
+const sc = (value: string): Subcomponent => ({ type: "subcomponent", value });
 const comp = (...subs: Subcomponent[]): Component => ({
-  type: 'component',
+  type: "component",
   children: subs,
 });
 const rep = (...comps: Component[]): FieldRepetition => ({
-  type: 'field-repetition',
+  type: "field-repetition",
   children: comps,
 });
 const field = (...reps: FieldRepetition[]): Field => ({
-  type: 'field',
+  type: "field",
   children: reps,
 });
 const segment = (...fields: Field[]): Segment => ({
-  type: 'segment',
+  type: "segment",
   children: fields,
 });
 
-describe('toJson', () => {
-  it('converts a simple MSH segment (parser-shaped AST)', () => {
+describe("toJson", () => {
+  it("converts a simple MSH segment (parser-shaped AST)", () => {
     const tree: Root = {
-      type: 'root',
+      type: "root",
       children: [
         segment(
-          field(rep(comp(sc('MSH')))),
-          field(rep(comp(sc('^~\\&')))),
-          field(rep(comp(sc('SENDER'))))
+          field(rep(comp(sc("MSH")))),
+          field(rep(comp(sc("^~\\&")))),
+          field(rep(comp(sc("SENDER"))))
         ),
       ],
     };
     const result = toJson(tree);
-    expect(result).toEqual([{ segment: 'MSH', fields: ['^~\\&', 'SENDER'] }]);
+    expect(result).toEqual([{ segment: "MSH", fields: ["^~\\&", "SENDER"] }]);
   });
 
-  it('handles nested components, subcomponents, and repetitions', () => {
+  it("handles nested components, subcomponents, and repetitions", () => {
     const tree: Root = {
-      type: 'root',
+      type: "root",
       children: [
         segment(
           // PID header field
-          field(rep(comp(sc('PID')))),
+          field(rep(comp(sc("PID")))),
           // PID.1 123^456
-          field(rep(comp(sc('123')), comp(sc('456')))),
+          field(rep(comp(sc("123")), comp(sc("456")))),
           // PID.2 A^123~B
-          field(rep(comp(sc('A'), sc('123'))), rep(comp(sc('B')))),
+          field(rep(comp(sc("A"), sc("123"))), rep(comp(sc("B")))),
           // PID.3 X~Y
-          field(rep(comp(sc('X'), sc('Y'))))
+          field(rep(comp(sc("X"), sc("Y"))))
         ),
       ],
     };
@@ -66,39 +66,39 @@ describe('toJson', () => {
     const result = toJson(tree);
     expect(result).toEqual([
       {
-        segment: 'PID',
-        fields: [['123', '456'], [['A', '123'], 'B'], [['X', 'Y']]],
+        segment: "PID",
+        fields: [["123", "456"], [["A", "123"], "B"], [["X", "Y"]]],
       },
     ]);
   });
 
-  it('handles multiple segments', () => {
+  it("handles multiple segments", () => {
     const tree: Root = {
-      type: 'root',
+      type: "root",
       children: [
-        segment(field(rep(comp(sc('MSH')))), field(rep(comp(sc('|'))))),
-        segment(field(rep(comp(sc('PID')))), field(rep(comp(sc('12345'))))),
+        segment(field(rep(comp(sc("MSH")))), field(rep(comp(sc("|"))))),
+        segment(field(rep(comp(sc("PID")))), field(rep(comp(sc("12345"))))),
       ],
     };
     const result = toJson(tree);
     expect(result).toEqual([
-      { segment: 'MSH', fields: ['|'] },
-      { segment: 'PID', fields: ['12345'] },
+      { segment: "MSH", fields: ["|"] },
+      { segment: "PID", fields: ["12345"] },
     ]);
   });
 
-  it('creates UNKNOWN when header is missing', () => {
-    const tree: Root = { type: 'root', children: [segment()] };
+  it("creates UNKNOWN when header is missing", () => {
+    const tree: Root = { type: "root", children: [segment()] };
     const result = toJson(tree);
-    expect(result).toEqual([{ segment: 'UNKNOWN', fields: [] }]);
+    expect(result).toEqual([{ segment: "UNKNOWN", fields: [] }]);
   });
 
-  it('materializes [ [] ] as an empty string', () => {
+  it("materializes [ [] ] as an empty string", () => {
     const tree: Root = {
-      type: 'root',
+      type: "root",
       children: [
         segment(
-          field(rep(comp(sc('PID')))),
+          field(rep(comp(sc("PID")))),
           // PID.1 -> [[]] (one component, zero subcomponents)
           field(rep(comp()))
         ),
@@ -107,18 +107,18 @@ describe('toJson', () => {
     const result = toJson(tree);
     expect(result).toEqual([
       {
-        segment: 'PID',
-        fields: [''],
+        segment: "PID",
+        fields: [""],
       },
     ]);
   });
 
   it('materializes [ [], [], [] ] as ["", "", ""]', () => {
     const tree: Root = {
-      type: 'root',
+      type: "root",
       children: [
         segment(
-          field(rep(comp(sc('PID')))),
+          field(rep(comp(sc("PID")))),
           // PID.1 -> [[], [], []] (three components, zero subcomponents each)
           field(rep(comp(), comp(), comp()))
         ),
@@ -127,18 +127,18 @@ describe('toJson', () => {
     const result = toJson(tree);
     expect(result).toEqual([
       {
-        segment: 'PID',
-        fields: [['', '', '']],
+        segment: "PID",
+        fields: [["", "", ""]],
       },
     ]);
   });
 
   it('materializes [ [ [] ], [ [] ] ] as ["", ""]', () => {
     const tree: Root = {
-      type: 'root',
+      type: "root",
       children: [
         segment(
-          field(rep(comp(sc('PID')))),
+          field(rep(comp(sc("PID")))),
           // PID.1 -> two repetitions, each with a single empty component
           field(rep(comp()), rep(comp()))
         ),
@@ -147,19 +147,19 @@ describe('toJson', () => {
     const result = toJson(tree);
     expect(result).toEqual([
       {
-        segment: 'PID',
-        fields: [['', '']],
+        segment: "PID",
+        fields: [["", ""]],
       },
     ]);
   });
 });
 
-describe('hl7v2Jsonify plugin', () => {
-  it('compiles tree to JSON string of toJson output', () => {
+describe("hl7v2Jsonify plugin", () => {
+  it("compiles tree to JSON string of toJson output", () => {
     const tree: Root = {
-      type: 'root',
+      type: "root",
       children: [
-        segment(field(rep(comp(sc('MSH')))), field(rep(comp(sc('|'))))),
+        segment(field(rep(comp(sc("MSH")))), field(rep(comp(sc("|"))))),
       ],
     };
     const processor = unified().use(hl7v2Jsonify) as unknown as {
@@ -167,7 +167,7 @@ describe('hl7v2Jsonify plugin', () => {
     };
     const out = processor.stringify(tree as unknown as Node);
     expect(out).toBe(
-      JSON.stringify([{ segment: 'MSH', fields: ['|'] }], null, 2)
+      JSON.stringify([{ segment: "MSH", fields: ["|"] }], null, 2)
     );
   });
 });

--- a/packages/hl7v2-jsonify/tsup.config.ts
+++ b/packages/hl7v2-jsonify/tsup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
@@ -6,11 +6,11 @@ export default defineConfig({
      * Directories and files should be bundled so that the resulting files line
      * up with the TSC generated type definitions.
      */
-    index: 'src/index.ts',
+    index: "src/index.ts",
     // "utils/index": "src/utils/index.ts",
   },
-  format: ['esm'],
-  target: 'es2022',
+  format: ["esm"],
+  target: "es2022",
   sourcemap: true,
   // treeshake: true,
 

--- a/packages/hl7v2-jsonify/vitest.config.ts
+++ b/packages/hl7v2-jsonify/vitest.config.ts
@@ -1,11 +1,11 @@
-import { baseConfig } from '@rethinkhealth/testing';
-import { defineConfig, mergeConfig } from 'vitest/config';
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
 
 export default mergeConfig(
   baseConfig,
   defineConfig({
     test: {
-      name: 'hl7-parser',
+      name: "hl7-parser",
     },
   })
 );

--- a/packages/hl7v2-lint-max-message-size/package.json
+++ b/packages/hl7v2-lint-max-message-size/package.json
@@ -35,7 +35,6 @@
     "@rethinkhealth/tsconfig": "workspace:*",
     "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "tsup": "8.5.0",
     "typescript": "^5.8.3",

--- a/packages/hl7v2-lint-max-message-size/package.json
+++ b/packages/hl7v2-lint-max-message-size/package.json
@@ -33,7 +33,7 @@
     "@rethinkhealth/hl7v2-parser": "workspace:*",
     "@rethinkhealth/testing": "workspace:*",
     "@rethinkhealth/tsconfig": "workspace:*",
-    "@types/node": "24.3.0",
+    "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
     "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",

--- a/packages/hl7v2-lint-max-message-size/src/index.ts
+++ b/packages/hl7v2-lint-max-message-size/src/index.ts
@@ -1,6 +1,6 @@
-import type { Node, Root } from '@rethinkhealth/hl7v2-ast';
-import { lintRule } from 'unified-lint-rule';
-import { SKIP, visitParents } from 'unist-util-visit-parents';
+import type { Node, Root } from "@rethinkhealth/hl7v2-ast";
+import { lintRule } from "unified-lint-rule";
+import { SKIP, visitParents } from "unist-util-visit-parents";
 
 export type MaxMessageSizeOptions = {
   /** Max allowed size of the HL7v2 message in bytes (UTF-8). Default: 1_000_000 (1MB). */
@@ -12,7 +12,7 @@ export type MaxMessageSizeOptions = {
   maxSegments?: number;
 };
 
-const defaultOptions: Required<Omit<MaxMessageSizeOptions, 'maxSegments'>> & {
+const defaultOptions: Required<Omit<MaxMessageSizeOptions, "maxSegments">> & {
   maxSegments?: number;
 } = {
   maxBytes: 10_000_000, // 10MB
@@ -27,14 +27,14 @@ const defaultOptions: Required<Omit<MaxMessageSizeOptions, 'maxSegments'>> & {
  */
 const hl7v2LintMaxMessageSize = lintRule<Node, MaxMessageSizeOptions>(
   {
-    origin: 'hl7v2-lint:max-message-size',
-    url: 'https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-max-message-size#readme',
+    origin: "hl7v2-lint:max-message-size",
+    url: "https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-max-message-size#readme",
   },
   (tree, file, opts) => {
     const options = { ...defaultOptions, ...opts };
 
     // Byte length of the message
-    const byteLength = Buffer.byteLength(String(file.value), 'utf8');
+    const byteLength = Buffer.byteLength(String(file.value), "utf8");
     if (byteLength > options.maxBytes) {
       file.message(
         `Message size ${byteLength.toLocaleString()} B exceeds limit ${(options.maxBytes).toLocaleString()} B`,
@@ -47,7 +47,7 @@ const hl7v2LintMaxMessageSize = lintRule<Node, MaxMessageSizeOptions>(
 
     visitParents(tree, (node, parents) => {
       // Message count at the root level
-      if (node.type === 'root') {
+      if (node.type === "root") {
         const totalSegments = (node as Root).children.length;
 
         if (options.maxSegments && totalSegments > options.maxSegments) {

--- a/packages/hl7v2-lint-max-message-size/tests/index.test.ts
+++ b/packages/hl7v2-lint-max-message-size/tests/index.test.ts
@@ -1,96 +1,96 @@
-import { hl7v2Jsonify } from '@rethinkhealth/hl7v2-jsonify';
-import { hl7v2Parser } from '@rethinkhealth/hl7v2-parser';
-import { unified } from 'unified';
-import { reporter } from 'vfile-reporter';
-import { describe, expect, it } from 'vitest';
-import hl7v2LintMaxMessageSize from '../src';
+import { hl7v2Jsonify } from "@rethinkhealth/hl7v2-jsonify";
+import { hl7v2Parser } from "@rethinkhealth/hl7v2-parser";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+import { describe, expect, it } from "vitest";
+import hl7v2LintMaxMessageSize from "../src";
 
-describe('hl7v2-lint:max-message-size', () => {
-  const parseHL7v2 = unified().use(hl7v2Parser).use(hl7v2Jsonify);
+describe("hl7v2-lint:max-message-size", () => {
+  const parseHl7v2 = unified().use(hl7v2Parser).use(hl7v2Jsonify);
 
-  it('should have no issues for a small message', async () => {
+  it("should have no issues for a small message", async () => {
     const msg = [
       // MSH
-      'MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5',
+      "MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5",
       // PID
-      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
       // OBX
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-    ].join('\r');
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+    ].join("\r");
 
-    const output = await parseHL7v2().use(hl7v2LintMaxMessageSize).process(msg);
+    const output = await parseHl7v2().use(hl7v2LintMaxMessageSize).process(msg);
 
     const report = reporter(output);
 
-    expect(report).toEqual('no issues found');
+    expect(report).toEqual("no issues found");
   });
 
-  it('warns when message size exceeds the limit', async () => {
+  it("warns when message size exceeds the limit", async () => {
     // Message size is ~440 bytes
     const msg = [
       // MSH
-      'MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5',
+      "MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5",
       // PID
-      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
       // OBX
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-    ].join('\r');
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+    ].join("\r");
 
-    const output = await parseHL7v2()
+    const output = await parseHl7v2()
       .use(hl7v2LintMaxMessageSize, { maxBytes: 100 })
       .process(msg);
 
     const report = reporter(output);
 
-    expect(report).not.toEqual('no issues found');
-    expect(report).toContain('Message size 441 B exceeds limit 100 B');
+    expect(report).not.toEqual("no issues found");
+    expect(report).toContain("Message size 441 B exceeds limit 100 B");
   });
 
-  it('warns when message has too many segments', async () => {
+  it("warns when message has too many segments", async () => {
     // Message size is ~440 bytes
     const msg = [
       // MSH
-      'MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5',
+      "MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5",
       // PID
-      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
       // OBX
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-    ].join('\r');
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+    ].join("\r");
 
-    const output = await parseHL7v2()
+    const output = await parseHl7v2()
       .use(hl7v2LintMaxMessageSize, { maxSegments: 1 })
       .process(msg);
 
     const report = reporter(output);
 
-    expect(report).not.toEqual('no issues found');
-    expect(report).toContain('Message has 3 segments, exceeds limit 1');
+    expect(report).not.toEqual("no issues found");
+    expect(report).toContain("Message has 3 segments, exceeds limit 1");
   });
 
-  it('warns when message has too many segments and size exceeds the limit', async () => {
+  it("warns when message has too many segments and size exceeds the limit", async () => {
     // Message size is ~440 bytes
     const msg = [
       // MSH
-      'MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5',
+      "MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5",
       // PID
-      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
       // OBX
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-    ].join('\r');
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+    ].join("\r");
 
-    const file = await parseHL7v2()
+    const file = await parseHl7v2()
       .use(hl7v2LintMaxMessageSize, { maxSegments: 1, maxBytes: 100 })
       .process(msg);
 
     const report = reporter(file);
 
-    expect(report).not.toEqual('no issues found');
+    expect(report).not.toEqual("no issues found");
     expect(file.messages).toHaveLength(2);
     expect(file.messages[0].message).toContain(
-      'Message size 441 B exceeds limit 100 B'
+      "Message size 441 B exceeds limit 100 B"
     );
     expect(file.messages[1].message).toContain(
-      'Message has 3 segments, exceeds limit 1'
+      "Message has 3 segments, exceeds limit 1"
     );
   });
 });

--- a/packages/hl7v2-lint-max-message-size/tsup.config.ts
+++ b/packages/hl7v2-lint-max-message-size/tsup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
@@ -6,11 +6,11 @@ export default defineConfig({
      * Directories and files should be bundled so that the resulting files line
      * up with the TSC generated type definitions.
      */
-    index: 'src/index.ts',
+    index: "src/index.ts",
     // "utils/index": "src/utils/index.ts",
   },
-  format: ['esm'],
-  target: 'es2022',
+  format: ["esm"],
+  target: "es2022",
   sourcemap: true,
   // treeshake: true,
 

--- a/packages/hl7v2-lint-max-message-size/vitest.config.ts
+++ b/packages/hl7v2-lint-max-message-size/vitest.config.ts
@@ -1,11 +1,11 @@
-import { baseConfig } from '@rethinkhealth/testing';
-import { defineConfig, mergeConfig } from 'vitest/config';
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
 
 export default mergeConfig(
   baseConfig,
   defineConfig({
     test: {
-      name: 'hl7-parser',
+      name: "hl7-parser",
     },
   })
 );

--- a/packages/hl7v2-lint-no-trailing-empty-field/package.json
+++ b/packages/hl7v2-lint-no-trailing-empty-field/package.json
@@ -36,7 +36,6 @@
     "@rethinkhealth/tsconfig": "workspace:*",
     "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "tsup": "8.5.0",
     "typescript": "^5.8.3",

--- a/packages/hl7v2-lint-no-trailing-empty-field/package.json
+++ b/packages/hl7v2-lint-no-trailing-empty-field/package.json
@@ -34,7 +34,7 @@
     "@rethinkhealth/hl7v2-parser": "workspace:*",
     "@rethinkhealth/testing": "workspace:*",
     "@rethinkhealth/tsconfig": "workspace:*",
-    "@types/node": "24.3.0",
+    "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
     "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",

--- a/packages/hl7v2-lint-no-trailing-empty-field/src/index.ts
+++ b/packages/hl7v2-lint-no-trailing-empty-field/src/index.ts
@@ -1,17 +1,17 @@
-import type { Node, Segment } from '@rethinkhealth/hl7v2-ast';
-import { isEmptyNode } from '@rethinkhealth/hl7v2-utils';
-import { lintRule } from 'unified-lint-rule';
-import type { Position } from 'unist';
-import { SKIP, visitParents } from 'unist-util-visit-parents';
+import type { Node, Segment } from "@rethinkhealth/hl7v2-ast";
+import { isEmptyNode } from "@rethinkhealth/hl7v2-utils";
+import { lintRule } from "unified-lint-rule";
+import type { Position } from "unist";
+import { SKIP, visitParents } from "unist-util-visit-parents";
 
 const hl7v2LintNoTrailingEmptyField = lintRule<Node, undefined>(
   {
-    origin: 'hl7v2-lint:no-trailing-empty-field',
-    url: 'https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-no-trailing-empty-field#readme',
+    origin: "hl7v2-lint:no-trailing-empty-field",
+    url: "https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-no-trailing-empty-field#readme",
   },
   (tree, file) => {
     // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Required for comprehensive HL7v2 segment field traversal logic.
-    visitParents(tree, 'segment', (seg: Segment, ancestors) => {
+    visitParents(tree, "segment", (seg: Segment, ancestors) => {
       const fields = seg.children ?? [];
       if (fields.length === 0) {
         return SKIP;

--- a/packages/hl7v2-lint-no-trailing-empty-field/tests/index.test.ts
+++ b/packages/hl7v2-lint-no-trailing-empty-field/tests/index.test.ts
@@ -1,31 +1,31 @@
-import { hl7v2Jsonify } from '@rethinkhealth/hl7v2-jsonify';
-import { hl7v2Parser } from '@rethinkhealth/hl7v2-parser';
-import { unified } from 'unified';
-import { reporter } from 'vfile-reporter';
-import { describe, expect, it } from 'vitest';
-import hl7v2LintNoTrailingFieldSeparator from '../src';
+import { hl7v2Jsonify } from "@rethinkhealth/hl7v2-jsonify";
+import { hl7v2Parser } from "@rethinkhealth/hl7v2-parser";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+import { describe, expect, it } from "vitest";
+import hl7v2LintNoTrailingFieldSeparator from "../src";
 
-const parseHL7v2 = unified().use(hl7v2Parser).use(hl7v2Jsonify).freeze();
+const parseHl7v2 = unified().use(hl7v2Parser).use(hl7v2Jsonify).freeze();
 
-describe('hl7v2-lint:no-trailing-field-separator', () => {
-  it('does not warn for a single segment message with no trailing field separators', async () => {
+describe("hl7v2-lint:no-trailing-field-separator", () => {
+  it("does not warn for a single segment message with no trailing field separators", async () => {
     const msg =
-      'MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5';
+      "MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5";
 
-    const file = await parseHL7v2()
+    const file = await parseHl7v2()
       .use(hl7v2LintNoTrailingFieldSeparator)
       .process(msg);
 
     const report = reporter(file);
 
-    expect(report).toEqual('no issues found');
+    expect(report).toEqual("no issues found");
   });
 
-  it('no warns for a message with an end field with components', async () => {
+  it("no warns for a message with an end field with components", async () => {
     const msg =
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R';
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R";
 
-    const file = await parseHL7v2()
+    const file = await parseHl7v2()
       .use(hl7v2LintNoTrailingFieldSeparator)
       .process(msg);
 
@@ -33,59 +33,59 @@ describe('hl7v2-lint:no-trailing-field-separator', () => {
 
     const report = reporter(file);
 
-    expect(report).toEqual('no issues found');
+    expect(report).toEqual("no issues found");
   });
 
-  it('no warns for a message with an end field with empty components', async () => {
-    const msg = 'OBR|1||200202150930|||^^^^^';
+  it("no warns for a message with an end field with empty components", async () => {
+    const msg = "OBR|1||200202150930|||^^^^^";
 
-    const file = await parseHL7v2()
+    const file = await parseHl7v2()
       .use(hl7v2LintNoTrailingFieldSeparator)
       .process(msg);
 
     const report = reporter(file);
 
-    expect(report).toEqual('no issues found');
+    expect(report).toEqual("no issues found");
   });
 
-  it('no warns for a message with end field with multiple components', async () => {
-    const msg = 'OBR|||^^^^^';
+  it("no warns for a message with end field with multiple components", async () => {
+    const msg = "OBR|||^^^^^";
 
-    const file = await parseHL7v2()
+    const file = await parseHl7v2()
       .use(hl7v2LintNoTrailingFieldSeparator)
       .process(msg);
 
     const report = reporter(file);
 
-    expect(report).toEqual('no issues found');
+    expect(report).toEqual("no issues found");
   });
 
-  it('no warns for a message with end field with multiple repetitions', async () => {
-    const msg = 'OBR|||~^^';
+  it("no warns for a message with end field with multiple repetitions", async () => {
+    const msg = "OBR|||~^^";
 
-    const file = await parseHL7v2()
+    const file = await parseHl7v2()
       .use(hl7v2LintNoTrailingFieldSeparator)
       .process(msg);
 
     const report = reporter(file);
 
-    expect(report).toEqual('no issues found');
+    expect(report).toEqual("no issues found");
   });
 
-  it('no warns for a message with a single trailing field separators', async () => {
+  it("no warns for a message with a single trailing field separators", async () => {
     const msg = [
       // MSH
-      'MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5|', // trailing field separator
+      "MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5|", // trailing field separator
       // PID
-    ].join('\r');
+    ].join("\r");
 
-    const file = await parseHL7v2()
+    const file = await parseHl7v2()
       .use(hl7v2LintNoTrailingFieldSeparator)
       .process(msg);
 
     const report = reporter(file);
 
-    expect(report).toEqual('no issues found');
+    expect(report).toEqual("no issues found");
     expect(file.messages.length).toEqual(0);
   });
 });

--- a/packages/hl7v2-lint-no-trailing-empty-field/tsup.config.ts
+++ b/packages/hl7v2-lint-no-trailing-empty-field/tsup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
@@ -6,11 +6,11 @@ export default defineConfig({
      * Directories and files should be bundled so that the resulting files line
      * up with the TSC generated type definitions.
      */
-    index: 'src/index.ts',
+    index: "src/index.ts",
     // "utils/index": "src/utils/index.ts",
   },
-  format: ['esm'],
-  target: 'es2022',
+  format: ["esm"],
+  target: "es2022",
   sourcemap: true,
   // treeshake: true,
 

--- a/packages/hl7v2-lint-no-trailing-empty-field/vitest.config.ts
+++ b/packages/hl7v2-lint-no-trailing-empty-field/vitest.config.ts
@@ -1,11 +1,11 @@
-import { baseConfig } from '@rethinkhealth/testing';
-import { defineConfig, mergeConfig } from 'vitest/config';
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
 
 export default mergeConfig(
   baseConfig,
   defineConfig({
     test: {
-      name: 'hl7-parser',
+      name: "hl7-parser",
     },
   })
 );

--- a/packages/hl7v2-lint-required-message-header/package.json
+++ b/packages/hl7v2-lint-required-message-header/package.json
@@ -35,7 +35,6 @@
     "@rethinkhealth/tsconfig": "workspace:*",
     "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "tsup": "8.5.0",
     "typescript": "^5.8.3",

--- a/packages/hl7v2-lint-required-message-header/package.json
+++ b/packages/hl7v2-lint-required-message-header/package.json
@@ -33,7 +33,7 @@
     "@rethinkhealth/hl7v2-parser": "workspace:*",
     "@rethinkhealth/testing": "workspace:*",
     "@rethinkhealth/tsconfig": "workspace:*",
-    "@types/node": "24.3.0",
+    "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
     "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",

--- a/packages/hl7v2-lint-required-message-header/src/index.ts
+++ b/packages/hl7v2-lint-required-message-header/src/index.ts
@@ -1,6 +1,6 @@
-import type { Node, Root, Segment } from '@rethinkhealth/hl7v2-ast';
-import { lintRule } from 'unified-lint-rule';
-import { SKIP, visitParents } from 'unist-util-visit-parents';
+import type { Node, Root, Segment } from "@rethinkhealth/hl7v2-ast";
+import { lintRule } from "unified-lint-rule";
+import { SKIP, visitParents } from "unist-util-visit-parents";
 
 /**
  * hl7v2-lint rule to warn when message header segment (MSH) is missing.
@@ -10,17 +10,17 @@ import { SKIP, visitParents } from 'unist-util-visit-parents';
  */
 const hl7v2LintSegmentRequiredMessageHeader = lintRule<Node, undefined>(
   {
-    origin: 'hl7v2-lint:segment-required-message-header',
-    url: 'https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-segment-required-message-header#readme',
+    origin: "hl7v2-lint:segment-required-message-header",
+    url: "https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-segment-required-message-header#readme",
   },
   (tree, file) => {
     visitParents(tree, (node, parents) => {
-      if (node.type === 'root') {
+      if (node.type === "root") {
         const firstSegment = (node as Root).children[0];
-        if (firstSegment?.type === 'segment') {
+        if (firstSegment?.type === "segment") {
           const header = (firstSegment as Segment).children?.[0]?.children?.[0]
             ?.children?.[0]?.children?.[0]?.value;
-          if (header !== 'MSH') {
+          if (header !== "MSH") {
             file.message(
               `Message header (MSH) segment is required. Received ${header} instead.`,
               {

--- a/packages/hl7v2-lint-required-message-header/tests/index.test.ts
+++ b/packages/hl7v2-lint-required-message-header/tests/index.test.ts
@@ -1,68 +1,68 @@
-import { hl7v2Jsonify } from '@rethinkhealth/hl7v2-jsonify';
-import { hl7v2Parser } from '@rethinkhealth/hl7v2-parser';
-import { unified } from 'unified';
-import { reporter } from 'vfile-reporter';
-import { describe, expect, it } from 'vitest';
-import hl7v2LintSegmentRequiredMessageHeader from '../src';
+import { hl7v2Jsonify } from "@rethinkhealth/hl7v2-jsonify";
+import { hl7v2Parser } from "@rethinkhealth/hl7v2-parser";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+import { describe, expect, it } from "vitest";
+import hl7v2LintSegmentRequiredMessageHeader from "../src";
 
-describe('hl7v2-lint:segment-required-message-header', () => {
-  const parseHL7v2 = unified().use(hl7v2Parser).use(hl7v2Jsonify);
+describe("hl7v2-lint:segment-required-message-header", () => {
+  const parseHl7v2 = unified().use(hl7v2Parser).use(hl7v2Jsonify);
 
-  it('should have no issues when message header MSH segment is present', async () => {
+  it("should have no issues when message header MSH segment is present", async () => {
     const msg = [
       // MSH
-      'MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5',
+      "MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5",
       // PID
-      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
       // OBX
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-    ].join('\r');
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+    ].join("\r");
 
-    const output = await parseHL7v2()
+    const output = await parseHl7v2()
       .use(hl7v2LintSegmentRequiredMessageHeader)
       .process(msg);
 
     const report = reporter(output);
 
-    expect(report).toEqual('no issues found');
+    expect(report).toEqual("no issues found");
   });
 
-  it('warns when message header MSH segment is missing', async () => {
+  it("warns when message header MSH segment is missing", async () => {
     const msg = [
       // PID
-      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
       // OBX
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-    ].join('\r');
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+    ].join("\r");
 
-    const file = await parseHL7v2()
+    const file = await parseHl7v2()
       .use(hl7v2LintSegmentRequiredMessageHeader)
       .process(msg);
 
     const report = reporter(file);
 
-    expect(report).not.toEqual('no issues found');
+    expect(report).not.toEqual("no issues found");
     expect(file.messages).toHaveLength(1);
     expect(file.messages[0].message).toEqual(
-      'Message header (MSH) segment is required. Received PID instead.'
+      "Message header (MSH) segment is required. Received PID instead."
     );
   });
 
-  it('warns with correct metadata', async () => {
+  it("warns with correct metadata", async () => {
     const msg = [
       // PID
-      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
       // OBX
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-    ].join('\r');
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+    ].join("\r");
 
-    const file = await parseHL7v2()
+    const file = await parseHl7v2()
       .use(hl7v2LintSegmentRequiredMessageHeader)
       .process(msg);
 
     const report = reporter(file);
 
-    expect(report).not.toEqual('no issues found');
+    expect(report).not.toEqual("no issues found");
     expect(file.messages).toHaveLength(1);
     // POSITION METADATA
     expect(file.messages[0].column).toEqual(1);
@@ -81,7 +81,7 @@ describe('hl7v2-lint:segment-required-message-header', () => {
     });
 
     // RULE METADATA
-    expect(file.messages[0].ruleId).toEqual('segment-required-message-header');
-    expect(file.messages[0].source).toEqual('hl7v2-lint');
+    expect(file.messages[0].ruleId).toEqual("segment-required-message-header");
+    expect(file.messages[0].source).toEqual("hl7v2-lint");
   });
 });

--- a/packages/hl7v2-lint-required-message-header/tsup.config.ts
+++ b/packages/hl7v2-lint-required-message-header/tsup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
@@ -6,11 +6,11 @@ export default defineConfig({
      * Directories and files should be bundled so that the resulting files line
      * up with the TSC generated type definitions.
      */
-    index: 'src/index.ts',
+    index: "src/index.ts",
     // "utils/index": "src/utils/index.ts",
   },
-  format: ['esm'],
-  target: 'es2022',
+  format: ["esm"],
+  target: "es2022",
   sourcemap: true,
   // treeshake: true,
 

--- a/packages/hl7v2-lint-required-message-header/vitest.config.ts
+++ b/packages/hl7v2-lint-required-message-header/vitest.config.ts
@@ -1,11 +1,11 @@
-import { baseConfig } from '@rethinkhealth/testing';
-import { defineConfig, mergeConfig } from 'vitest/config';
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
 
 export default mergeConfig(
   baseConfig,
   defineConfig({
     test: {
-      name: 'hl7-parser',
+      name: "hl7-parser",
     },
   })
 );

--- a/packages/hl7v2-lint-segment-header-length/package.json
+++ b/packages/hl7v2-lint-segment-header-length/package.json
@@ -34,7 +34,7 @@
     "@rethinkhealth/hl7v2-parser": "workspace:*",
     "@rethinkhealth/testing": "workspace:*",
     "@rethinkhealth/tsconfig": "workspace:*",
-    "@types/node": "24.3.0",
+    "@types/node": "24.5.2",
     "@types/pluralize": "^0.0.33",
     "@types/unist": "^3.0.3",
     "@vitest/coverage-c8": "^0.33.0",

--- a/packages/hl7v2-lint-segment-header-length/package.json
+++ b/packages/hl7v2-lint-segment-header-length/package.json
@@ -37,7 +37,6 @@
     "@types/node": "24.5.2",
     "@types/pluralize": "^0.0.33",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "tsup": "8.5.0",
     "typescript": "^5.8.3",

--- a/packages/hl7v2-lint-segment-header-length/src/index.ts
+++ b/packages/hl7v2-lint-segment-header-length/src/index.ts
@@ -1,7 +1,7 @@
-import type { Node, Segment } from '@rethinkhealth/hl7v2-ast';
-import pluralize from 'pluralize';
-import { lintRule } from 'unified-lint-rule';
-import { CONTINUE, SKIP, visitParents } from 'unist-util-visit-parents';
+import type { Node, Segment } from "@rethinkhealth/hl7v2-ast";
+import pluralize from "pluralize";
+import { lintRule } from "unified-lint-rule";
+import { CONTINUE, SKIP, visitParents } from "unist-util-visit-parents";
 
 /**
  * hl7v2-lint rule to warn when segment header length is invalid.
@@ -10,16 +10,16 @@ import { CONTINUE, SKIP, visitParents } from 'unist-util-visit-parents';
  */
 const hl7v2LintSegmentHeaderLength = lintRule<Node, undefined>(
   {
-    origin: 'hl7v2-lint:segment-header-length',
-    url: 'https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-segment-header-length#readme',
+    origin: "hl7v2-lint:segment-header-length",
+    url: "https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-segment-header-length#readme",
   },
   (tree, file) => {
     visitParents(tree, (node, parents) => {
-      if (node.type === 'root') {
+      if (node.type === "root") {
         return CONTINUE;
       }
 
-      if (node.type !== 'segment') {
+      if (node.type !== "segment") {
         return SKIP;
       }
 
@@ -34,8 +34,8 @@ const hl7v2LintSegmentHeaderLength = lintRule<Node, undefined>(
       file.message(
         `Unexpected ${size} header length, expected 3 characters, ${
           size > 3
-            ? `remove ${size - 3} ${pluralize('character', size - 3)}`
-            : `add ${3 - (size ?? 0)} ${pluralize('character', 3 - (size ?? 0))}`
+            ? `remove ${size - 3} ${pluralize("character", size - 3)}`
+            : `add ${3 - (size ?? 0)} ${pluralize("character", 3 - (size ?? 0))}`
         }`,
         { ancestors: [...parents, node], place: node.position }
       );

--- a/packages/hl7v2-lint-segment-header-length/tests/index.test.ts
+++ b/packages/hl7v2-lint-segment-header-length/tests/index.test.ts
@@ -1,97 +1,97 @@
-import { hl7v2Jsonify } from '@rethinkhealth/hl7v2-jsonify';
-import { hl7v2Parser } from '@rethinkhealth/hl7v2-parser';
-import { unified } from 'unified';
-import { reporter } from 'vfile-reporter';
-import { describe, expect, it } from 'vitest';
-import hl7v2LintSegmentHeaderLength from '../src';
+import { hl7v2Jsonify } from "@rethinkhealth/hl7v2-jsonify";
+import { hl7v2Parser } from "@rethinkhealth/hl7v2-parser";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+import { describe, expect, it } from "vitest";
+import hl7v2LintSegmentHeaderLength from "../src";
 
-const parseHL7v2 = unified().use(hl7v2Parser).use(hl7v2Jsonify);
+const parseHl7v2 = unified().use(hl7v2Parser).use(hl7v2Jsonify);
 
-describe('hl7v2-lint:segment-header-length', () => {
-  it('should have no issues when segment header length is valid', async () => {
-    const hl7v2 = 'MSH|^~\\&';
+describe("hl7v2-lint:segment-header-length", () => {
+  it("should have no issues when segment header length is valid", async () => {
+    const hl7v2 = "MSH|^~\\&";
 
-    const output = await parseHL7v2()
+    const output = await parseHl7v2()
       .use(hl7v2LintSegmentHeaderLength)
       .process(hl7v2);
 
     const report = reporter(output);
 
-    expect(report).toEqual('no issues found');
+    expect(report).toEqual("no issues found");
   });
 
-  it('should warn when segment header length is invalid - more than 3 characters', async () => {
-    const hl7v2 = 'PID_ADDED|^~\\&';
+  it("should warn when segment header length is invalid - more than 3 characters", async () => {
+    const hl7v2 = "PID_ADDED|^~\\&";
 
-    const output = await parseHL7v2()
+    const output = await parseHl7v2()
       .use(hl7v2LintSegmentHeaderLength)
       .process(hl7v2);
 
     const report = reporter(output);
 
-    expect(report).not.toEqual('no issues found');
+    expect(report).not.toEqual("no issues found");
     expect(output.messages.length).toEqual(1);
     expect(output.messages[0]).toMatchObject({
       message:
-        'Unexpected 9 header length, expected 3 characters, remove 6 characters',
-      name: '1:1-1:15',
-      ruleId: 'segment-header-length',
-      source: 'hl7v2-lint',
-      url: 'https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-segment-header-length#readme',
+        "Unexpected 9 header length, expected 3 characters, remove 6 characters",
+      name: "1:1-1:15",
+      ruleId: "segment-header-length",
+      source: "hl7v2-lint",
+      url: "https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-segment-header-length#readme",
     });
   });
 
-  it('should warn when segment header length is invalid - less than 3 characters', async () => {
-    const hl7v2 = 'PI|^~\\&';
+  it("should warn when segment header length is invalid - less than 3 characters", async () => {
+    const hl7v2 = "PI|^~\\&";
 
-    const output = await parseHL7v2()
+    const output = await parseHl7v2()
       .use(hl7v2LintSegmentHeaderLength)
       .process(hl7v2);
 
     const report = reporter(output);
 
-    expect(report).not.toEqual('no issues found');
+    expect(report).not.toEqual("no issues found");
     expect(output.messages.length).toEqual(1);
     expect(output.messages[0]).toMatchObject({
       message:
-        'Unexpected 2 header length, expected 3 characters, add 1 character',
-      name: '1:1-1:8',
+        "Unexpected 2 header length, expected 3 characters, add 1 character",
+      name: "1:1-1:8",
     });
   });
 
-  it('shoud not warn when multiple segments are present', async () => {
+  it("shoud not warn when multiple segments are present", async () => {
     const hl7v2 =
-      'PID|1|John Doe|Doe|John|19900101|M|||\r\nPID|2|Jane Doe|Doe|Jane|19900101|F|||\r\n';
+      "PID|1|John Doe|Doe|John|19900101|M|||\r\nPID|2|Jane Doe|Doe|Jane|19900101|F|||\r\n";
 
-    const output = await parseHL7v2()
+    const output = await parseHl7v2()
       .use(hl7v2LintSegmentHeaderLength)
       .process(hl7v2);
 
     const report = reporter(output);
 
-    expect(report).toEqual('no issues found');
+    expect(report).toEqual("no issues found");
     expect(output.messages.length).toEqual(0);
   });
 
-  it('shoud warn when multiple segments are present - first segment is invalid', async () => {
+  it("shoud warn when multiple segments are present - first segment is invalid", async () => {
     const msg = [
-      'PIDAFD|1||12345^^^HOSP^MR||DOE\\S\\JOHN^A&J|19700101|M',
+      "PIDAFD|1||12345^^^HOSP^MR||DOE\\S\\JOHN^A&J|19700101|M",
       // PID with components, repetitions and escapes (\S\ for ^)
-      'NK1|1||12345^^^HOSP^MR||DOE\\S\\JOHN^A&J|19700101|M',
-    ].join('\r');
+      "NK1|1||12345^^^HOSP^MR||DOE\\S\\JOHN^A&J|19700101|M",
+    ].join("\r");
 
-    const output = await parseHL7v2()
+    const output = await parseHl7v2()
       .use(hl7v2LintSegmentHeaderLength)
       .process(msg);
 
     const report = reporter(output);
 
-    expect(report).not.toEqual('no issues found');
+    expect(report).not.toEqual("no issues found");
     expect(output.messages.length).toEqual(1);
     expect(output.messages[0]).toMatchObject({
       message:
-        'Unexpected 6 header length, expected 3 characters, remove 3 characters',
-      name: '1:1-1:53',
+        "Unexpected 6 header length, expected 3 characters, remove 3 characters",
+      name: "1:1-1:53",
     });
   });
 });

--- a/packages/hl7v2-lint-segment-header-length/tsup.config.ts
+++ b/packages/hl7v2-lint-segment-header-length/tsup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
@@ -6,11 +6,11 @@ export default defineConfig({
      * Directories and files should be bundled so that the resulting files line
      * up with the TSC generated type definitions.
      */
-    index: 'src/index.ts',
+    index: "src/index.ts",
     // "utils/index": "src/utils/index.ts",
   },
-  format: ['esm'],
-  target: 'es2022',
+  format: ["esm"],
+  target: "es2022",
   sourcemap: true,
   // treeshake: true,
 

--- a/packages/hl7v2-lint-segment-header-length/vitest.config.ts
+++ b/packages/hl7v2-lint-segment-header-length/vitest.config.ts
@@ -1,11 +1,11 @@
-import { baseConfig } from '@rethinkhealth/testing';
-import { defineConfig, mergeConfig } from 'vitest/config';
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
 
 export default mergeConfig(
   baseConfig,
   defineConfig({
     test: {
-      name: 'hl7-parser',
+      name: "hl7-parser",
     },
   })
 );

--- a/packages/hl7v2-parser/package.json
+++ b/packages/hl7v2-parser/package.json
@@ -30,7 +30,7 @@
     "@rethinkhealth/hl7v2-ast": "workspace:*",
     "@rethinkhealth/testing": "workspace:*",
     "@rethinkhealth/tsconfig": "workspace:*",
-    "@types/node": "24.3.0",
+    "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
     "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",

--- a/packages/hl7v2-parser/package.json
+++ b/packages/hl7v2-parser/package.json
@@ -32,7 +32,6 @@
     "@rethinkhealth/tsconfig": "workspace:*",
     "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "tsup": "8.5.0",
     "typescript": "^5.8.3",

--- a/packages/hl7v2-parser/src/index.ts
+++ b/packages/hl7v2-parser/src/index.ts
@@ -1,6 +1,6 @@
 // biome-ignore lint/performance/noBarrelFile: fine.
-export { default as hl7v2Parser } from './parser';
-export * from './preprocessor';
-export { parseHL7v2FromIterator } from './processor';
-export * from './tokenizer';
-export * from './types';
+export { default as hl7v2Parser } from "./parser";
+export * from "./preprocessor";
+export { parseHL7v2FromIterator } from "./processor";
+export * from "./tokenizer";
+export * from "./types";

--- a/packages/hl7v2-parser/src/parser.ts
+++ b/packages/hl7v2-parser/src/parser.ts
@@ -1,10 +1,10 @@
-import type { Root } from '@rethinkhealth/hl7v2-ast';
-import { DEFAULT_DELIMITERS } from '@rethinkhealth/hl7v2-utils';
-import type { Plugin } from 'unified';
-import { defaultPreprocessors, runPreprocessors } from './preprocessor';
-import { parseHL7v2FromIterator } from './processor';
-import { HL7v2Tokenizer } from './tokenizer';
-import type { ParseOptions, ParserContext, Token, Tokenizer } from './types';
+import type { Root } from "@rethinkhealth/hl7v2-ast";
+import { DEFAULT_DELIMITERS } from "@rethinkhealth/hl7v2-utils";
+import type { Plugin } from "unified";
+import { defaultPreprocessors, runPreprocessors } from "./preprocessor";
+import { parseHL7v2FromIterator } from "./processor";
+import { HL7v2Tokenizer } from "./tokenizer";
+import type { ParseOptions, ParserContext, Token, Tokenizer } from "./types";
 
 function* iterateTokenizerSync(t: Tokenizer): Iterable<Token> {
   for (let tok = t.next(); tok; tok = t.next()) {
@@ -12,6 +12,7 @@ function* iterateTokenizerSync(t: Tokenizer): Iterable<Token> {
   }
 }
 
+// biome-ignore lint/style/useNamingConvention: HL7v2 is a special case
 export function parseHL7v2(input: string, opts: ParseOptions): Root {
   let ctx: ParserContext = {
     input,

--- a/packages/hl7v2-parser/src/preprocessor.ts
+++ b/packages/hl7v2-parser/src/preprocessor.ts
@@ -1,11 +1,12 @@
-import { DEFAULT_DELIMITERS } from '@rethinkhealth/hl7v2-utils';
-import type { ParserContext, PreprocessorStep } from './types';
+import { DEFAULT_DELIMITERS } from "@rethinkhealth/hl7v2-utils";
+import type { ParserContext, PreprocessorStep } from "./types";
 
 // PreprocessorStep is declared in `types.ts` to avoid circular imports
 
 /**
  * Step: strip UTF-8 BOM.
  */
+// biome-ignore lint/style/useNamingConvention: fine
 export const stripBOM: PreprocessorStep = (ctx) => {
   if (ctx.input.charCodeAt(0) === 0xfe_ff) {
     ctx.input = ctx.input.slice(1);
@@ -25,7 +26,7 @@ export const normalizeNewlines: PreprocessorStep = (ctx) => {
  * Step: auto-detect delimiters from MSH.
  */
 export const detectDelimiters: PreprocessorStep = (ctx) => {
-  if (ctx.input.startsWith('MSH')) {
+  if (ctx.input.startsWith("MSH")) {
     const field = ctx.input.charAt(3) || DEFAULT_DELIMITERS.field;
     const enc = ctx.input.slice(4, 8);
     const component = enc.charAt(0) || DEFAULT_DELIMITERS.component;

--- a/packages/hl7v2-parser/src/types.ts
+++ b/packages/hl7v2-parser/src/types.ts
@@ -1,4 +1,4 @@
-import type { Delimiters } from '@rethinkhealth/hl7v2-ast';
+import type { Delimiters } from "@rethinkhealth/hl7v2-ast";
 
 // Forward declaration to avoid circular import at runtime
 // Consumers provide functions with compatible signature from `preprocessor.ts`
@@ -30,13 +30,13 @@ export type Token = {
 
 // ---- Tokenizer interface ----
 export type TokenType =
-  | 'SEGMENT_START'
-  | 'SEGMENT_END'
-  | 'FIELD_DELIM'
-  | 'REPETITION_DELIM'
-  | 'COMPONENT_DELIM'
-  | 'SUBCOMP_DELIM'
-  | 'TEXT';
+  | "SEGMENT_START"
+  | "SEGMENT_END"
+  | "FIELD_DELIM"
+  | "REPETITION_DELIM"
+  | "COMPONENT_DELIM"
+  | "SUBCOMP_DELIM"
+  | "TEXT";
 
 export type Tokenizer = {
   reset(ctx: ParserContext): void;

--- a/packages/hl7v2-parser/test/parser.test.ts
+++ b/packages/hl7v2-parser/test/parser.test.ts
@@ -4,54 +4,54 @@ import type {
   Field,
   FieldRepetition,
   Segment,
-} from '@rethinkhealth/hl7v2-ast';
-import { describe, expect, it } from 'vitest';
-import { parseHL7v2 } from '../src/parser';
-import type { PreprocessorStep } from '../src/types';
+} from "@rethinkhealth/hl7v2-ast";
+import { describe, expect, it } from "vitest";
+import { parseHL7v2 } from "../src/parser";
+import type { PreprocessorStep } from "../src/types";
 
 const delims: Delimiters = {
-  field: '|',
-  component: '^',
-  repetition: '~',
-  escape: '\\',
-  subcomponent: '&',
-  segment: '\r',
+  field: "|",
+  component: "^",
+  repetition: "~",
+  escape: "\\",
+  subcomponent: "&",
+  segment: "\r",
 };
 
-describe('HL7v2 parser', () => {
-  describe('single segment', () => {
-    it('parses a single segment with two fields', () => {
-      const root = parseHL7v2('PID|1\r', { delimiters: delims });
+describe("HL7v2 parser", () => {
+  describe("single segment", () => {
+    it("parses a single segment with two fields", () => {
+      const root = parseHL7v2("PID|1\r", { delimiters: delims });
       expect(root.children).toHaveLength(1);
       const seg = root.children[0] as Segment;
       expect(seg.children).toHaveLength(2);
       expect(seg.children[0].children[0].children[0].children[0].value).toBe(
-        'PID'
+        "PID"
       );
       expect(seg.children[1].children[0].children[0].children[0].value).toBe(
-        '1'
+        "1"
       );
 
       expect(root).toMatchSnapshot();
     });
 
-    it('parses a segment ending with a field delimiter', () => {
-      const root = parseHL7v2('PID|1|', { delimiters: delims });
+    it("parses a segment ending with a field delimiter", () => {
+      const root = parseHL7v2("PID|1|", { delimiters: delims });
       expect(root.children).toHaveLength(1);
       const seg = root.children[0] as Segment;
       expect(seg.children).toHaveLength(2);
       expect(seg.children[0].children[0].children[0].children[0].value).toBe(
-        'PID'
+        "PID"
       );
       expect(seg.children[1].children[0].children[0].children[0].value).toBe(
-        '1'
+        "1"
       );
 
       expect(root).toMatchSnapshot();
     });
 
-    it('parses a segment ending with multiple field delimiters', () => {
-      const root = parseHL7v2('PID|1|||||', { delimiters: delims });
+    it("parses a segment ending with multiple field delimiters", () => {
+      const root = parseHL7v2("PID|1|||||", { delimiters: delims });
       expect(root.children).toHaveLength(1);
       const seg = root.children[0] as Segment;
       expect(seg.children).toHaveLength(6);
@@ -59,9 +59,9 @@ describe('HL7v2 parser', () => {
       expect(root).toMatchSnapshot();
     });
 
-    it('parses a segment ending with multiple field delimiters and segment carriage return', () => {
-      const root = parseHL7v2('PID|1|||||\r', { delimiters: delims });
-      const root2 = parseHL7v2('PID|1|||||', { delimiters: delims });
+    it("parses a segment ending with multiple field delimiters and segment carriage return", () => {
+      const root = parseHL7v2("PID|1|||||\r", { delimiters: delims });
+      const root2 = parseHL7v2("PID|1|||||", { delimiters: delims });
       expect(root.children).toHaveLength(1);
       const seg = root.children[0] as Segment;
       expect(seg.children).toHaveLength(6);
@@ -70,8 +70,8 @@ describe('HL7v2 parser', () => {
       expect(root).toMatchSnapshot();
     });
 
-    it('parses a segment ending with two field delimiters and preserves the last empty field', () => {
-      const root = parseHL7v2('PID|1||', { delimiters: delims });
+    it("parses a segment ending with two field delimiters and preserves the last empty field", () => {
+      const root = parseHL7v2("PID|1||", { delimiters: delims });
       const seg = root.children[0] as Segment;
 
       // Expect 1 segment at the root
@@ -84,10 +84,10 @@ describe('HL7v2 parser', () => {
       const lastField = seg.children[2] as Field;
       expect(lastField.children).toMatchObject([
         {
-          type: 'field-repetition',
+          type: "field-repetition",
           children: [
             {
-              type: 'component',
+              type: "component",
               children: [],
             },
           ],
@@ -98,24 +98,24 @@ describe('HL7v2 parser', () => {
       expect(root).toMatchSnapshot();
     });
 
-    it('equates with and without CR when ending with a single trailing field delimiter', () => {
-      const withCr = parseHL7v2('PID|1|\r', { delimiters: delims });
-      const withoutCr = parseHL7v2('PID|1|', { delimiters: delims });
+    it("equates with and without CR when ending with a single trailing field delimiter", () => {
+      const withCr = parseHL7v2("PID|1|\r", { delimiters: delims });
+      const withoutCr = parseHL7v2("PID|1|", { delimiters: delims });
       expect(withCr).toEqual(withoutCr);
       const seg = withCr.children[0] as Segment;
       expect(seg.children).toHaveLength(2);
     });
 
-    it('handles leading double field delimiters as two empty leading fields', () => {
-      const root = parseHL7v2('||A\r', { delimiters: delims });
+    it("handles leading double field delimiters as two empty leading fields", () => {
+      const root = parseHL7v2("||A\r", { delimiters: delims });
       const seg = root.children[0] as Segment;
       expect(seg.children).toHaveLength(3);
 
       expect(root).toMatchSnapshot();
     });
 
-    it('preserves trailing component delimiter by creating an empty component', () => {
-      const root = parseHL7v2('PID|A^\r', { delimiters: delims });
+    it("preserves trailing component delimiter by creating an empty component", () => {
+      const root = parseHL7v2("PID|A^\r", { delimiters: delims });
       const seg = root.children[0] as Segment;
       const field2 = seg.children[1] as Field;
       const rep = field2.children[0] as FieldRepetition;
@@ -126,17 +126,17 @@ describe('HL7v2 parser', () => {
       expect(root).toMatchSnapshot();
     });
 
-    it('preserves trailing subcomponent delimiter by creating an empty subcomponent', () => {
-      const root = parseHL7v2('PID|A&B&\r', { delimiters: delims });
+    it("preserves trailing subcomponent delimiter by creating an empty subcomponent", () => {
+      const root = parseHL7v2("PID|A&B&\r", { delimiters: delims });
       const seg = root.children[0] as Segment;
       const field2 = seg.children[1] as Field;
       const rep = field2.children[0] as FieldRepetition;
       const comp = rep.children[0] as Component;
-      expect(comp.children.map((s) => s.value)).toEqual(['A', 'B', '']);
+      expect(comp.children.map((s) => s.value)).toEqual(["A", "B", ""]);
     });
 
-    it('preserves trailing repetition delimiter by creating an empty repetition container', () => {
-      const root = parseHL7v2('OBX|1~2~\r', { delimiters: delims });
+    it("preserves trailing repetition delimiter by creating an empty repetition container", () => {
+      const root = parseHL7v2("OBX|1~2~\r", { delimiters: delims });
       const seg = root.children[0] as Segment;
       const field2 = seg.children[1];
       expect(field2.children.length).toBe(3);
@@ -146,68 +146,68 @@ describe('HL7v2 parser', () => {
     });
 
     it('parses MSH line with bootstrap: TEXT("MSH"), FIELD_DELIM, TEXT(MSH.2)', () => {
-      const root = parseHL7v2('MSH|^~\\&|SENDER\r', { delimiters: delims });
+      const root = parseHL7v2("MSH|^~\\&|SENDER\r", { delimiters: delims });
       const seg = root.children[0] as Segment;
       expect(seg.children).toHaveLength(4);
       // MSH Header
       expect(seg.children[0].children[0].children[0].children[0].value).toBe(
-        'MSH'
+        "MSH"
       );
       // MSH.1: field delimiter
       expect(seg.children[1].children[0].children[0].children[0].value).toBe(
-        '|'
+        "|"
       );
       // MSH.2: delimiters
       expect(seg.children[2].children[0].children[0].children[0].value).toBe(
-        '^~\\&'
+        "^~\\&"
       );
       // MSH.3: sender
       expect(seg.children[3].children[0].children[0].children[0].value).toBe(
-        'SENDER'
+        "SENDER"
       );
     });
 
-    it('handles components and subcomponents', () => {
-      const root = parseHL7v2('PID|1^A&B\r', { delimiters: delims });
+    it("handles components and subcomponents", () => {
+      const root = parseHL7v2("PID|1^A&B\r", { delimiters: delims });
       const seg = root.children[0] as Segment;
       const field2 = seg.children[1] as Field;
       const rep = field2.children[0] as FieldRepetition;
       expect(rep.children).toHaveLength(2);
-      expect(rep.children[0].children[0].value).toBe('1');
+      expect(rep.children[0].children[0].value).toBe("1");
       const comp2 = rep.children[1] as Component;
-      expect(comp2.children.map((s) => s.value)).toEqual(['A', 'B']);
+      expect(comp2.children.map((s) => s.value)).toEqual(["A", "B"]);
     });
 
-    it('handles repetitions', () => {
-      const root = parseHL7v2('OBX|1~2\r', { delimiters: delims });
+    it("handles repetitions", () => {
+      const root = parseHL7v2("OBX|1~2\r", { delimiters: delims });
       const seg = root.children[0] as Segment;
       const field2 = seg.children[1] as Field;
       expect(field2.children).toHaveLength(2);
-      expect(field2.children[0].children[0].children[0].value).toBe('1');
-      expect(field2.children[1].children[0].children[0].value).toBe('2');
+      expect(field2.children[0].children[0].children[0].value).toBe("1");
+      expect(field2.children[1].children[0].children[0].value).toBe("2");
     });
 
-    it('handles leading field delimiter as empty first field', () => {
-      const root = parseHL7v2('|A\r', { delimiters: delims });
+    it("handles leading field delimiter as empty first field", () => {
+      const root = parseHL7v2("|A\r", { delimiters: delims });
       const seg = root.children[0] as Segment;
       expect(seg.children).toHaveLength(2);
       expect(seg.children[0].children[0].children[0].children[0].value).toBe(
-        ''
+        ""
       );
       expect(seg.children[1].children[0].children[0].children[0].value).toBe(
-        'A'
+        "A"
       );
     });
 
-    it('finalizes last segment without trailing segment delimiter', () => {
-      const root = parseHL7v2('PID|1', { delimiters: delims });
+    it("finalizes last segment without trailing segment delimiter", () => {
+      const root = parseHL7v2("PID|1", { delimiters: delims });
       expect(root.children).toHaveLength(1);
       const seg = root.children[0] as Segment;
       expect(seg.children).toHaveLength(2);
     });
 
-    it('runs default preprocessors', () => {
-      const root = parseHL7v2('PID|1|ABC|\nNK1|2|ABC|\n', {
+    it("runs default preprocessors", () => {
+      const root = parseHL7v2("PID|1|ABC|\nNK1|2|ABC|\n", {
         delimiters: delims,
       });
 
@@ -216,13 +216,13 @@ describe('HL7v2 parser', () => {
       expect(root).toMatchSnapshot();
     });
 
-    it('runs custom preprocessors', () => {
+    it("runs custom preprocessors", () => {
       const customProcessor: PreprocessorStep = (context) => {
-        context.input = context.input.replace('ABC', 'DEF');
+        context.input = context.input.replace("ABC", "DEF");
         return context;
       };
 
-      const root = parseHL7v2('PID|1|ABC|', {
+      const root = parseHL7v2("PID|1|ABC|", {
         delimiters: delims,
         preprocess: [customProcessor],
       });
@@ -233,17 +233,17 @@ describe('HL7v2 parser', () => {
 
       // The field should be replaced with DEF
       expect(seg.children[2]).toMatchObject({
-        type: 'field',
+        type: "field",
         children: [
           {
-            type: 'field-repetition',
+            type: "field-repetition",
             children: [
               {
-                type: 'component',
+                type: "component",
                 children: [
                   {
-                    type: 'subcomponent',
-                    value: 'DEF',
+                    type: "subcomponent",
+                    value: "DEF",
                   },
                 ],
               },
@@ -255,9 +255,9 @@ describe('HL7v2 parser', () => {
       expect(root).toMatchSnapshot();
     });
 
-    it('does not run preprocessors when option is an empty array', () => {
+    it("does not run preprocessors when option is an empty array", () => {
       // LF should NOT be normalized to CR when preprocessors are disabled
-      const input = 'PID|1\nOBX|2';
+      const input = "PID|1\nOBX|2";
       const root = parseHL7v2(input, { delimiters: delims, preprocess: [] });
 
       // Without normalization, the tokenizer will not see a segment delimiter, so only one segment is produced
@@ -265,16 +265,16 @@ describe('HL7v2 parser', () => {
       expect(root).toMatchSnapshot();
     });
 
-    it('parses MSH with custom delimiters)', () => {
-      const randomMessage = 'MSH$%*\\#$SENDER$12%34%abc%abc\n';
+    it("parses MSH with custom delimiters)", () => {
+      const randomMessage = "MSH$%*\\#$SENDER$12%34%abc%abc\n";
       const root = parseHL7v2(randomMessage, {
         delimiters: {
-          segment: '\n',
-          component: '%',
-          escape: '\\',
-          field: '$',
-          repetition: '*',
-          subcomponent: '#',
+          segment: "\n",
+          component: "%",
+          escape: "\\",
+          field: "$",
+          repetition: "*",
+          subcomponent: "#",
         },
       });
       const seg = root.children[0] as Segment;
@@ -285,108 +285,108 @@ describe('HL7v2 parser', () => {
     });
   });
 
-  describe('multiple segments', () => {
-    it('parses multiple segments with MSH as the first segment', () => {
+  describe("multiple segments", () => {
+    it("parses multiple segments with MSH as the first segment", () => {
       const msg = [
         // MSH
-        'MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5',
+        "MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5",
         // PID
-        'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+        "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
         // OBX
-        'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-      ].join('\r');
+        "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+      ].join("\r");
 
       const root = parseHL7v2(msg, { delimiters: delims });
       expect(root.children).toHaveLength(3);
       expect(root).toMatchSnapshot();
     });
 
-    it('parses multiple segments without MSH as the first segment', () => {
+    it("parses multiple segments without MSH as the first segment", () => {
       const msg = [
         // PID
-        'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+        "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
         // OBX
-        'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-      ].join('\r');
+        "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+      ].join("\r");
 
       const root = parseHL7v2(msg, { delimiters: delims });
       expect(root.children).toHaveLength(2);
       expect(root).toMatchSnapshot();
     });
 
-    it('parses correctly similar messages with different carriage returns', () => {
-      const msg_with_cr = [
+    it("parses correctly similar messages with different carriage returns", () => {
+      const msgWithCr = [
         // PID
-        'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+        "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
         // OBX
-        'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-      ].join('\r');
+        "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+      ].join("\r");
 
-      const msg_with_lf = [
+      const msgWithLf = [
         // PID
-        'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+        "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
         // OBX
-        'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-      ].join('\n');
+        "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+      ].join("\n");
 
-      const output_cr = parseHL7v2(msg_with_cr, { delimiters: delims });
-      const output_lf = parseHL7v2(msg_with_lf, { delimiters: delims });
+      const outputCr = parseHL7v2(msgWithCr, { delimiters: delims });
+      const outputLf = parseHL7v2(msgWithLf, { delimiters: delims });
 
-      expect(output_cr).toEqual(output_lf);
+      expect(outputCr).toEqual(outputLf);
     });
 
     // biome-ignore lint/suspicious/noSkippedTests: must be fixed
-    it.skip('parses correctly similar messages with or without trailing field separators', () => {
-      const msg_with_trailing_field_separator = [
+    it.skip("parses correctly similar messages with or without trailing field separators", () => {
+      const msgWithTrailingFieldSeparator = [
         // PID
-        'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC|',
+        "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC|",
         // OBX
-        'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R|',
-      ].join('\r');
+        "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R|",
+      ].join("\r");
 
-      const msg_without_trailing_field_separator = [
+      const msgWithoutTrailingFieldSeparator = [
         // PID
-        'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+        "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
         // OBX
-        'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-      ].join('\r');
+        "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+      ].join("\r");
 
-      const file_cr = parseHL7v2(msg_with_trailing_field_separator, {
+      const fileCr = parseHL7v2(msgWithTrailingFieldSeparator, {
         delimiters: delims,
       });
 
-      const file_lf = parseHL7v2(msg_without_trailing_field_separator, {
+      const fileLf = parseHL7v2(msgWithoutTrailingFieldSeparator, {
         delimiters: delims,
       });
 
-      expect(file_cr).toEqual(file_lf);
+      expect(fileCr).toEqual(fileLf);
     });
 
     // biome-ignore lint/suspicious/noSkippedTests: must be fixed
-    it.skip('parses correctly similar messages with or without trailing field separators and empty last field', () => {
-      const msg_with_trailing_field_separator = [
+    it.skip("parses correctly similar messages with or without trailing field separators and empty last field", () => {
+      const msgWithTrailingFieldSeparator = [
         // PID
-        'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC|',
+        "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC|",
         // OBX
-        'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^|',
-      ].join('\r');
+        "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^|",
+      ].join("\r");
 
-      const msg_without_trailing_field_separator = [
+      const msgWithoutTrailingFieldSeparator = [
         // PID
-        'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+        "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
         // OBX
-        'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^',
-      ].join('\r');
+        "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^",
+      ].join("\r");
 
-      const file_cr = parseHL7v2(msg_with_trailing_field_separator, {
+      const fileCr = parseHL7v2(msgWithTrailingFieldSeparator, {
         delimiters: delims,
       });
 
-      const file_lf = parseHL7v2(msg_without_trailing_field_separator, {
+      const fileLf = parseHL7v2(msgWithoutTrailingFieldSeparator, {
         delimiters: delims,
       });
 
-      expect(file_cr).toEqual(file_lf);
+      expect(fileCr).toEqual(fileLf);
     });
   });
 });

--- a/packages/hl7v2-parser/test/preprocessor.test.ts
+++ b/packages/hl7v2-parser/test/preprocessor.test.ts
@@ -1,18 +1,18 @@
-import { DEFAULT_DELIMITERS } from '@rethinkhealth/hl7v2-utils';
-import { describe, expect, it } from 'vitest';
+import { DEFAULT_DELIMITERS } from "@rethinkhealth/hl7v2-utils";
+import { describe, expect, it } from "vitest";
 import {
   defaultPreprocessors,
   detectDelimiters,
   normalizeNewlines,
   runPreprocessors,
   stripBOM,
-} from '../src/preprocessor';
-import type { ParserContext, PreprocessorStep } from '../src/types';
+} from "../src/preprocessor";
+import type { ParserContext, PreprocessorStep } from "../src/types";
 
-describe('runPreprocessors', () => {
-  it('runs default preprocessors (stripBOM + normalizeNewlines + detectDelimiters)', () => {
-    const bomChar = '\uFEFF';
-    const msg = 'MSH|^~\\&\nPID|123';
+describe("runPreprocessors", () => {
+  it("runs default preprocessors (stripBOM + normalizeNewlines + detectDelimiters)", () => {
+    const bomChar = "\uFEFF";
+    const msg = "MSH|^~\\&\nPID|123";
     const raw = bomChar + msg;
 
     const ctx = runPreprocessors(
@@ -22,112 +22,112 @@ describe('runPreprocessors', () => {
       },
       defaultPreprocessors
     );
-    expect(ctx.input).toEqual('MSH|^~\\&\rPID|123');
+    expect(ctx.input).toEqual("MSH|^~\\&\rPID|123");
     expect(ctx.delimiters).toBeDefined();
   });
 
-  it('respects custom step arrays', () => {
+  it("respects custom step arrays", () => {
     const customProcessor: PreprocessorStep = (context) => {
-      context.input = context.input.replace('ABC', 'DEF');
+      context.input = context.input.replace("ABC", "DEF");
       return context;
     };
 
     const ctx = runPreprocessors(
       {
-        input: 'ABC\nXYZ',
+        input: "ABC\nXYZ",
         delimiters: DEFAULT_DELIMITERS,
       },
       [customProcessor]
     );
-    expect(ctx.input).toBe('DEF\nXYZ');
+    expect(ctx.input).toBe("DEF\nXYZ");
   });
 });
 
-describe('preprocessor steps', () => {
-  describe('stripBOM', () => {
-    it('removes UTF-8 BOM at start of input', () => {
-      const bomChar = '\uFEFF';
+describe("preprocessor steps", () => {
+  describe("stripBOM", () => {
+    it("removes UTF-8 BOM at start of input", () => {
+      const bomChar = "\uFEFF";
       const ctx: ParserContext = {
         input: `${bomChar}MSH|^~\\&`,
         delimiters: DEFAULT_DELIMITERS,
         metadata: {},
       };
       const result = stripBOM(ctx);
-      expect(result.input).toBe('MSH|^~\\&');
+      expect(result.input).toBe("MSH|^~\\&");
     });
 
-    it('leaves input unchanged if no BOM', () => {
+    it("leaves input unchanged if no BOM", () => {
       const ctx: ParserContext = {
-        input: 'MSH|^~\\&',
+        input: "MSH|^~\\&",
         delimiters: DEFAULT_DELIMITERS,
         metadata: {},
       };
       const result = stripBOM(ctx);
-      expect(result.input).toBe('MSH|^~\\&');
+      expect(result.input).toBe("MSH|^~\\&");
     });
 
-    it('leaves input unchanged if BOM is not at start', () => {
+    it("leaves input unchanged if BOM is not at start", () => {
       const ctx: ParserContext = {
-        input: 'ABC\uFEFFMSH|^~\\&',
+        input: "ABC\uFEFFMSH|^~\\&",
         delimiters: DEFAULT_DELIMITERS,
         metadata: {},
       };
       const result = stripBOM(ctx);
-      expect(result.input).toBe('ABC\uFEFFMSH|^~\\&');
+      expect(result.input).toBe("ABC\uFEFFMSH|^~\\&");
     });
   });
 
-  describe('normalizeNewlines', () => {
-    it('converts LF to CR', () => {
+  describe("normalizeNewlines", () => {
+    it("converts LF to CR", () => {
       const ctx: ParserContext = {
-        input: 'MSH|A\nPID|B',
+        input: "MSH|A\nPID|B",
         delimiters: DEFAULT_DELIMITERS,
         metadata: {},
       };
       const result = normalizeNewlines(ctx);
-      expect(result.input).toBe('MSH|A\rPID|B');
+      expect(result.input).toBe("MSH|A\rPID|B");
     });
 
-    it('converts CRLF to CR', () => {
+    it("converts CRLF to CR", () => {
       const ctx: ParserContext = {
-        input: 'MSH|A\r\nPID|B',
+        input: "MSH|A\r\nPID|B",
         delimiters: DEFAULT_DELIMITERS,
         metadata: {},
       };
       const result = normalizeNewlines(ctx);
-      expect(result.input).toBe('MSH|A\rPID|B');
+      expect(result.input).toBe("MSH|A\rPID|B");
     });
 
-    it('leaves CR untouched', () => {
+    it("leaves CR untouched", () => {
       const ctx: ParserContext = {
-        input: 'MSH|A\rPID|B',
+        input: "MSH|A\rPID|B",
         delimiters: DEFAULT_DELIMITERS,
         metadata: {},
       };
       const result = normalizeNewlines(ctx);
-      expect(result.input).toBe('MSH|A\rPID|B');
+      expect(result.input).toBe("MSH|A\rPID|B");
     });
   });
 
-  describe('detectDelimiters', () => {
-    it('detects delimiters from MSH-1 and MSH-2', () => {
+  describe("detectDelimiters", () => {
+    it("detects delimiters from MSH-1 and MSH-2", () => {
       // MSH-1: '*', MSH-2: %$#& etc.
       const ctx: ParserContext = {
-        input: 'MSH*%$#&',
+        input: "MSH*%$#&",
         delimiters: DEFAULT_DELIMITERS,
         metadata: {},
       };
       const result = detectDelimiters(ctx);
-      expect(result.delimiters?.field).toBe('*');
-      expect(result.delimiters?.component).toBe('%');
-      expect(result.delimiters?.repetition).toBe('$');
-      expect(result.delimiters?.escape).toBe('#');
-      expect(result.delimiters?.subcomponent).toBe('&');
+      expect(result.delimiters?.field).toBe("*");
+      expect(result.delimiters?.component).toBe("%");
+      expect(result.delimiters?.repetition).toBe("$");
+      expect(result.delimiters?.escape).toBe("#");
+      expect(result.delimiters?.subcomponent).toBe("&");
     });
 
-    it('does not change delimiters if input does not start with MSH', () => {
+    it("does not change delimiters if input does not start with MSH", () => {
       const ctx: ParserContext = {
-        input: 'PID|123',
+        input: "PID|123",
         delimiters: DEFAULT_DELIMITERS,
         metadata: {},
       };

--- a/packages/hl7v2-parser/test/processor.test.ts
+++ b/packages/hl7v2-parser/test/processor.test.ts
@@ -5,16 +5,16 @@ import type {
   Root,
   Segment,
   Subcomponent,
-} from '@rethinkhealth/hl7v2-ast';
-import { DEFAULT_DELIMITERS } from '@rethinkhealth/hl7v2-utils';
-import { describe, expect, it } from 'vitest';
-import type { ParserContext } from '../dist';
-import { parseHL7v2FromIterator } from '../src/processor';
-import type { Token } from '../src/types';
+} from "@rethinkhealth/hl7v2-ast";
+import { DEFAULT_DELIMITERS } from "@rethinkhealth/hl7v2-utils";
+import { describe, expect, it } from "vitest";
+import type { ParserContext } from "../dist";
+import { parseHL7v2FromIterator } from "../src/processor";
+import type { Token } from "../src/types";
 
 function segEnd(pos = 0): Token {
   return {
-    type: 'SEGMENT_END',
+    type: "SEGMENT_END",
     position: {
       start: { offset: pos, line: 1, column: 1 },
       end: { offset: pos, line: 1, column: 1 },
@@ -24,7 +24,7 @@ function segEnd(pos = 0): Token {
 
 function text(value: string, pos = 0): Token {
   return {
-    type: 'TEXT',
+    type: "TEXT",
     value,
     position: {
       start: { offset: pos, line: 1, column: 1 },
@@ -34,7 +34,7 @@ function text(value: string, pos = 0): Token {
 }
 
 function tok(
-  type: Exclude<Token['type'], 'TEXT' | 'SEGMENT_END'>,
+  type: Exclude<Token["type"], "TEXT" | "SEGMENT_END">,
   pos = 0
 ): Token {
   return {
@@ -46,49 +46,49 @@ function tok(
   } as Token;
 }
 
-const asSeg = (n: Root['children'][number]): Segment => n as Segment;
-const asField = (n: Segment['children'][number]): Field => n as Field;
-const asRep = (n: Field['children'][number]): FieldRepetition =>
+const asSeg = (n: Root["children"][number]): Segment => n as Segment;
+const asField = (n: Segment["children"][number]): Field => n as Field;
+const asRep = (n: Field["children"][number]): FieldRepetition =>
   n as FieldRepetition;
-const asComp = (n: FieldRepetition['children'][number]): Component =>
+const asComp = (n: FieldRepetition["children"][number]): Component =>
   n as Component;
-const asSub = (n: Component['children'][number]): Subcomponent =>
+const asSub = (n: Component["children"][number]): Subcomponent =>
   n as Subcomponent;
 
 const dummyCtx: ParserContext = {
   delimiters: DEFAULT_DELIMITERS,
-  input: 'any_input',
+  input: "any_input",
 };
 
-describe('processor (semantics-agnostic)', () => {
-  it('builds segment -> field -> repetition -> component -> subcomponents from tokens (sync iterator)', () => {
+describe("processor (semantics-agnostic)", () => {
+  it("builds segment -> field -> repetition -> component -> subcomponents from tokens (sync iterator)", () => {
     const tokens: Token[] = [
-      text('PID'),
-      tok('FIELD_DELIM'),
-      text('1'),
+      text("PID"),
+      tok("FIELD_DELIM"),
+      text("1"),
       segEnd(),
     ];
     const root = parseHL7v2FromIterator(tokens, dummyCtx);
     expect(root.children).toHaveLength(1);
     const seg = asSeg(root.children[0]);
-    expect(seg.type).toBe('segment');
+    expect(seg.type).toBe("segment");
     expect(seg.children).toHaveLength(2); // PID, then 1
     expect(
       asSub(
         asComp(asRep(asField(seg.children[0]).children[0]).children[0])
           .children[0]
       ).value
-    ).toBe('PID');
+    ).toBe("PID");
     expect(
       asSub(
         asComp(asRep(asField(seg.children[1]).children[0]).children[0])
           .children[0]
       ).value
-    ).toBe('1');
+    ).toBe("1");
   });
 
-  it('handles leading FIELD_DELIM by creating an empty first field', () => {
-    const tokens: Token[] = [tok('FIELD_DELIM'), text('A'), segEnd()];
+  it("handles leading FIELD_DELIM by creating an empty first field", () => {
+    const tokens: Token[] = [tok("FIELD_DELIM"), text("A"), segEnd()];
     const root = parseHL7v2FromIterator(tokens, dummyCtx);
     const seg = asSeg(root.children[0]);
     expect(seg.children).toHaveLength(2);
@@ -98,22 +98,22 @@ describe('processor (semantics-agnostic)', () => {
         asComp(asRep(asField(seg.children[0]).children[0]).children[0])
           .children[0]
       ).value
-    ).toBe('');
+    ).toBe("");
     expect(
       asSub(
         asComp(asRep(asField(seg.children[1]).children[0]).children[0])
           .children[0]
       ).value
-    ).toBe('A');
+    ).toBe("A");
   });
 
-  it('supports repetition and components', () => {
+  it("supports repetition and components", () => {
     const tokens: Token[] = [
-      text('X'),
-      tok('REPETITION_DELIM'),
-      text('Y'),
-      tok('COMPONENT_DELIM'),
-      text('Z'),
+      text("X"),
+      tok("REPETITION_DELIM"),
+      text("Y"),
+      tok("COMPONENT_DELIM"),
+      text("Z"),
       segEnd(),
     ];
     const root = parseHL7v2FromIterator(tokens, dummyCtx);
@@ -123,16 +123,16 @@ describe('processor (semantics-agnostic)', () => {
     expect(field.children).toHaveLength(2); // two repetitions
     const rep1 = asRep(field.children[0]);
     const rep2 = asRep(field.children[1]);
-    expect(asSub(asComp(rep1.children[0]).children[0]).value).toBe('X');
-    expect(asSub(asComp(rep2.children[0]).children[0]).value).toBe('Y');
-    expect(asSub(asComp(rep2.children[1]).children[0]).value).toBe('Z');
+    expect(asSub(asComp(rep1.children[0]).children[0]).value).toBe("X");
+    expect(asSub(asComp(rep2.children[0]).children[0]).value).toBe("Y");
+    expect(asSub(asComp(rep2.children[1]).children[0]).value).toBe("Z");
   });
 
-  it('SUBCOMP_DELIM starts a new empty subcomponent slot', () => {
+  it("SUBCOMP_DELIM starts a new empty subcomponent slot", () => {
     const tokens: Token[] = [
-      text('A'),
-      tok('SUBCOMP_DELIM'),
-      text('B'),
+      text("A"),
+      tok("SUBCOMP_DELIM"),
+      text("B"),
       segEnd(),
     ];
     const root = parseHL7v2FromIterator(tokens, dummyCtx);
@@ -142,30 +142,30 @@ describe('processor (semantics-agnostic)', () => {
     );
     const subs = comps.children;
     expect(subs).toHaveLength(2);
-    expect(subs[0].value).toBe('A');
-    expect(subs[1].value).toBe('B');
+    expect(subs[0].value).toBe("A");
+    expect(subs[1].value).toBe("B");
   });
 
-  it('finalizes last segment without trailing SEGMENT_END (sync tokens)', () => {
-    const tokens: Token[] = [text('PID'), tok('FIELD_DELIM'), text('1')];
+  it("finalizes last segment without trailing SEGMENT_END (sync tokens)", () => {
+    const tokens: Token[] = [text("PID"), tok("FIELD_DELIM"), text("1")];
     const root = parseHL7v2FromIterator(tokens, dummyCtx);
     expect(root.children).toHaveLength(1);
     const seg = asSeg(root.children[0]);
     expect(seg.children).toHaveLength(2);
   });
 
-  it('handles empty line (segment with no fields) by dropping the empty trailing segment', () => {
+  it("handles empty line (segment with no fields) by dropping the empty trailing segment", () => {
     const root = parseHL7v2FromIterator([segEnd()], dummyCtx);
     expect(root.children).toHaveLength(0);
   });
 
-  it('drops only the final trailing empty field but preserves preceding empty fields', () => {
+  it("drops only the final trailing empty field but preserves preceding empty fields", () => {
     const tokens: Token[] = [
-      text('PID'),
-      tok('FIELD_DELIM'),
-      text('1'),
-      tok('FIELD_DELIM'),
-      tok('FIELD_DELIM'),
+      text("PID"),
+      tok("FIELD_DELIM"),
+      text("1"),
+      tok("FIELD_DELIM"),
+      tok("FIELD_DELIM"),
       segEnd(),
     ];
     const root = parseHL7v2FromIterator(tokens, dummyCtx);
@@ -177,12 +177,12 @@ describe('processor (semantics-agnostic)', () => {
     expect(asComp(rep.children[0]).children.length).toBe(0);
   });
 
-  it('does not add a new field when segment ends with a single FIELD_DELIM', () => {
+  it("does not add a new field when segment ends with a single FIELD_DELIM", () => {
     const tokens: Token[] = [
-      text('PID'),
-      tok('FIELD_DELIM'),
-      text('1'),
-      tok('FIELD_DELIM'),
+      text("PID"),
+      tok("FIELD_DELIM"),
+      text("1"),
+      tok("FIELD_DELIM"),
       segEnd(),
     ];
     const root = parseHL7v2FromIterator(tokens, dummyCtx);
@@ -190,12 +190,12 @@ describe('processor (semantics-agnostic)', () => {
     expect(seg.children.length).toBe(2);
   });
 
-  it('keeps trailing empty component when COMPONENT_DELIM is last before SEGMENT_END', () => {
+  it("keeps trailing empty component when COMPONENT_DELIM is last before SEGMENT_END", () => {
     const tokens: Token[] = [
-      text('PID'),
-      tok('FIELD_DELIM'),
-      text('A'),
-      tok('COMPONENT_DELIM'),
+      text("PID"),
+      tok("FIELD_DELIM"),
+      text("A"),
+      tok("COMPONENT_DELIM"),
       segEnd(),
     ];
     const root = parseHL7v2FromIterator(tokens, dummyCtx);
@@ -204,12 +204,12 @@ describe('processor (semantics-agnostic)', () => {
     expect(lastComp.children.length).toBe(0);
   });
 
-  it('keeps trailing empty subcomponent when SUBCOMP_DELIM is last before SEGMENT_END', () => {
+  it("keeps trailing empty subcomponent when SUBCOMP_DELIM is last before SEGMENT_END", () => {
     const tokens: Token[] = [
-      text('PID'),
-      tok('FIELD_DELIM'),
-      text('A'),
-      tok('SUBCOMP_DELIM'),
+      text("PID"),
+      tok("FIELD_DELIM"),
+      text("A"),
+      tok("SUBCOMP_DELIM"),
       segEnd(),
     ];
     const root = parseHL7v2FromIterator(tokens, dummyCtx);
@@ -219,16 +219,16 @@ describe('processor (semantics-agnostic)', () => {
     );
     const subs = comp.children;
     expect(subs.length).toBe(2);
-    expect(subs[0].value).toBe('A');
-    expect(subs[1].value).toBe('');
+    expect(subs[0].value).toBe("A");
+    expect(subs[1].value).toBe("");
   });
 
-  it('keeps trailing empty repetition when REPETITION_DELIM is last before SEGMENT_END', () => {
+  it("keeps trailing empty repetition when REPETITION_DELIM is last before SEGMENT_END", () => {
     const tokens: Token[] = [
-      text('OBX'),
-      tok('FIELD_DELIM'),
-      text('1'),
-      tok('REPETITION_DELIM'),
+      text("OBX"),
+      tok("FIELD_DELIM"),
+      text("1"),
+      tok("REPETITION_DELIM"),
       segEnd(),
     ];
     const root = parseHL7v2FromIterator(tokens, dummyCtx);

--- a/packages/hl7v2-parser/test/tokenizer.test.ts
+++ b/packages/hl7v2-parser/test/tokenizer.test.ts
@@ -1,7 +1,7 @@
-import { DEFAULT_DELIMITERS } from '@rethinkhealth/hl7v2-utils';
-import { describe, expect, it } from 'vitest';
-import { HL7v2Tokenizer } from '../src/tokenizer';
-import type { Token } from '../src/types';
+import { DEFAULT_DELIMITERS } from "@rethinkhealth/hl7v2-utils";
+import { describe, expect, it } from "vitest";
+import { HL7v2Tokenizer } from "../src/tokenizer";
+import type { Token } from "../src/types";
 
 function toks(input: string): Token[] {
   const t = new HL7v2Tokenizer();
@@ -13,27 +13,27 @@ function toks(input: string): Token[] {
   return out;
 }
 
-describe('MSH bootstrap only at file start', () => {
-  it('emits MSH as TEXT, then a synthetic FIELD_DELIM, then MSH.2 as TEXT for first segment only', () => {
-    const out = toks('MSH|^~\\&|SENDER\rPID|1\rMSH|^~\\&|AGAIN'); // later MSH should NOT be bootstrapped
+describe("MSH bootstrap only at file start", () => {
+  it("emits MSH as TEXT, then a synthetic FIELD_DELIM, then MSH.2 as TEXT for first segment only", () => {
+    const out = toks("MSH|^~\\&|SENDER\rPID|1\rMSH|^~\\&|AGAIN"); // later MSH should NOT be bootstrapped
 
-    expect(out[0]).toMatchObject({ type: 'TEXT', value: 'MSH' });
-    expect(out[1]).toMatchObject({ type: 'FIELD_DELIM' });
-    expect(out[2]).toMatchObject({ type: 'TEXT', value: '|' });
-    expect(out[3]).toMatchObject({ type: 'FIELD_DELIM' });
-    expect(out[4]).toMatchObject({ type: 'TEXT', value: '^~\\&' });
+    expect(out[0]).toMatchObject({ type: "TEXT", value: "MSH" });
+    expect(out[1]).toMatchObject({ type: "FIELD_DELIM" });
+    expect(out[2]).toMatchObject({ type: "TEXT", value: "|" });
+    expect(out[3]).toMatchObject({ type: "FIELD_DELIM" });
+    expect(out[4]).toMatchObject({ type: "TEXT", value: "^~\\&" });
     // ensure later MSH is not bootstrapped (the '|' appears as a delimiter, not bootstrap emission)
     const later = out.findIndex(
-      (t) => t.type === 'TEXT' && t.value === 'AGAIN'
+      (t) => t.type === "TEXT" && t.value === "AGAIN"
     );
     expect(later).toBeGreaterThan(0);
 
     expect(out).toMatchSnapshot();
   });
 
-  it('does not bootstrap when file does not start with MSH', () => {
-    const out = toks('PID|1\rMSH|^~\\&|SENDER');
+  it("does not bootstrap when file does not start with MSH", () => {
+    const out = toks("PID|1\rMSH|^~\\&|SENDER");
     // No special tokens up front—just TEXT('PID') then delimiters
-    expect(out[0]).toMatchObject({ type: 'TEXT', value: 'PID' });
+    expect(out[0]).toMatchObject({ type: "TEXT", value: "PID" });
   });
 });

--- a/packages/hl7v2-parser/tsup.config.ts
+++ b/packages/hl7v2-parser/tsup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
@@ -6,10 +6,10 @@ export default defineConfig({
      * Directories and files should be bundled so that the resulting files line
      * up with the TSC generated type definitions.
      */
-    index: 'src/index.ts',
+    index: "src/index.ts",
   },
-  format: ['esm'],
-  target: 'es2022',
+  format: ["esm"],
+  target: "es2022",
   sourcemap: true,
   // treeshake: true,
 

--- a/packages/hl7v2-parser/vitest.config.ts
+++ b/packages/hl7v2-parser/vitest.config.ts
@@ -1,11 +1,11 @@
-import { baseConfig } from '@rethinkhealth/testing';
-import { defineConfig, mergeConfig } from 'vitest/config';
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
 
 export default mergeConfig(
   baseConfig,
   defineConfig({
     test: {
-      name: 'hl7-parser',
+      name: "hl7-parser",
     },
   })
 );

--- a/packages/hl7v2-preset-lint-recommended/package.json
+++ b/packages/hl7v2-preset-lint-recommended/package.json
@@ -37,7 +37,6 @@
     "@rethinkhealth/tsconfig": "workspace:*",
     "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "tsup": "8.5.0",
     "typescript": "^5.8.3",

--- a/packages/hl7v2-preset-lint-recommended/package.json
+++ b/packages/hl7v2-preset-lint-recommended/package.json
@@ -35,7 +35,7 @@
     "@rethinkhealth/hl7v2-parser": "workspace:*",
     "@rethinkhealth/testing": "workspace:*",
     "@rethinkhealth/tsconfig": "workspace:*",
-    "@types/node": "24.3.0",
+    "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
     "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",

--- a/packages/hl7v2-preset-lint-recommended/src/index.ts
+++ b/packages/hl7v2-preset-lint-recommended/src/index.ts
@@ -1,7 +1,7 @@
-import hl7v2LintNoTrailingEmptyField from '@rethinkhealth/hl7v2-lint-no-trailing-empty-field';
-import hl7v2LintRequiredMessageHeader from '@rethinkhealth/hl7v2-lint-required-message-header';
-import hl7v2LintSegmentHeaderLength from '@rethinkhealth/hl7v2-lint-segment-header-length';
-import type { Preset } from 'unified';
+import hl7v2LintNoTrailingEmptyField from "@rethinkhealth/hl7v2-lint-no-trailing-empty-field";
+import hl7v2LintRequiredMessageHeader from "@rethinkhealth/hl7v2-lint-required-message-header";
+import hl7v2LintSegmentHeaderLength from "@rethinkhealth/hl7v2-lint-segment-header-length";
+import type { Preset } from "unified";
 
 /**
  * Preset of hl7v2-lint rules to warn for likely problems.
@@ -28,8 +28,8 @@ import type { Preset } from 'unified';
 const hl7v2PresetLintRecommended: Preset = {
   plugins: [
     // segment linting rules
-    [hl7v2LintSegmentHeaderLength, ['error']],
-    [hl7v2LintRequiredMessageHeader, ['error']],
+    [hl7v2LintSegmentHeaderLength, ["error"]],
+    [hl7v2LintRequiredMessageHeader, ["error"]],
     hl7v2LintNoTrailingEmptyField,
   ],
 };

--- a/packages/hl7v2-preset-lint-recommended/tests/index.test.ts
+++ b/packages/hl7v2-preset-lint-recommended/tests/index.test.ts
@@ -1,57 +1,57 @@
-import { hl7v2Jsonify } from '@rethinkhealth/hl7v2-jsonify';
-import { hl7v2Parser } from '@rethinkhealth/hl7v2-parser';
-import { unified } from 'unified';
-import { describe, expect, it } from 'vitest';
-import hl7v2PresetLintRecommended from '../src/index';
+import { hl7v2Jsonify } from "@rethinkhealth/hl7v2-jsonify";
+import { hl7v2Parser } from "@rethinkhealth/hl7v2-parser";
+import { unified } from "unified";
+import { describe, expect, it } from "vitest";
+import hl7v2PresetLintRecommended from "../src/index";
 
-const parseHL7v2 = unified().use(hl7v2Parser).use(hl7v2Jsonify);
+const parseHl7v2 = unified().use(hl7v2Parser).use(hl7v2Jsonify);
 
-describe('HL7v2 lint preset', () => {
-  it('errors when segment header length is invalid', async () => {
+describe("HL7v2 lint preset", () => {
+  it("errors when segment header length is invalid", async () => {
     // GIVEN
     const msg = [
       // MSH
-      'MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5',
+      "MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5",
       // PID with invalid header length
-      'PIDTOOLONG|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      "PIDTOOLONG|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
       // OBX
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-    ].join('\r');
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+    ].join("\r");
 
     // WHEN
-    const file = await parseHL7v2()
+    const file = await parseHl7v2()
       .use(hl7v2PresetLintRecommended)
       .process(msg);
 
     // THEN
     expect(file.messages).toHaveLength(1);
     expect(file.messages[0].message).toBe(
-      'Unexpected 10 header length, expected 3 characters, remove 7 characters'
+      "Unexpected 10 header length, expected 3 characters, remove 7 characters"
     );
 
     expect(file.messages[0].fatal).toBe(true);
   });
 
-  it('errors when segment header is missing', async () => {
+  it("errors when segment header is missing", async () => {
     // GIVEN
     const msg = [
       // MSH
       // 'MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5',
       // PID with invalid header length
-      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
       // OBX
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-    ].join('\r');
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+    ].join("\r");
 
     // WHEN
-    const file = await parseHL7v2()
+    const file = await parseHl7v2()
       .use(hl7v2PresetLintRecommended)
       .process(msg);
 
     // THEN
     expect(file.messages).toHaveLength(1);
     expect(file.messages[0].message).toBe(
-      'Message header (MSH) segment is required. Received PID instead.'
+      "Message header (MSH) segment is required. Received PID instead."
     );
 
     expect(file.messages[0].fatal).toBe(true);

--- a/packages/hl7v2-preset-lint-recommended/tsup.config.ts
+++ b/packages/hl7v2-preset-lint-recommended/tsup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
@@ -6,11 +6,11 @@ export default defineConfig({
      * Directories and files should be bundled so that the resulting files line
      * up with the TSC generated type definitions.
      */
-    index: 'src/index.ts',
+    index: "src/index.ts",
     // "utils/index": "src/utils/index.ts",
   },
-  format: ['esm'],
-  target: 'es2022',
+  format: ["esm"],
+  target: "es2022",
   sourcemap: true,
   // treeshake: true,
 

--- a/packages/hl7v2-to-hl7v2/package.json
+++ b/packages/hl7v2-to-hl7v2/package.json
@@ -34,7 +34,6 @@
     "@rethinkhealth/tsconfig": "workspace:*",
     "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "tsup": "8.5.0",
     "typescript": "^5.8.3",

--- a/packages/hl7v2-to-hl7v2/package.json
+++ b/packages/hl7v2-to-hl7v2/package.json
@@ -32,7 +32,7 @@
     "@rethinkhealth/hl7v2-ast": "workspace:*",
     "@rethinkhealth/testing": "workspace:*",
     "@rethinkhealth/tsconfig": "workspace:*",
-    "@types/node": "24.3.0",
+    "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
     "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",

--- a/packages/hl7v2-to-hl7v2/src/index.ts
+++ b/packages/hl7v2-to-hl7v2/src/index.ts
@@ -7,10 +7,10 @@ import type {
   Root,
   Segment,
   Subcomponent,
-} from '@rethinkhealth/hl7v2-ast';
-import { DEFAULT_DELIMITERS } from '@rethinkhealth/hl7v2-utils';
-import type { Plugin } from 'unified';
-import type { Node } from 'unist';
+} from "@rethinkhealth/hl7v2-ast";
+import { DEFAULT_DELIMITERS } from "@rethinkhealth/hl7v2-utils";
+import type { Plugin } from "unified";
+import type { Node } from "unist";
 
 /**
  * Unified compiler plugin: HL7v2 AST -> HL7v2 string
@@ -32,18 +32,18 @@ export function toHl7v2(node: Nodes, delimiters?: Partial<Delimiters>): string {
   };
 
   switch (node.type) {
-    case 'root':
+    case "root":
       return serializeRoot(node, d);
-    case 'segment':
+    case "segment":
       return serializeSegment(node, d); // generic path
-    case 'field':
+    case "field":
       return serializeField(node, d);
-    case 'field-repetition':
+    case "field-repetition":
       return serializeFieldRep(node, d);
-    case 'component':
+    case "component":
       return serializeComponent(node, d);
-    case 'subcomponent':
-      return node.value ?? '';
+    case "subcomponent":
+      return node.value ?? "";
     default:
       // @ts-expect-error – ensure exhaustiveness
       (() => node satisfies never)();
@@ -62,8 +62,8 @@ function serializeRoot(root: Root, d: Delimiters): string {
   const out: string[] = [];
   for (const seg of segments) {
     const name = getSegmentName(seg);
-    if (name === 'MSH') {
-      out.push(serializeMSH(seg, d));
+    if (name === "MSH") {
+      out.push(serializeMsh(seg, d));
     } else {
       out.push(serializeSegment(seg, d));
     }
@@ -79,7 +79,7 @@ function serializeRoot(root: Root, d: Delimiters): string {
  * HL7 requires: "MSH" + <field-sep char> + MSH-2..N
  * MSH-1 (the field separator itself) is not emitted as a field value.
  */
-function serializeMSH(segment: Segment, d: Delimiters): string {
+function serializeMsh(segment: Segment, d: Delimiters): string {
   const fields = segment.children as Field[];
   // fields[0] holds the “MSH” token in this AST model.
   // Start from index 2 to skip MSH-1 (field separator).
@@ -125,7 +125,7 @@ function serializeFieldRep(rep: FieldRepetition, d: Delimiters): string {
 }
 
 function serializeComponent(component: Component, d: Delimiters): string {
-  const subs = (component.children as Subcomponent[]).map((s) => s.value ?? '');
+  const subs = (component.children as Subcomponent[]).map((s) => s.value ?? "");
   return subs.join(d.subcomponent);
 }
 
@@ -138,9 +138,9 @@ function getSegmentName(segment: Segment): string {
   const r0 = f0?.children?.[0] as FieldRepetition | undefined;
   const c0 = r0?.children?.[0] as Component | undefined;
   const s0 = c0?.children?.[0] as Subcomponent | undefined;
-  return s0?.value ?? '';
+  return s0?.value ?? "";
 }
 
 function isRoot(n: Nodes): n is Root {
-  return (n as Node).type === 'root';
+  return (n as Node).type === "root";
 }

--- a/packages/hl7v2-to-hl7v2/tests/index.test.ts
+++ b/packages/hl7v2-to-hl7v2/tests/index.test.ts
@@ -1,87 +1,87 @@
-import type { Nodes } from '@rethinkhealth/hl7v2-ast';
-import { unified } from 'unified';
-import type { Node } from 'unist';
-import { u } from 'unist-builder';
-import { describe, expect, it } from 'vitest';
-import { hl7v2ToHl7v2, toHl7v2 } from '../src';
+import type { Nodes } from "@rethinkhealth/hl7v2-ast";
+import { unified } from "unified";
+import type { Node } from "unist";
+import { u } from "unist-builder";
+import { describe, expect, it } from "vitest";
+import { hl7v2ToHl7v2, toHl7v2 } from "../src";
 
-describe('toHl7v2', () => {
-  it('converts a simple MSH segment back to HL7v2 format', () => {
-    const tree = u('root', [
-      u('segment', [
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'MSH')])]),
+describe("toHl7v2", () => {
+  it("converts a simple MSH segment back to HL7v2 format", () => {
+    const tree = u("root", [
+      u("segment", [
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "MSH")])]),
         ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', '|')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "|")])]),
         ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', '^~\\&')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "^~\\&")])]),
         ]),
-        u('field', [
-          u('field-repetition', [
-            u('component', [u('subcomponent', 'SENDER')]),
+        u("field", [
+          u("field-repetition", [
+            u("component", [u("subcomponent", "SENDER")]),
           ]),
         ]),
       ]),
     ]);
 
     const result = toHl7v2(tree);
-    expect(result).toBe('MSH|^~\\&|SENDER');
+    expect(result).toBe("MSH|^~\\&|SENDER");
   });
 
-  it('handles multiple segments with segment delimiter', () => {
-    const tree = u('root', [
-      u('segment', [
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'MSH')])]),
+  it("handles multiple segments with segment delimiter", () => {
+    const tree = u("root", [
+      u("segment", [
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "MSH")])]),
         ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', '|')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "|")])]),
         ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', '^~\\&')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "^~\\&")])]),
         ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', '')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "")])]),
         ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', '2.5')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "2.5")])]),
         ]),
       ]),
-      u('segment', [
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'PID')])]),
+      u("segment", [
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "PID")])]),
         ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', '12345')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "12345")])]),
         ]),
       ]),
     ]);
 
     const result = toHl7v2(tree);
-    expect(result).toBe('MSH|^~\\&||2.5\rPID|12345');
+    expect(result).toBe("MSH|^~\\&||2.5\rPID|12345");
   });
 
-  it('handles complex field structures with components and subcomponents', () => {
-    const tree = u('root', [
-      u('segment', [
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'PID')])]),
+  it("handles complex field structures with components and subcomponents", () => {
+    const tree = u("root", [
+      u("segment", [
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "PID")])]),
         ]),
         // PID.1: component1^component2
-        u('field', [
-          u('field-repetition', [
-            u('component', [u('subcomponent', 'component1')]),
-            u('component', [u('subcomponent', 'component2')]),
+        u("field", [
+          u("field-repetition", [
+            u("component", [u("subcomponent", "component1")]),
+            u("component", [u("subcomponent", "component2")]),
           ]),
         ]),
         // PID.2: subcomp1&subcomp2
-        u('field', [
-          u('field-repetition', [
-            u('component', [
-              u('subcomponent', 'subcomp1'),
-              u('subcomponent', 'subcomp2'),
+        u("field", [
+          u("field-repetition", [
+            u("component", [
+              u("subcomponent", "subcomp1"),
+              u("subcomponent", "subcomp2"),
             ]),
           ]),
         ]),
@@ -89,94 +89,94 @@ describe('toHl7v2', () => {
     ]);
 
     const result = toHl7v2(tree);
-    expect(result).toBe('PID|component1^component2|subcomp1&subcomp2');
+    expect(result).toBe("PID|component1^component2|subcomp1&subcomp2");
   });
 
-  it('handles field repetitions', () => {
-    const tree = u('root', [
-      u('segment', [
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'PID')])]),
+  it("handles field repetitions", () => {
+    const tree = u("root", [
+      u("segment", [
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "PID")])]),
         ]),
         // PID.1: rep1~rep2
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'rep1')])]),
-          u('field-repetition', [u('component', [u('subcomponent', 'rep2')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "rep1")])]),
+          u("field-repetition", [u("component", [u("subcomponent", "rep2")])]),
         ]),
       ]),
     ]);
 
     const result = toHl7v2(tree);
-    expect(result).toBe('PID|rep1~rep2');
+    expect(result).toBe("PID|rep1~rep2");
   });
 
-  it('handles complex nested structures with all delimiter types', () => {
-    const tree = u('root', [
-      u('segment', [
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'PID')])]),
+  it("handles complex nested structures with all delimiter types", () => {
+    const tree = u("root", [
+      u("segment", [
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "PID")])]),
         ]),
         // PID.1: A^B&C~D^E
-        u('field', [
-          u('field-repetition', [
-            u('component', [u('subcomponent', 'A')]),
-            u('component', [u('subcomponent', 'B'), u('subcomponent', 'C')]),
+        u("field", [
+          u("field-repetition", [
+            u("component", [u("subcomponent", "A")]),
+            u("component", [u("subcomponent", "B"), u("subcomponent", "C")]),
           ]),
-          u('field-repetition', [
-            u('component', [u('subcomponent', 'D')]),
-            u('component', [u('subcomponent', 'E')]),
+          u("field-repetition", [
+            u("component", [u("subcomponent", "D")]),
+            u("component", [u("subcomponent", "E")]),
           ]),
         ]),
       ]),
     ]);
 
     const result = toHl7v2(tree);
-    expect(result).toBe('PID|A^B&C~D^E');
+    expect(result).toBe("PID|A^B&C~D^E");
   });
 
-  it('handles empty values correctly', () => {
-    const tree = u('root', [
-      u('segment', [
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'PID')])]),
+  it("handles empty values correctly", () => {
+    const tree = u("root", [
+      u("segment", [
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "PID")])]),
         ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'TEST')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "TEST")])]),
         ]),
         // MSH.2 - empty field
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', '')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "")])]),
         ]),
         // MSH.3
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'VALUE')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "VALUE")])]),
         ]),
         // MSH.4 - another empty field
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', '')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "")])]),
         ]),
       ]),
     ]);
 
     const result = toHl7v2(tree);
-    expect(result).toBe('PID|TEST||VALUE|');
+    expect(result).toBe("PID|TEST||VALUE|");
   });
 
-  it('handles empty components and subcomponents', () => {
-    const tree = u('root', [
-      u('segment', [
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'PID')])]),
+  it("handles empty components and subcomponents", () => {
+    const tree = u("root", [
+      u("segment", [
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "PID")])]),
         ]),
         // Empty component
-        u('field', [u('field-repetition', [u('component', [])])]),
+        u("field", [u("field-repetition", [u("component", [])])]),
         // Component with empty subcomponents
-        u('field', [
-          u('field-repetition', [
-            u('component', [
-              u('subcomponent', ''),
-              u('subcomponent', 'value'),
-              u('subcomponent', ''),
+        u("field", [
+          u("field-repetition", [
+            u("component", [
+              u("subcomponent", ""),
+              u("subcomponent", "value"),
+              u("subcomponent", ""),
             ]),
           ]),
         ]),
@@ -184,24 +184,24 @@ describe('toHl7v2', () => {
     ]);
 
     const result = toHl7v2(tree);
-    expect(result).toBe('PID||&value&');
+    expect(result).toBe("PID||&value&");
   });
 
-  it('handles empty subcomponents', () => {
-    const tree = u('root', [
-      u('segment', [
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'PID')])]),
+  it("handles empty subcomponents", () => {
+    const tree = u("root", [
+      u("segment", [
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "PID")])]),
         ]),
         // Empty component
-        u('field', [u('field-repetition', [u('component', [])])]),
+        u("field", [u("field-repetition", [u("component", [])])]),
         // Component with empty subcomponents
-        u('field', [
-          u('field-repetition', [
-            u('component', [
-              u('subcomponent', ''),
-              u('subcomponent', ''),
-              u('subcomponent', ''),
+        u("field", [
+          u("field-repetition", [
+            u("component", [
+              u("subcomponent", ""),
+              u("subcomponent", ""),
+              u("subcomponent", ""),
             ]),
           ]),
         ]),
@@ -209,68 +209,68 @@ describe('toHl7v2', () => {
     ]);
 
     const result = toHl7v2(tree);
-    expect(result).toBe('PID||&&');
+    expect(result).toBe("PID||&&");
   });
 
-  it('handles empty components', () => {
-    const tree = u('root', [
-      u('segment', [
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'PID')])]),
+  it("handles empty components", () => {
+    const tree = u("root", [
+      u("segment", [
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "PID")])]),
         ]),
         // Empty component
-        u('field', [u('field-repetition', [u('component', [])])]),
+        u("field", [u("field-repetition", [u("component", [])])]),
         // Component with empty subcomponents
-        u('field', [
-          u('field-repetition', [
-            u('component', []),
-            u('component', []),
-            u('component', []),
+        u("field", [
+          u("field-repetition", [
+            u("component", []),
+            u("component", []),
+            u("component", []),
           ]),
         ]),
       ]),
     ]);
 
     const result = toHl7v2(tree);
-    expect(result).toBe('PID||^^');
+    expect(result).toBe("PID||^^");
   });
 
-  it('uses custom delimiters when provided in root data', () => {
+  it("uses custom delimiters when provided in root data", () => {
     const tree = u(
-      'root',
+      "root",
       {
         data: {
           delimiters: {
-            field: '*',
-            component: '#',
-            subcomponent: '@',
-            repetition: '$',
-            escape: '!',
-            segment: '\n',
+            field: "*",
+            component: "#",
+            subcomponent: "@",
+            repetition: "$",
+            escape: "!",
+            segment: "\n",
           },
         },
       },
       [
-        u('segment', [
-          u('field', [
-            u('field-repetition', [u('component', [u('subcomponent', 'MSH')])]),
+        u("segment", [
+          u("field", [
+            u("field-repetition", [u("component", [u("subcomponent", "MSH")])]),
           ]),
-          u('field', [
-            u('field-repetition', [u('component', [u('subcomponent', '*')])]),
+          u("field", [
+            u("field-repetition", [u("component", [u("subcomponent", "*")])]),
           ]),
-          u('field', [
-            u('field-repetition', [
-              u('component', [u('subcomponent', 'test')]),
+          u("field", [
+            u("field-repetition", [
+              u("component", [u("subcomponent", "test")]),
             ]),
           ]),
         ]),
-        u('segment', [
-          u('field', [
-            u('field-repetition', [u('component', [u('subcomponent', 'PID')])]),
+        u("segment", [
+          u("field", [
+            u("field-repetition", [u("component", [u("subcomponent", "PID")])]),
           ]),
-          u('field', [
-            u('field-repetition', [
-              u('component', [u('subcomponent', 'A'), u('subcomponent', 'B')]),
+          u("field", [
+            u("field-repetition", [
+              u("component", [u("subcomponent", "A"), u("subcomponent", "B")]),
             ]),
           ]),
         ]),
@@ -278,245 +278,206 @@ describe('toHl7v2', () => {
     );
 
     const result = toHl7v2(tree);
-    expect(result).toBe('MSH*test\nPID*A@B');
+    expect(result).toBe("MSH*test\nPID*A@B");
   });
 
-  it('uses default delimiters when none provided in root data', () => {
-    const tree = u('root', [
-      u('segment', [
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'MSH')])]),
+  it("uses default delimiters when none provided in root data", () => {
+    const tree = u("root", [
+      u("segment", [
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "MSH")])]),
         ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', '|')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "|")])]),
         ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'test')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "test")])]),
         ]),
       ]),
     ]);
 
     const result = toHl7v2(tree);
-    expect(result).toBe('MSH|test');
+    expect(result).toBe("MSH|test");
   });
 
-  it('handles real-world MSH segment structure', () => {
-    const tree = u('root', [
-      u('segment', [
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'MSH')])]),
+  it("handles real-world MSH segment structure", () => {
+    const tree = u("root", [
+      u("segment", [
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "MSH")])]),
         ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', '|')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "|")])]),
         ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', '^~\\&')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "^~\\&")])]),
         ]),
-        u('field', [
-          u('field-repetition', [
-            u('component', [u('subcomponent', 'SendingApp')]),
+        u("field", [
+          u("field-repetition", [
+            u("component", [u("subcomponent", "SendingApp")]),
           ]),
         ]),
-        u('field', [
-          u('field-repetition', [
-            u('component', [u('subcomponent', 'SendingFacility')]),
+        u("field", [
+          u("field-repetition", [
+            u("component", [u("subcomponent", "SendingFacility")]),
           ]),
         ]),
-        u('field', [
-          u('field-repetition', [
-            u('component', [u('subcomponent', 'ReceivingApp')]),
+        u("field", [
+          u("field-repetition", [
+            u("component", [u("subcomponent", "ReceivingApp")]),
           ]),
         ]),
-        u('field', [
-          u('field-repetition', [
-            u('component', [u('subcomponent', 'ReceivingFacility')]),
+        u("field", [
+          u("field-repetition", [
+            u("component", [u("subcomponent", "ReceivingFacility")]),
           ]),
         ]),
-        u('field', [
-          u('field-repetition', [
-            u('component', [u('subcomponent', '20241201120000')]),
+        u("field", [
+          u("field-repetition", [
+            u("component", [u("subcomponent", "20241201120000")]),
           ]),
         ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', '')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "")])]),
         ]),
-        u('field', [
-          u('field-repetition', [
-            u('component', [u('subcomponent', 'ADT')]),
-            u('component', [u('subcomponent', 'A01')]),
+        u("field", [
+          u("field-repetition", [
+            u("component", [u("subcomponent", "ADT")]),
+            u("component", [u("subcomponent", "A01")]),
           ]),
         ]),
-        u('field', [
-          u('field-repetition', [
-            u('component', [u('subcomponent', 'MSG00001')]),
+        u("field", [
+          u("field-repetition", [
+            u("component", [u("subcomponent", "MSG00001")]),
           ]),
         ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'P')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "P")])]),
         ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', '2.5')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "2.5")])]),
         ]),
       ]),
     ]);
 
     const result = toHl7v2(tree);
     expect(result).toBe(
-      'MSH|^~\\&|SendingApp|SendingFacility|ReceivingApp|ReceivingFacility|20241201120000||ADT^A01|MSG00001|P|2.5'
+      "MSH|^~\\&|SendingApp|SendingFacility|ReceivingApp|ReceivingFacility|20241201120000||ADT^A01|MSG00001|P|2.5"
     );
   });
 });
 
-describe('toHl7v2 with individual node types', () => {
-  it('converts individual segments', () => {
-    const segmentNode = u('segment', [
-      u('field', [
-        u('field-repetition', [u('component', [u('subcomponent', 'PID')])]),
+describe("toHl7v2 with individual node types", () => {
+  it("converts individual segments", () => {
+    const segmentNode = u("segment", [
+      u("field", [
+        u("field-repetition", [u("component", [u("subcomponent", "PID")])]),
       ]),
-      u('field', [
-        u('field-repetition', [u('component', [u('subcomponent', '12345')])]),
+      u("field", [
+        u("field-repetition", [u("component", [u("subcomponent", "12345")])]),
       ]),
-      u('field', [
-        u('field-repetition', [
-          u('component', [u('subcomponent', 'DOE')]),
-          u('component', [u('subcomponent', 'JOHN')]),
+      u("field", [
+        u("field-repetition", [
+          u("component", [u("subcomponent", "DOE")]),
+          u("component", [u("subcomponent", "JOHN")]),
         ]),
       ]),
     ]) as Nodes;
 
     const result = toHl7v2(segmentNode);
-    expect(result).toBe('PID|12345|DOE^JOHN');
+    expect(result).toBe("PID|12345|DOE^JOHN");
   });
 
-  it('converts individual fields', () => {
-    const fieldNode = u('field', [
-      u('field-repetition', [
-        u('component', [u('subcomponent', 'DOE')]),
-        u('component', [u('subcomponent', 'JOHN')]),
+  it("converts individual fields", () => {
+    const fieldNode = u("field", [
+      u("field-repetition", [
+        u("component", [u("subcomponent", "DOE")]),
+        u("component", [u("subcomponent", "JOHN")]),
       ]),
     ]) as Nodes;
 
     const result = toHl7v2(fieldNode);
-    expect(result).toBe('DOE^JOHN');
+    expect(result).toBe("DOE^JOHN");
   });
 
-  it('converts field repetitions', () => {
-    const repNode = u('field-repetition', [
-      u('component', [u('subcomponent', 'A')]),
-      u('component', [u('subcomponent', 'B'), u('subcomponent', 'C')]),
+  it("converts field repetitions", () => {
+    const repNode = u("field-repetition", [
+      u("component", [u("subcomponent", "A")]),
+      u("component", [u("subcomponent", "B"), u("subcomponent", "C")]),
     ]) as Nodes;
 
     const result = toHl7v2(repNode);
-    expect(result).toBe('A^B&C');
+    expect(result).toBe("A^B&C");
   });
 
-  it('converts components', () => {
-    const compNode = u('component', [
-      u('subcomponent', 'SUB1'),
-      u('subcomponent', 'SUB2'),
+  it("converts components", () => {
+    const compNode = u("component", [
+      u("subcomponent", "SUB1"),
+      u("subcomponent", "SUB2"),
     ]) as Nodes;
 
     const result = toHl7v2(compNode);
-    expect(result).toBe('SUB1&SUB2');
+    expect(result).toBe("SUB1&SUB2");
   });
 
-  it('converts subcomponents', () => {
-    const subNode = u('subcomponent', 'VALUE') as Nodes;
+  it("converts subcomponents", () => {
+    const subNode = u("subcomponent", "VALUE") as Nodes;
 
     const result = toHl7v2(subNode);
-    expect(result).toBe('VALUE');
+    expect(result).toBe("VALUE");
   });
 
-  it('handles field with repetitions', () => {
-    const fieldNode = u('field', [
-      u('field-repetition', [u('component', [u('subcomponent', 'rep1')])]),
-      u('field-repetition', [u('component', [u('subcomponent', 'rep2')])]),
+  it("handles field with repetitions", () => {
+    const fieldNode = u("field", [
+      u("field-repetition", [u("component", [u("subcomponent", "rep1")])]),
+      u("field-repetition", [u("component", [u("subcomponent", "rep2")])]),
     ]) as Nodes;
 
     const result = toHl7v2(fieldNode);
-    expect(result).toBe('rep1~rep2');
+    expect(result).toBe("rep1~rep2");
   });
 
-  it('uses provided delimiters for non-root nodes', () => {
+  it("uses provided delimiters for non-root nodes", () => {
     const customDelimiters = {
-      field: '*',
-      component: '#',
-      subcomponent: '@',
-      repetition: '$',
-      escape: '!',
-      segment: '\n',
+      field: "*",
+      component: "#",
+      subcomponent: "@",
+      repetition: "$",
+      escape: "!",
+      segment: "\n",
     };
 
-    const fieldNode = u('field', [
-      u('field-repetition', [
-        u('component', [u('subcomponent', 'A'), u('subcomponent', 'B')]),
+    const fieldNode = u("field", [
+      u("field-repetition", [
+        u("component", [u("subcomponent", "A"), u("subcomponent", "B")]),
       ]),
     ]) as Nodes;
 
     const result = toHl7v2(fieldNode, customDelimiters);
-    expect(result).toBe('A@B');
+    expect(result).toBe("A@B");
   });
 
-  it('throws error for unsupported node types', () => {
-    const invalidNode = { type: 'unknown' } as any;
+  it("throws error for unsupported node types", () => {
+    const invalidNode = { type: "unknown" } as any;
 
     expect(() => toHl7v2(invalidNode)).toThrow(
-      'Unsupported node type: unknown'
+      "Unsupported node type: unknown"
     );
   });
 });
 
-describe('hl7v2ToHl7v2 plugin', () => {
-  it('compiles tree to HL7v2 string using unified', () => {
-    const tree = u('root', [
-      u('segment', [
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'MSH')])]),
+describe("hl7v2ToHl7v2 plugin", () => {
+  it("compiles tree to HL7v2 string using unified", () => {
+    const tree = u("root", [
+      u("segment", [
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "MSH")])]),
         ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', '|')])]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "|")])]),
         ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'test')])]),
-        ]),
-      ]),
-    ]);
-
-    const processor = unified().use(hl7v2ToHl7v2) as unknown as {
-      stringify: (tree: Node) => string;
-    };
-
-    const result = processor.stringify(tree as unknown as Node);
-    expect(result).toBe('MSH|test');
-  });
-
-  it('works with complex message through unified', () => {
-    const tree = u('root', [
-      u('segment', [
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'MSH')])]),
-        ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', '|')])]),
-        ]),
-        u('field', [
-          u('field-repetition', [
-            u('component', [u('subcomponent', 'SendingApp')]),
-          ]),
-        ]),
-      ]),
-      u('segment', [
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', 'PID')])]),
-        ]),
-        u('field', [
-          u('field-repetition', [u('component', [u('subcomponent', '12345')])]),
-        ]),
-        u('field', [
-          u('field-repetition', [
-            u('component', [u('subcomponent', 'DOE')]),
-            u('component', [u('subcomponent', 'JOHN')]),
-          ]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "test")])]),
         ]),
       ]),
     ]);
@@ -526,45 +487,84 @@ describe('hl7v2ToHl7v2 plugin', () => {
     };
 
     const result = processor.stringify(tree as unknown as Node);
-    expect(result).toBe('MSH|SendingApp\rPID|12345|DOE^JOHN');
+    expect(result).toBe("MSH|test");
   });
 
-  it('preserves custom delimiters from root data in unified processing', () => {
+  it("works with complex message through unified", () => {
+    const tree = u("root", [
+      u("segment", [
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "MSH")])]),
+        ]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "|")])]),
+        ]),
+        u("field", [
+          u("field-repetition", [
+            u("component", [u("subcomponent", "SendingApp")]),
+          ]),
+        ]),
+      ]),
+      u("segment", [
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "PID")])]),
+        ]),
+        u("field", [
+          u("field-repetition", [u("component", [u("subcomponent", "12345")])]),
+        ]),
+        u("field", [
+          u("field-repetition", [
+            u("component", [u("subcomponent", "DOE")]),
+            u("component", [u("subcomponent", "JOHN")]),
+          ]),
+        ]),
+      ]),
+    ]);
+
+    const processor = unified().use(hl7v2ToHl7v2) as unknown as {
+      stringify: (tree: Node) => string;
+    };
+
+    const result = processor.stringify(tree as unknown as Node);
+    expect(result).toBe("MSH|SendingApp\rPID|12345|DOE^JOHN");
+  });
+
+  it("preserves custom delimiters from root data in unified processing", () => {
     const tree = u(
-      'root',
+      "root",
       {
         data: {
           delimiters: {
-            field: '*',
-            component: '#',
-            subcomponent: '@',
-            repetition: '$',
-            escape: '!',
-            segment: '\n',
+            field: "*",
+            component: "#",
+            subcomponent: "@",
+            repetition: "$",
+            escape: "!",
+            segment: "\n",
           },
         },
       },
       [
-        u('segment', [
-          u('field', [
-            u('field-repetition', [u('component', [u('subcomponent', 'MSH')])]),
+        u("segment", [
+          u("field", [
+            u("field-repetition", [u("component", [u("subcomponent", "MSH")])]),
           ]),
-          u('field', [
-            u('field-repetition', [u('component', [u('subcomponent', '*')])]),
+          u("field", [
+            u("field-repetition", [u("component", [u("subcomponent", "*")])]),
           ]),
-          u('field', [
-            u('field-repetition', [
-              u('component', [u('subcomponent', 'custom')]),
+          u("field", [
+            u("field-repetition", [
+              u("component", [u("subcomponent", "custom")]),
             ]),
           ]),
         ]),
-        u('segment', [
-          u('field', [
-            u('field-repetition', [u('component', [u('subcomponent', 'PID')])]),
+        u("segment", [
+          u("field", [
+            u("field-repetition", [u("component", [u("subcomponent", "PID")])]),
           ]),
-          u('field', [
-            u('field-repetition', [
-              u('component', [u('subcomponent', 'A'), u('subcomponent', 'B')]),
+          u("field", [
+            u("field-repetition", [
+              u("component", [u("subcomponent", "A"), u("subcomponent", "B")]),
             ]),
           ]),
         ]),
@@ -576,66 +576,66 @@ describe('hl7v2ToHl7v2 plugin', () => {
     };
 
     const result = processor.stringify(tree as unknown as Node);
-    expect(result).toBe('MSH*custom\nPID*A@B');
+    expect(result).toBe("MSH*custom\nPID*A@B");
   });
 });
 
-describe('getSegmentName graceful degradation', () => {
-  it('handles segment with no fields by returning empty segment name', () => {
+describe("getSegmentName graceful degradation", () => {
+  it("handles segment with no fields by returning empty segment name", () => {
     // Simulate a malformed segment with no children (fields)
-    const malformedSegment = u('segment', []) as Nodes;
+    const malformedSegment = u("segment", []) as Nodes;
 
     const result = toHl7v2(malformedSegment);
     // Should produce empty string as segment name (no segment identifier)
-    expect(result).toBe('');
+    expect(result).toBe("");
   });
 
-  it('handles first field with no field repetitions by returning empty segment name', () => {
+  it("handles first field with no field repetitions by returning empty segment name", () => {
     // Simulate a field without field repetitions
-    const malformedSegment = u('segment', [
-      u('field', []), // Empty field - no field repetitions
+    const malformedSegment = u("segment", [
+      u("field", []), // Empty field - no field repetitions
     ]) as Nodes;
 
     const result = toHl7v2(malformedSegment);
     // Should produce empty string as segment name
-    expect(result).toBe('');
+    expect(result).toBe("");
   });
 
-  it('handles first field repetition with no components by returning empty segment name', () => {
+  it("handles first field repetition with no components by returning empty segment name", () => {
     // Simulate a field repetition without components
-    const malformedSegment = u('segment', [
-      u('field', [
-        u('field-repetition', []), // Empty field repetition - no components
+    const malformedSegment = u("segment", [
+      u("field", [
+        u("field-repetition", []), // Empty field repetition - no components
       ]),
     ]) as Nodes;
 
     const result = toHl7v2(malformedSegment);
     // Should produce empty string as segment name
-    expect(result).toBe('');
+    expect(result).toBe("");
   });
 
-  it('handles first component with no subcomponents by returning empty segment name', () => {
+  it("handles first component with no subcomponents by returning empty segment name", () => {
     // Simulate a component without subcomponents
-    const malformedSegment = u('segment', [
-      u('field', [
-        u('field-repetition', [
-          u('component', []), // Empty component - no subcomponents
+    const malformedSegment = u("segment", [
+      u("field", [
+        u("field-repetition", [
+          u("component", []), // Empty component - no subcomponents
         ]),
       ]),
     ]) as Nodes;
 
     const result = toHl7v2(malformedSegment);
     // Should produce empty string as segment name
-    expect(result).toBe('');
+    expect(result).toBe("");
   });
 
-  it('handles empty segment name by returning empty string', () => {
+  it("handles empty segment name by returning empty string", () => {
     // Simulate a segment where the first subcomponent has no value
-    const malformedSegment = u('segment', [
-      u('field', [
-        u('field-repetition', [
-          u('component', [
-            u('subcomponent', ''), // Empty segment name
+    const malformedSegment = u("segment", [
+      u("field", [
+        u("field-repetition", [
+          u("component", [
+            u("subcomponent", ""), // Empty segment name
           ]),
         ]),
       ]),
@@ -643,101 +643,101 @@ describe('getSegmentName graceful degradation', () => {
 
     const result = toHl7v2(malformedSegment);
     // Should produce empty string as segment name
-    expect(result).toBe('');
+    expect(result).toBe("");
   });
 
-  describe('real-world malformed HL7v2 scenarios', () => {
-    it('handles corrupted message starting with field delimiter gracefully', () => {
+  describe("real-world malformed HL7v2 scenarios", () => {
+    it("handles corrupted message starting with field delimiter gracefully", () => {
       // This would result from parsing "|SOME_APP|FACILITY|"
       // where the segment name is missing
-      const corruptedSegment = u('segment', [
-        u('field', [
-          u('field-repetition', [
-            u('component', [
-              u('subcomponent', ''), // No segment name before first |
+      const corruptedSegment = u("segment", [
+        u("field", [
+          u("field-repetition", [
+            u("component", [
+              u("subcomponent", ""), // No segment name before first |
             ]),
           ]),
         ]),
-        u('field', [
-          u('field-repetition', [
-            u('component', [u('subcomponent', 'SOME_APP')]),
+        u("field", [
+          u("field-repetition", [
+            u("component", [u("subcomponent", "SOME_APP")]),
           ]),
         ]),
       ]) as Nodes;
 
       const result = toHl7v2(corruptedSegment);
       // Should produce "|SOME_APP" - empty segment name but rest of data preserved
-      expect(result).toBe('|SOME_APP');
+      expect(result).toBe("|SOME_APP");
     });
 
-    it('handles truncated segment parsing gracefully', () => {
+    it("handles truncated segment parsing gracefully", () => {
       // This could result from parsing a truncated message like "MSH"
       // where the parser stopped before creating the full hierarchy
-      const truncatedSegment = u('segment', [
-        u('field', []), // Parser stopped before creating field repetition
+      const truncatedSegment = u("segment", [
+        u("field", []), // Parser stopped before creating field repetition
       ]) as Nodes;
 
       const result = toHl7v2(truncatedSegment);
       // Should produce empty string - no segment name, no additional fields
-      expect(result).toBe('');
+      expect(result).toBe("");
     });
 
-    it('handles empty message parsing gracefully', () => {
+    it("handles empty message parsing gracefully", () => {
       // This could result from parsing an empty line or just delimiters
-      const emptySegment = u('root', [
-        u('segment', []),
-        u('segment', []),
+      const emptySegment = u("root", [
+        u("segment", []),
+        u("segment", []),
       ]) as Nodes;
 
       const result = toHl7v2(emptySegment);
       // Should produce empty string - no content at all
-      expect(result).toBe('\r');
+      expect(result).toBe("\r");
     });
   });
 
-  describe('manual AST construction issues', () => {
-    it('handles missing field-repetition layer gracefully', () => {
+  describe("manual AST construction issues", () => {
+    it("handles missing field-repetition layer gracefully", () => {
       // Developer error: trying to put components directly in fields
       // This violates the AST hierarchy: field -> field-repetition -> component -> subcomponent
-      const badManualSegment = u('segment', [
-        u('field', [
+      const badManualSegment = u("segment", [
+        u("field", [
           // Missing field-repetition layer - this is invalid AST structure
-          u('component', [u('subcomponent', 'MSH')]),
+          u("component", [u("subcomponent", "MSH")]),
         ]),
       ]) as unknown as Nodes;
 
       const result = toHl7v2(badManualSegment);
       // Should gracefully handle the malformed structure and return empty string
-      expect(result).toBe('');
+      expect(result).toBe("");
     });
 
-    it('handles missing component layer gracefully', () => {
+    it("handles missing component layer gracefully", () => {
       // Developer error: trying to put subcomponents directly in field-repetitions
-      const badManualSegment = u('segment', [
-        u('field', [
-          u('field-repetition', [
+      const badManualSegment = u("segment", [
+        u("field", [
+          u("field-repetition", [
             // Missing component layer - this is invalid AST structure
-            u('subcomponent', 'MSH'),
+            u("subcomponent", "MSH"),
           ]),
         ]),
       ]) as unknown as Nodes;
 
       const result = toHl7v2(badManualSegment);
       // Should gracefully handle the malformed structure and return empty string
-      expect(result).toBe('');
+      expect(result).toBe("");
     });
   });
 
-  describe('AST transformation scenarios', () => {
-    it('documents what happens when transformations accidentally remove required nodes', () => {
+  describe("AST transformation scenarios", () => {
+    it("documents what happens when transformations accidentally remove required nodes", () => {
       // This simulates what might happen if a transformation accidentally
       // removes the first field containing the segment identifier
-      const transformedSegment = u('segment', [
+      const transformedSegment = u("segment", [
         // First field (segment name) was accidentally removed by transformation
-        u('field', [
-          u('field-repetition', [
-            u('component', [
-              u('subcomponent', 'SOME_DATA'), // This is field 2, not the segment name
+        u("field", [
+          u("field-repetition", [
+            u("component", [
+              u("subcomponent", "SOME_DATA"), // This is field 2, not the segment name
             ]),
           ]),
         ]),
@@ -746,30 +746,30 @@ describe('getSegmentName graceful degradation', () => {
       // While this has a valid structure, the segment name is wrong
       const result = toHl7v2(transformedSegment);
       // This would produce "SOME_DATA" instead of a proper segment name like "PID"
-      expect(result).toBe('SOME_DATA');
+      expect(result).toBe("SOME_DATA");
     });
 
-    it('shows the importance of preserving the first field', () => {
+    it("shows the importance of preserving the first field", () => {
       // Correct structure - first field contains segment name
-      const correctSegment = u('segment', [
-        u('field', [
-          u('field-repetition', [
-            u('component', [
-              u('subcomponent', 'PID'), // Proper segment name
+      const correctSegment = u("segment", [
+        u("field", [
+          u("field-repetition", [
+            u("component", [
+              u("subcomponent", "PID"), // Proper segment name
             ]),
           ]),
         ]),
-        u('field', [
-          u('field-repetition', [
-            u('component', [
-              u('subcomponent', 'SOME_DATA'), // This is field 2
+        u("field", [
+          u("field-repetition", [
+            u("component", [
+              u("subcomponent", "SOME_DATA"), // This is field 2
             ]),
           ]),
         ]),
       ]) as Nodes;
 
       const result = toHl7v2(correctSegment);
-      expect(result).toBe('PID|SOME_DATA');
+      expect(result).toBe("PID|SOME_DATA");
     });
   });
 });

--- a/packages/hl7v2-to-hl7v2/tsup.config.ts
+++ b/packages/hl7v2-to-hl7v2/tsup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
@@ -6,11 +6,11 @@ export default defineConfig({
      * Directories and files should be bundled so that the resulting files line
      * up with the TSC generated type definitions.
      */
-    index: 'src/index.ts',
+    index: "src/index.ts",
     // "utils/index": "src/utils/index.ts",
   },
-  format: ['esm'],
-  target: 'es2022',
+  format: ["esm"],
+  target: "es2022",
   sourcemap: true,
   // treeshake: true,
 

--- a/packages/hl7v2-to-hl7v2/vitest.config.ts
+++ b/packages/hl7v2-to-hl7v2/vitest.config.ts
@@ -1,11 +1,11 @@
-import { baseConfig } from '@rethinkhealth/testing';
-import { defineConfig, mergeConfig } from 'vitest/config';
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
 
 export default mergeConfig(
   baseConfig,
   defineConfig({
     test: {
-      name: 'hl7-parser',
+      name: "hl7-parser",
     },
   })
 );

--- a/packages/hl7v2-util-query/package.json
+++ b/packages/hl7v2-util-query/package.json
@@ -32,7 +32,6 @@
     "@rethinkhealth/tsconfig": "workspace:*",
     "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "tsup": "8.5.0",
     "typescript": "^5.8.3",

--- a/packages/hl7v2-util-query/package.json
+++ b/packages/hl7v2-util-query/package.json
@@ -27,16 +27,16 @@
     "@rethinkhealth/hl7v2-utils": "workspace:*"
   },
   "devDependencies": {
+    "@rethinkhealth/hl7v2-parser": "workspace:*",
     "@rethinkhealth/testing": "workspace:*",
     "@rethinkhealth/tsconfig": "workspace:*",
-    "@types/node": "24.3.0",
+    "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
     "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "tsup": "8.5.0",
     "typescript": "^5.8.3",
-    "vitest": "^3.2.4",
-    "@rethinkhealth/hl7v2-parser": "workspace:*"
+    "vitest": "^3.2.4"
   },
   "repository": "rethinkhealth/hl7v2.git",
   "homepage": "https://www.rethinkhealth.io/hl7v2/docs",

--- a/packages/hl7v2-util-query/src/index.ts
+++ b/packages/hl7v2-util-query/src/index.ts
@@ -4,8 +4,8 @@ import type {
   Nodes,
   Root,
   Segment,
-} from '@rethinkhealth/hl7v2-ast';
-import { getSegmentId, type PathParts } from '@rethinkhealth/hl7v2-utils';
+} from "@rethinkhealth/hl7v2-ast";
+import { getSegmentId, type PathParts } from "@rethinkhealth/hl7v2-utils";
 
 // -------------
 // Types
@@ -71,7 +71,7 @@ const PATH_REGEX =
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: fine
 export function parsePath(path: string): Partial<PathParts> {
-  if (!path || typeof path !== 'string') {
+  if (!path || typeof path !== "string") {
     throw new Error(`Path must be a non-empty string, got: ${path}`);
   }
 
@@ -99,7 +99,7 @@ export function parsePath(path: string): Partial<PathParts> {
     );
   }
 
-  const result: Partial<PathParts> = { segmentId: segmentId ?? '' };
+  const result: Partial<PathParts> = { segmentId: segmentId ?? "" };
 
   if (fieldStr) {
     const field = Number.parseInt(fieldStr, 10);
@@ -325,16 +325,16 @@ function queryComponent<T extends Nodes>(
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: fine
 function findSegment(root: Root, segmentId: string): Segment | null {
   for (const child of root.children) {
-    if (child.type === 'segment') {
+    if (child.type === "segment") {
       const id = getSegmentId(child);
       if (id === segmentId) {
         return child;
       }
     }
     // Handle groups recursively
-    if (child.type === 'group') {
+    if (child.type === "group") {
       for (const groupChild of child.children) {
-        if (groupChild.type === 'segment') {
+        if (groupChild.type === "segment") {
           const id = getSegmentId(groupChild);
           if (id === segmentId) {
             return groupChild;
@@ -369,7 +369,7 @@ export function getValue(result: QueryResult): string | null {
   if (!(result.found && result.node)) {
     return null;
   }
-  if (result.node.type === 'subcomponent') {
+  if (result.node.type === "subcomponent") {
     return result.node.value ?? null;
   }
   return null;

--- a/packages/hl7v2-util-query/tests/index.test.ts
+++ b/packages/hl7v2-util-query/tests/index.test.ts
@@ -1,27 +1,27 @@
-import type { Root } from '@rethinkhealth/hl7v2-ast';
-import { describe, expect, it } from 'vitest';
-import { exists, getValue, parsePath, query, queryValue } from '../src/index';
+import type { Root } from "@rethinkhealth/hl7v2-ast";
+import { describe, expect, it } from "vitest";
+import { exists, getValue, parsePath, query, queryValue } from "../src/index";
 
 // Test data: Simple HL7v2 AST structure
-const createTestAST = (): Root => ({
-  type: 'root',
+const createTestAst = (): Root => ({
+  type: "root",
   children: [
     {
-      type: 'segment',
+      type: "segment",
       children: [
         // MSH-1: Field separator
         {
-          type: 'field',
+          type: "field",
           children: [
             {
-              type: 'field-repetition',
+              type: "field-repetition",
               children: [
                 {
-                  type: 'component',
+                  type: "component",
                   children: [
                     {
-                      type: 'subcomponent',
-                      value: 'MSH',
+                      type: "subcomponent",
+                      value: "MSH",
                     },
                   ],
                 },
@@ -31,17 +31,17 @@ const createTestAST = (): Root => ({
         },
         // MSH-2: Encoding characters
         {
-          type: 'field',
+          type: "field",
           children: [
             {
-              type: 'field-repetition',
+              type: "field-repetition",
               children: [
                 {
-                  type: 'component',
+                  type: "component",
                   children: [
                     {
-                      type: 'subcomponent',
-                      value: '|',
+                      type: "subcomponent",
+                      value: "|",
                     },
                   ],
                 },
@@ -51,17 +51,17 @@ const createTestAST = (): Root => ({
         },
         // MSH-3: Sending application
         {
-          type: 'field',
+          type: "field",
           children: [
             {
-              type: 'field-repetition',
+              type: "field-repetition",
               children: [
                 {
-                  type: 'component',
+                  type: "component",
                   children: [
                     {
-                      type: 'subcomponent',
-                      value: 'MyApp',
+                      type: "subcomponent",
+                      value: "MyApp",
                     },
                   ],
                 },
@@ -72,21 +72,21 @@ const createTestAST = (): Root => ({
       ],
     },
     {
-      type: 'segment',
+      type: "segment",
       children: [
         // PID-1: Set ID
         {
-          type: 'field',
+          type: "field",
           children: [
             {
-              type: 'field-repetition',
+              type: "field-repetition",
               children: [
                 {
-                  type: 'component',
+                  type: "component",
                   children: [
                     {
-                      type: 'subcomponent',
-                      value: 'PID',
+                      type: "subcomponent",
+                      value: "PID",
                     },
                   ],
                 },
@@ -96,17 +96,17 @@ const createTestAST = (): Root => ({
         },
         // PID-2: Patient ID (empty)
         {
-          type: 'field',
+          type: "field",
           children: [
             {
-              type: 'field-repetition',
+              type: "field-repetition",
               children: [
                 {
-                  type: 'component',
+                  type: "component",
                   children: [
                     {
-                      type: 'subcomponent',
-                      value: '1',
+                      type: "subcomponent",
+                      value: "1",
                     },
                   ],
                 },
@@ -116,17 +116,17 @@ const createTestAST = (): Root => ({
         },
         // PID-3: Patient identifier list (empty)
         {
-          type: 'field',
+          type: "field",
           children: [
             {
-              type: 'field-repetition',
+              type: "field-repetition",
               children: [
                 {
-                  type: 'component',
+                  type: "component",
                   children: [
                     {
-                      type: 'subcomponent',
-                      value: '',
+                      type: "subcomponent",
+                      value: "",
                     },
                   ],
                 },
@@ -136,17 +136,17 @@ const createTestAST = (): Root => ({
         },
         // PID-4: Alternate patient ID (empty)
         {
-          type: 'field',
+          type: "field",
           children: [
             {
-              type: 'field-repetition',
+              type: "field-repetition",
               children: [
                 {
-                  type: 'component',
+                  type: "component",
                   children: [
                     {
-                      type: 'subcomponent',
-                      value: '',
+                      type: "subcomponent",
+                      value: "",
                     },
                   ],
                 },
@@ -156,38 +156,38 @@ const createTestAST = (): Root => ({
         },
         // PID-5: Patient name with multiple components
         {
-          type: 'field',
+          type: "field",
           children: [
             {
-              type: 'field-repetition',
+              type: "field-repetition",
               children: [
                 // Component 1: Last name
                 {
-                  type: 'component',
+                  type: "component",
                   children: [
                     {
-                      type: 'subcomponent',
-                      value: 'Smith',
+                      type: "subcomponent",
+                      value: "Smith",
                     },
                   ],
                 },
                 // Component 2: First name
                 {
-                  type: 'component',
+                  type: "component",
                   children: [
                     {
-                      type: 'subcomponent',
-                      value: 'John',
+                      type: "subcomponent",
+                      value: "John",
                     },
                   ],
                 },
                 // Component 3: Middle name
                 {
-                  type: 'component',
+                  type: "component",
                   children: [
                     {
-                      type: 'subcomponent',
-                      value: 'Michael',
+                      type: "subcomponent",
+                      value: "Michael",
                     },
                   ],
                 },
@@ -200,59 +200,59 @@ const createTestAST = (): Root => ({
   ],
 });
 
-describe('parsePath', () => {
-  describe('valid paths', () => {
-    it('parses segment-only paths', () => {
-      expect(parsePath('PID')).toEqual({ segmentId: 'PID' });
-      expect(parsePath('MSH')).toEqual({ segmentId: 'MSH' });
-      expect(parsePath('OBX')).toEqual({ segmentId: 'OBX' });
-      expect(parsePath('Z123')).toEqual({ segmentId: 'Z123' });
+describe("parsePath", () => {
+  describe("valid paths", () => {
+    it("parses segment-only paths", () => {
+      expect(parsePath("PID")).toEqual({ segmentId: "PID" });
+      expect(parsePath("MSH")).toEqual({ segmentId: "MSH" });
+      expect(parsePath("OBX")).toEqual({ segmentId: "OBX" });
+      expect(parsePath("Z123")).toEqual({ segmentId: "Z123" });
     });
 
-    it('parses field paths', () => {
-      expect(parsePath('PID-5')).toEqual({ segmentId: 'PID', field: 5 });
-      expect(parsePath('MSH-1')).toEqual({ segmentId: 'MSH', field: 1 });
-      expect(parsePath('OBX-99')).toEqual({ segmentId: 'OBX', field: 99 });
+    it("parses field paths", () => {
+      expect(parsePath("PID-5")).toEqual({ segmentId: "PID", field: 5 });
+      expect(parsePath("MSH-1")).toEqual({ segmentId: "MSH", field: 1 });
+      expect(parsePath("OBX-99")).toEqual({ segmentId: "OBX", field: 99 });
     });
 
-    it('parses repetition paths', () => {
-      expect(parsePath('PID-5[1]')).toEqual({
-        segmentId: 'PID',
+    it("parses repetition paths", () => {
+      expect(parsePath("PID-5[1]")).toEqual({
+        segmentId: "PID",
         field: 5,
         repetition: 1,
       });
-      expect(parsePath('OBX-5[2]')).toEqual({
-        segmentId: 'OBX',
+      expect(parsePath("OBX-5[2]")).toEqual({
+        segmentId: "OBX",
         field: 5,
         repetition: 2,
       });
     });
 
-    it('parses component paths', () => {
-      expect(parsePath('PID-5[1].2')).toEqual({
-        segmentId: 'PID',
+    it("parses component paths", () => {
+      expect(parsePath("PID-5[1].2")).toEqual({
+        segmentId: "PID",
         field: 5,
         repetition: 1,
         component: 2,
       });
-      expect(parsePath('MSH-9[1].3')).toEqual({
-        segmentId: 'MSH',
+      expect(parsePath("MSH-9[1].3")).toEqual({
+        segmentId: "MSH",
         field: 9,
         repetition: 1,
         component: 3,
       });
     });
 
-    it('parses full subcomponent paths', () => {
-      expect(parsePath('PID-5[1].2.1')).toEqual({
-        segmentId: 'PID',
+    it("parses full subcomponent paths", () => {
+      expect(parsePath("PID-5[1].2.1")).toEqual({
+        segmentId: "PID",
         field: 5,
         repetition: 1,
         component: 2,
         subcomponent: 1,
       });
-      expect(parsePath('MSH-9[1].3.2')).toEqual({
-        segmentId: 'MSH',
+      expect(parsePath("MSH-9[1].3.2")).toEqual({
+        segmentId: "MSH",
         field: 9,
         repetition: 1,
         component: 3,
@@ -261,316 +261,316 @@ describe('parsePath', () => {
     });
   });
 
-  describe('input validation', () => {
-    it('rejects empty or invalid inputs', () => {
-      expect(() => parsePath('')).toThrow('Path must be a non-empty string');
+  describe("input validation", () => {
+    it("rejects empty or invalid inputs", () => {
+      expect(() => parsePath("")).toThrow("Path must be a non-empty string");
       expect(() => parsePath(null as any)).toThrow(
-        'Path must be a non-empty string'
+        "Path must be a non-empty string"
       );
       expect(() => parsePath(undefined as any)).toThrow(
-        'Path must be a non-empty string'
+        "Path must be a non-empty string"
       );
       expect(() => parsePath(123 as any)).toThrow(
-        'Path must be a non-empty string'
+        "Path must be a non-empty string"
       );
     });
 
-    it('rejects paths with whitespace', () => {
-      expect(() => parsePath(' PID')).toThrow(
-        'Path cannot have leading/trailing whitespace'
+    it("rejects paths with whitespace", () => {
+      expect(() => parsePath(" PID")).toThrow(
+        "Path cannot have leading/trailing whitespace"
       );
-      expect(() => parsePath('PID ')).toThrow(
-        'Path cannot have leading/trailing whitespace'
+      expect(() => parsePath("PID ")).toThrow(
+        "Path cannot have leading/trailing whitespace"
       );
-      expect(() => parsePath(' PID-5 ')).toThrow(
-        'Path cannot have leading/trailing whitespace'
+      expect(() => parsePath(" PID-5 ")).toThrow(
+        "Path cannot have leading/trailing whitespace"
       );
     });
 
-    it('rejects invalid path formats', () => {
-      expect(() => parsePath('P')).toThrow('Invalid HL7 path format');
-      expect(() => parsePath('PIDDD')).toThrow('Invalid HL7 path format');
-      expect(() => parsePath('pid-5')).toThrow('Invalid HL7 path format');
-      expect(() => parsePath('PID-')).toThrow('Invalid HL7 path format');
-      expect(() => parsePath('PID-5[]')).toThrow('Invalid HL7 path format');
-      expect(() => parsePath('PID-5[1].')).toThrow('Invalid HL7 path format');
-      expect(() => parsePath('PID-5.2')).toThrow('Invalid HL7 path format'); // Missing repetition
+    it("rejects invalid path formats", () => {
+      expect(() => parsePath("P")).toThrow("Invalid HL7 path format");
+      expect(() => parsePath("PIDDD")).toThrow("Invalid HL7 path format");
+      expect(() => parsePath("pid-5")).toThrow("Invalid HL7 path format");
+      expect(() => parsePath("PID-")).toThrow("Invalid HL7 path format");
+      expect(() => parsePath("PID-5[]")).toThrow("Invalid HL7 path format");
+      expect(() => parsePath("PID-5[1].")).toThrow("Invalid HL7 path format");
+      expect(() => parsePath("PID-5.2")).toThrow("Invalid HL7 path format"); // Missing repetition
     });
 
-    it('rejects zero or negative numbers', () => {
-      expect(() => parsePath('PID-0')).toThrow('Field number must be ≥1');
-      expect(() => parsePath('PID-5[0]')).toThrow(
-        'Repetition number must be ≥1'
+    it("rejects zero or negative numbers", () => {
+      expect(() => parsePath("PID-0")).toThrow("Field number must be ≥1");
+      expect(() => parsePath("PID-5[0]")).toThrow(
+        "Repetition number must be ≥1"
       );
-      expect(() => parsePath('PID-5[1].0')).toThrow(
-        'Component number must be ≥1'
+      expect(() => parsePath("PID-5[1].0")).toThrow(
+        "Component number must be ≥1"
       );
-      expect(() => parsePath('PID-5[1].2.0')).toThrow(
-        'Subcomponent number must be ≥1'
+      expect(() => parsePath("PID-5[1].2.0")).toThrow(
+        "Subcomponent number must be ≥1"
       );
     });
   });
 });
 
-describe('query', () => {
-  const root = createTestAST();
+describe("query", () => {
+  const root = createTestAst();
 
-  describe('segment queries', () => {
-    it('finds existing segments', () => {
-      const result = query(root, 'MSH');
+  describe("segment queries", () => {
+    it("finds existing segments", () => {
+      const result = query(root, "MSH");
       expect(result.found).toBe(true);
-      expect(result.node?.type).toBe('segment');
-      expect(result.path).toBe('MSH');
+      expect(result.node?.type).toBe("segment");
+      expect(result.path).toBe("MSH");
 
-      const pidResult = query(root, 'PID');
+      const pidResult = query(root, "PID");
       expect(pidResult.found).toBe(true);
-      expect(pidResult.node?.type).toBe('segment');
+      expect(pidResult.node?.type).toBe("segment");
     });
 
-    it('returns null for non-existent segments', () => {
-      const result = query(root, 'OBX');
+    it("returns null for non-existent segments", () => {
+      const result = query(root, "OBX");
       expect(result.found).toBe(false);
       expect(result.node).toBe(null);
-      expect(result.path).toBe('OBX');
+      expect(result.path).toBe("OBX");
     });
   });
 
-  describe('field queries', () => {
-    it('finds existing fields', () => {
-      const result = query(root, 'PID-5');
+  describe("field queries", () => {
+    it("finds existing fields", () => {
+      const result = query(root, "PID-5");
       expect(result.found).toBe(true);
-      expect(result.node?.type).toBe('field');
-      expect(result.path).toBe('PID-5');
+      expect(result.node?.type).toBe("field");
+      expect(result.path).toBe("PID-5");
     });
 
-    it('returns null for non-existent fields', () => {
-      const result = query(root, 'PID-99');
-      expect(result.found).toBe(false);
-      expect(result.node).toBe(null);
-    });
-
-    it('supports partial matches for non-existent fields', () => {
-      const result = query(root, 'PID-99', { allowPartialMatch: true });
-      expect(result.found).toBe(true);
-      expect(result.node?.type).toBe('segment');
-    });
-  });
-
-  describe('repetition queries', () => {
-    it('finds existing repetitions', () => {
-      const result = query(root, 'PID-5[1]');
-      expect(result.found).toBe(true);
-      expect(result.node?.type).toBe('field-repetition');
-    });
-
-    it('returns null for non-existent repetitions', () => {
-      const result = query(root, 'PID-5[2]');
+    it("returns null for non-existent fields", () => {
+      const result = query(root, "PID-99");
       expect(result.found).toBe(false);
       expect(result.node).toBe(null);
     });
 
-    it('supports partial matches for non-existent repetitions', () => {
-      const result = query(root, 'PID-5[2]', { allowPartialMatch: true });
+    it("supports partial matches for non-existent fields", () => {
+      const result = query(root, "PID-99", { allowPartialMatch: true });
       expect(result.found).toBe(true);
-      expect(result.node?.type).toBe('field');
+      expect(result.node?.type).toBe("segment");
     });
   });
 
-  describe('component queries', () => {
-    it('finds existing components', () => {
-      const result = query(root, 'PID-5[1].2');
+  describe("repetition queries", () => {
+    it("finds existing repetitions", () => {
+      const result = query(root, "PID-5[1]");
       expect(result.found).toBe(true);
-      expect(result.node?.type).toBe('component');
+      expect(result.node?.type).toBe("field-repetition");
     });
 
-    it('returns null for non-existent components', () => {
-      const result = query(root, 'PID-5[1].99');
+    it("returns null for non-existent repetitions", () => {
+      const result = query(root, "PID-5[2]");
       expect(result.found).toBe(false);
       expect(result.node).toBe(null);
     });
 
-    it('supports partial matches for non-existent components', () => {
-      const result = query(root, 'PID-5[1].99', { allowPartialMatch: true });
+    it("supports partial matches for non-existent repetitions", () => {
+      const result = query(root, "PID-5[2]", { allowPartialMatch: true });
       expect(result.found).toBe(true);
-      expect(result.node?.type).toBe('field-repetition');
+      expect(result.node?.type).toBe("field");
     });
   });
 
-  describe('subcomponent queries', () => {
-    it('finds existing subcomponents', () => {
-      const result = query(root, 'PID-5[1].1.1');
+  describe("component queries", () => {
+    it("finds existing components", () => {
+      const result = query(root, "PID-5[1].2");
       expect(result.found).toBe(true);
-      expect(result.node?.type).toBe('subcomponent');
-      if (result.node?.type === 'subcomponent') {
-        expect(result.node.value).toBe('Smith');
+      expect(result.node?.type).toBe("component");
+    });
+
+    it("returns null for non-existent components", () => {
+      const result = query(root, "PID-5[1].99");
+      expect(result.found).toBe(false);
+      expect(result.node).toBe(null);
+    });
+
+    it("supports partial matches for non-existent components", () => {
+      const result = query(root, "PID-5[1].99", { allowPartialMatch: true });
+      expect(result.found).toBe(true);
+      expect(result.node?.type).toBe("field-repetition");
+    });
+  });
+
+  describe("subcomponent queries", () => {
+    it("finds existing subcomponents", () => {
+      const result = query(root, "PID-5[1].1.1");
+      expect(result.found).toBe(true);
+      expect(result.node?.type).toBe("subcomponent");
+      if (result.node?.type === "subcomponent") {
+        expect(result.node.value).toBe("Smith");
       }
     });
 
-    it('finds different subcomponents', () => {
-      const firstName = query(root, 'PID-5[1].2.1');
+    it("finds different subcomponents", () => {
+      const firstName = query(root, "PID-5[1].2.1");
       expect(firstName.found).toBe(true);
-      if (firstName.node?.type === 'subcomponent') {
-        expect(firstName.node.value).toBe('John');
+      if (firstName.node?.type === "subcomponent") {
+        expect(firstName.node.value).toBe("John");
       }
 
-      const middleName = query(root, 'PID-5[1].3.1');
+      const middleName = query(root, "PID-5[1].3.1");
       expect(middleName.found).toBe(true);
-      if (middleName.node?.type === 'subcomponent') {
-        expect(middleName.node.value).toBe('Michael');
+      if (middleName.node?.type === "subcomponent") {
+        expect(middleName.node.value).toBe("Michael");
       }
     });
 
-    it('returns null for non-existent subcomponents', () => {
-      const result = query(root, 'PID-5[1].1.2');
+    it("returns null for non-existent subcomponents", () => {
+      const result = query(root, "PID-5[1].1.2");
       expect(result.found).toBe(false);
       expect(result.node).toBe(null);
     });
 
-    it('supports partial matches for non-existent subcomponents', () => {
-      const result = query(root, 'PID-5[1].1.2', { allowPartialMatch: true });
+    it("supports partial matches for non-existent subcomponents", () => {
+      const result = query(root, "PID-5[1].1.2", { allowPartialMatch: true });
       expect(result.found).toBe(true);
-      expect(result.node?.type).toBe('component');
+      expect(result.node?.type).toBe("component");
     });
   });
 
-  describe('error handling', () => {
-    it('handles invalid path formats', () => {
-      expect(() => query(root, 'invalid')).toThrow('Invalid HL7 path format');
-      expect(() => query(root, 'PID-')).toThrow('Invalid HL7 path format');
+  describe("error handling", () => {
+    it("handles invalid path formats", () => {
+      expect(() => query(root, "invalid")).toThrow("Invalid HL7 path format");
+      expect(() => query(root, "PID-")).toThrow("Invalid HL7 path format");
     });
 
-    it('handles non-existent segments gracefully', () => {
-      const result = query(root, 'OBX-1');
+    it("handles non-existent segments gracefully", () => {
+      const result = query(root, "OBX-1");
       expect(result.found).toBe(false);
       expect(result.node).toBe(null);
     });
   });
 });
 
-describe('getValue', () => {
-  const root = createTestAST();
+describe("getValue", () => {
+  const root = createTestAst();
 
-  it('extracts values from subcomponent nodes', () => {
-    const result = query(root, 'PID-5[1].1.1');
+  it("extracts values from subcomponent nodes", () => {
+    const result = query(root, "PID-5[1].1.1");
     const value = getValue(result);
-    expect(value).toBe('Smith');
+    expect(value).toBe("Smith");
   });
 
-  it('returns null for non-subcomponent nodes', () => {
-    const fieldResult = query(root, 'PID-5');
+  it("returns null for non-subcomponent nodes", () => {
+    const fieldResult = query(root, "PID-5");
     const fieldValue = getValue(fieldResult);
     expect(fieldValue).toBe(null);
 
-    const segmentResult = query(root, 'PID');
+    const segmentResult = query(root, "PID");
     const segmentValue = getValue(segmentResult);
     expect(segmentValue).toBe(null);
   });
 
-  it('returns null for non-existent nodes', () => {
-    const result = query(root, 'OBX-1[1].1.1');
+  it("returns null for non-existent nodes", () => {
+    const result = query(root, "OBX-1[1].1.1");
     const value = getValue(result);
     expect(value).toBe(null);
   });
 
-  it('handles empty values', () => {
-    const result = query(root, 'PID-3[1].1.1'); // Empty field
+  it("handles empty values", () => {
+    const result = query(root, "PID-3[1].1.1"); // Empty field
     const value = getValue(result);
-    expect(value).toBe(''); // Empty string, not null
+    expect(value).toBe(""); // Empty string, not null
   });
 });
 
-describe('queryValue', () => {
-  const root = createTestAST();
+describe("queryValue", () => {
+  const root = createTestAst();
 
-  it('directly returns string values', () => {
-    expect(queryValue(root, 'PID-5[1].1.1')).toBe('Smith');
-    expect(queryValue(root, 'PID-5[1].2.1')).toBe('John');
-    expect(queryValue(root, 'PID-5[1].3.1')).toBe('Michael');
-    expect(queryValue(root, 'MSH-3[1].1.1')).toBe('MyApp');
+  it("directly returns string values", () => {
+    expect(queryValue(root, "PID-5[1].1.1")).toBe("Smith");
+    expect(queryValue(root, "PID-5[1].2.1")).toBe("John");
+    expect(queryValue(root, "PID-5[1].3.1")).toBe("Michael");
+    expect(queryValue(root, "MSH-3[1].1.1")).toBe("MyApp");
   });
 
-  it('returns null for non-existent paths', () => {
-    expect(queryValue(root, 'OBX-1[1].1.1')).toBe(null);
-    expect(queryValue(root, 'PID-99[1].1.1')).toBe(null);
+  it("returns null for non-existent paths", () => {
+    expect(queryValue(root, "OBX-1[1].1.1")).toBe(null);
+    expect(queryValue(root, "PID-99[1].1.1")).toBe(null);
   });
 
-  it('returns null for non-subcomponent nodes', () => {
-    expect(queryValue(root, 'PID-5')).toBe(null);
-    expect(queryValue(root, 'PID')).toBe(null);
+  it("returns null for non-subcomponent nodes", () => {
+    expect(queryValue(root, "PID-5")).toBe(null);
+    expect(queryValue(root, "PID")).toBe(null);
   });
 
-  it('handles empty values', () => {
-    expect(queryValue(root, 'PID-3[1].1.1')).toBe('');
-  });
-});
-
-describe('exists', () => {
-  const root = createTestAST();
-
-  it('returns true for existing paths', () => {
-    expect(exists(root, 'MSH')).toBe(true);
-    expect(exists(root, 'PID')).toBe(true);
-    expect(exists(root, 'PID-5')).toBe(true);
-    expect(exists(root, 'PID-5[1]')).toBe(true);
-    expect(exists(root, 'PID-5[1].1')).toBe(true);
-    expect(exists(root, 'PID-5[1].1.1')).toBe(true);
-  });
-
-  it('returns false for non-existent paths', () => {
-    expect(exists(root, 'OBX')).toBe(false);
-    expect(exists(root, 'PID-99')).toBe(false);
-    expect(exists(root, 'PID-5[2]')).toBe(false);
-    expect(exists(root, 'PID-5[1].99')).toBe(false);
-    expect(exists(root, 'PID-5[1].1.2')).toBe(false);
-  });
-
-  it('supports partial matches', () => {
-    expect(exists(root, 'PID-99', { allowPartialMatch: true })).toBe(true);
-    expect(exists(root, 'PID-5[2]', { allowPartialMatch: true })).toBe(true);
-    expect(exists(root, 'OBX-1', { allowPartialMatch: true })).toBe(false); // Segment doesn't exist
+  it("handles empty values", () => {
+    expect(queryValue(root, "PID-3[1].1.1")).toBe("");
   });
 });
 
-describe('integration tests', () => {
-  const root = createTestAST();
+describe("exists", () => {
+  const root = createTestAst();
 
-  it('provides a complete workflow for extracting patient data', () => {
+  it("returns true for existing paths", () => {
+    expect(exists(root, "MSH")).toBe(true);
+    expect(exists(root, "PID")).toBe(true);
+    expect(exists(root, "PID-5")).toBe(true);
+    expect(exists(root, "PID-5[1]")).toBe(true);
+    expect(exists(root, "PID-5[1].1")).toBe(true);
+    expect(exists(root, "PID-5[1].1.1")).toBe(true);
+  });
+
+  it("returns false for non-existent paths", () => {
+    expect(exists(root, "OBX")).toBe(false);
+    expect(exists(root, "PID-99")).toBe(false);
+    expect(exists(root, "PID-5[2]")).toBe(false);
+    expect(exists(root, "PID-5[1].99")).toBe(false);
+    expect(exists(root, "PID-5[1].1.2")).toBe(false);
+  });
+
+  it("supports partial matches", () => {
+    expect(exists(root, "PID-99", { allowPartialMatch: true })).toBe(true);
+    expect(exists(root, "PID-5[2]", { allowPartialMatch: true })).toBe(true);
+    expect(exists(root, "OBX-1", { allowPartialMatch: true })).toBe(false); // Segment doesn't exist
+  });
+});
+
+describe("integration tests", () => {
+  const root = createTestAst();
+
+  it("provides a complete workflow for extracting patient data", () => {
     // Check if patient name exists
-    if (exists(root, 'PID-5[1].1.1')) {
-      const lastName = queryValue(root, 'PID-5[1].1.1');
-      const firstName = queryValue(root, 'PID-5[1].2.1');
-      const middleName = queryValue(root, 'PID-5[1].3.1');
+    if (exists(root, "PID-5[1].1.1")) {
+      const lastName = queryValue(root, "PID-5[1].1.1");
+      const firstName = queryValue(root, "PID-5[1].2.1");
+      const middleName = queryValue(root, "PID-5[1].3.1");
 
-      expect(lastName).toBe('Smith');
-      expect(firstName).toBe('John');
-      expect(middleName).toBe('Michael');
+      expect(lastName).toBe("Smith");
+      expect(firstName).toBe("John");
+      expect(middleName).toBe("Michael");
     }
   });
 
-  it('handles missing optional fields gracefully', () => {
+  it("handles missing optional fields gracefully", () => {
     // Try to get a field that doesn't exist
-    const alternateId = queryValue(root, 'PID-4[1].1.1');
-    expect(alternateId).toBe(''); // Field exists but is empty
+    const alternateId = queryValue(root, "PID-4[1].1.1");
+    expect(alternateId).toBe(""); // Field exists but is empty
 
-    const nonExistentField = queryValue(root, 'PID-99[1].1.1');
+    const nonExistentField = queryValue(root, "PID-99[1].1.1");
     expect(nonExistentField).toBe(null); // Field doesn't exist
   });
 
-  it('demonstrates type safety with generic queries', () => {
+  it("demonstrates type safety with generic queries", () => {
     // Query for specific node types
-    const segmentResult = query(root, 'PID');
-    if (segmentResult.found && segmentResult.node?.type === 'segment') {
+    const segmentResult = query(root, "PID");
+    if (segmentResult.found && segmentResult.node?.type === "segment") {
       expect(segmentResult.node.children).toBeDefined();
       expect(Array.isArray(segmentResult.node.children)).toBe(true);
     }
 
-    const subcomponentResult = query(root, 'PID-5[1].1.1');
+    const subcomponentResult = query(root, "PID-5[1].1.1");
     if (
       subcomponentResult.found &&
-      subcomponentResult.node?.type === 'subcomponent'
+      subcomponentResult.node?.type === "subcomponent"
     ) {
-      expect(typeof subcomponentResult.node.value).toBe('string');
-      expect(subcomponentResult.node.value).toBe('Smith');
+      expect(typeof subcomponentResult.node.value).toBe("string");
+      expect(subcomponentResult.node.value).toBe("Smith");
     }
   });
 });

--- a/packages/hl7v2-util-query/tsup.config.ts
+++ b/packages/hl7v2-util-query/tsup.config.ts
@@ -1,10 +1,10 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
-    index: 'src/index.ts',
+    index: "src/index.ts",
   },
-  format: ['esm'],
-  target: 'es2022',
+  format: ["esm"],
+  target: "es2022",
   sourcemap: true,
 });

--- a/packages/hl7v2-util-query/vitest.config.ts
+++ b/packages/hl7v2-util-query/vitest.config.ts
@@ -1,11 +1,11 @@
-import { baseConfig } from '@rethinkhealth/testing';
-import { defineConfig, mergeConfig } from 'vitest/config';
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
 
 export default mergeConfig(
   baseConfig,
   defineConfig({
     test: {
-      name: 'hl7v2-util-query',
+      name: "hl7v2-util-query",
     },
   })
 );

--- a/packages/hl7v2-utils/package.json
+++ b/packages/hl7v2-utils/package.json
@@ -26,7 +26,7 @@
     "@rethinkhealth/hl7v2-ast": "workspace:*",
     "@rethinkhealth/testing": "workspace:*",
     "@rethinkhealth/tsconfig": "workspace:*",
-    "@types/node": "24.3.0",
+    "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
     "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",

--- a/packages/hl7v2-utils/package.json
+++ b/packages/hl7v2-utils/package.json
@@ -28,7 +28,6 @@
     "@rethinkhealth/tsconfig": "workspace:*",
     "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "tsup": "8.5.0",
     "typescript": "^5.8.3",

--- a/packages/hl7v2-utils/src/index.ts
+++ b/packages/hl7v2-utils/src/index.ts
@@ -1,9 +1,9 @@
 /** biome-ignore-all lint/performance/noBarrelFile: fine */
-export type { PathParts } from './types';
+export type { PathParts } from "./types";
 export {
   DEFAULT_DELIMITERS,
   formatPath,
   getSegmentId,
   isEmptyNode,
   pathFromIndices,
-} from './utils';
+} from "./utils";

--- a/packages/hl7v2-utils/src/utils.ts
+++ b/packages/hl7v2-utils/src/utils.ts
@@ -1,17 +1,17 @@
-import type { Nodes, Segment } from '@rethinkhealth/hl7v2-ast';
-import type { PathParts } from './types';
+import type { Nodes, Segment } from "@rethinkhealth/hl7v2-ast";
+import type { PathParts } from "./types";
 
 // -------------
 // Delimiters
 // -------------
 
 export const DEFAULT_DELIMITERS = {
-  field: '|',
-  component: '^',
-  repetition: '~',
-  subcomponent: '&',
-  escape: '\\',
-  segment: '\r',
+  field: "|",
+  component: "^",
+  repetition: "~",
+  subcomponent: "&",
+  escape: "\\",
+  segment: "\r",
 };
 
 // -------------
@@ -27,12 +27,12 @@ export function isEmptyNode(node: Nodes | null | undefined): boolean {
   }
 
   // If node has a "value" property (Subcomponent, maybe Component)
-  if ('value' in node) {
-    return !node.value || node.value.trim() === '';
+  if ("value" in node) {
+    return !node.value || node.value.trim() === "";
   }
 
   // If node has children (Field, Component, Repetition, Segment, Root, etc.)
-  if ('children' in node) {
+  if ("children" in node) {
     if (!node.children || node.children.length === 0) {
       return true;
     }
@@ -57,7 +57,7 @@ export function isEmptyNode(node: Nodes | null | undefined): boolean {
  * @param componentName - Name of the component for error messages
  * @throws {Error} If the value is not a valid positive integer
  */
-function validateHL7Number(value: number, componentName: string): void {
+function validateHl7Number(value: number, componentName: string): void {
   if (!Number.isInteger(value)) {
     throw new Error(`${componentName} must be an integer, got: ${value}`);
   }
@@ -75,7 +75,7 @@ function validateHL7Number(value: number, componentName: string): void {
  * @param componentName - Name of the component for error messages
  * @throws {Error} If the value is not a valid non-negative integer
  */
-function validateASTIndex(value: number, componentName: string): void {
+function validateAstIndex(value: number, componentName: string): void {
   if (!Number.isInteger(value)) {
     throw new Error(`${componentName} must be an integer, got: ${value}`);
   }
@@ -96,7 +96,7 @@ const SEGMENT_ID_PATTERN = /^[A-Z0-9]{2,4}$/;
  * @throws {Error} If the segment ID is invalid
  */
 function validateSegmentId(segmentId: string): void {
-  if (!segmentId || typeof segmentId !== 'string') {
+  if (!segmentId || typeof segmentId !== "string") {
     throw new Error(`segmentId must be a non-empty string, got: ${segmentId}`);
   }
   if (segmentId.trim() !== segmentId) {
@@ -189,30 +189,30 @@ export function formatPath(parts: PathParts): string {
 
   // Validate numeric components (all should be 1-based positive integers)
   if (field != null) {
-    validateHL7Number(field, 'field');
+    validateHl7Number(field, "field");
   }
   if (repetition != null) {
-    validateHL7Number(repetition, 'repetition');
+    validateHl7Number(repetition, "repetition");
   }
   if (component != null) {
-    validateHL7Number(component, 'component');
+    validateHl7Number(component, "component");
   }
   if (subcomponent != null) {
-    validateHL7Number(subcomponent, 'subcomponent');
+    validateHl7Number(subcomponent, "subcomponent");
   }
 
   // Build path string
   let out = segmentId;
-  if (typeof field === 'number') {
+  if (typeof field === "number") {
     out += `-${field}`;
   }
-  if (typeof repetition === 'number') {
+  if (typeof repetition === "number") {
     out += `[${repetition}]`;
   }
-  if (typeof component === 'number') {
+  if (typeof component === "number") {
     out += `.${component}`;
   }
-  if (typeof subcomponent === 'number') {
+  if (typeof subcomponent === "number") {
     out += `.${subcomponent}`;
   }
   return out;
@@ -302,16 +302,16 @@ export function pathFromIndices(parts: {
 
   // Validate provided indices (undefined values are skipped)
   if (fieldIndex != null) {
-    validateHL7Number(fieldIndex, 'fieldIndex'); // fieldIndex is HL7 field number (1-based)
+    validateHl7Number(fieldIndex, "fieldIndex"); // fieldIndex is HL7 field number (1-based)
   }
   if (repetitionIndex != null) {
-    validateASTIndex(repetitionIndex, 'repetitionIndex');
+    validateAstIndex(repetitionIndex, "repetitionIndex");
   }
   if (componentIndex != null) {
-    validateASTIndex(componentIndex, 'componentIndex');
+    validateAstIndex(componentIndex, "componentIndex");
   }
   if (subcomponentIndex != null) {
-    validateASTIndex(subcomponentIndex, 'subcomponentIndex');
+    validateAstIndex(subcomponentIndex, "subcomponentIndex");
   }
 
   // Build path with only present components

--- a/packages/hl7v2-utils/tests/index.test.ts
+++ b/packages/hl7v2-utils/tests/index.test.ts
@@ -4,104 +4,104 @@ import type {
   FieldRepetition,
   Segment,
   Subcomponent,
-} from '@rethinkhealth/hl7v2-ast';
-import { u } from 'unist-builder';
-import { describe, expect, it } from 'vitest';
+} from "@rethinkhealth/hl7v2-ast";
+import { u } from "unist-builder";
+import { describe, expect, it } from "vitest";
 import {
   formatPath,
   getSegmentId,
   isEmptyNode,
   pathFromIndices,
-} from '../src/utils';
+} from "../src/utils";
 
-describe('isEmptyNode', () => {
+describe("isEmptyNode", () => {
   // Subcomponents that are considered empty
   const emptySubcomponents = [
-    u('subcomponent', { value: undefined }) as unknown as Subcomponent,
-    u('subcomponent', { value: null }) as unknown as Subcomponent,
-    u('subcomponent', { value: '' }),
-    u('subcomponent', { value: '' }),
-    u('subcomponent', { value: '   ' }),
+    u("subcomponent", { value: undefined }) as unknown as Subcomponent,
+    u("subcomponent", { value: null }) as unknown as Subcomponent,
+    u("subcomponent", { value: "" }),
+    u("subcomponent", { value: "" }),
+    u("subcomponent", { value: "   " }),
   ] satisfies Subcomponent[];
 
   const emptyComponents = [
-    u('component', { children: [] }),
-    u('component', { children: undefined }) as unknown as Component,
+    u("component", { children: [] }),
+    u("component", { children: undefined }) as unknown as Component,
     ...emptySubcomponents.map((subcomponent) =>
-      u('component', { children: [subcomponent] })
+      u("component", { children: [subcomponent] })
     ),
   ] satisfies Component[];
 
   const emptyFieldRepetitions = [
-    u('field-repetition', { children: [] }),
-    u('field-repetition', {
+    u("field-repetition", { children: [] }),
+    u("field-repetition", {
       children: undefined,
     }) as unknown as FieldRepetition,
     ...emptyComponents.map((component) =>
-      u('field-repetition', { children: [component] })
+      u("field-repetition", { children: [component] })
     ),
   ] satisfies FieldRepetition[];
 
   const emptyFields = [
-    u('field', { children: [] }),
-    u('field', { children: undefined }) as unknown as Field,
+    u("field", { children: [] }),
+    u("field", { children: undefined }) as unknown as Field,
     ...emptyFieldRepetitions.map((fieldRepetition) =>
-      u('field', { children: [fieldRepetition] })
+      u("field", { children: [fieldRepetition] })
     ),
   ] satisfies Field[];
 
   const emptySegments = [
-    u('segment', { children: [] }),
-    u('segment', { children: undefined }) as unknown as Segment,
-    ...emptyFields.map((field) => u('segment', { children: [field] })),
+    u("segment", { children: [] }),
+    u("segment", { children: undefined }) as unknown as Segment,
+    ...emptyFields.map((field) => u("segment", { children: [field] })),
   ] satisfies Segment[];
-  describe('empty nodes', () => {
+  describe("empty nodes", () => {
     it.each(emptySegments)(
-      'should return true for an empty segment %#',
+      "should return true for an empty segment %#",
       (segment) => {
         expect(isEmptyNode(segment)).toBe(true);
       }
     );
 
     it.each(emptyFields)(
-      'should return true for an empty field %#',
+      "should return true for an empty field %#",
       (field) => {
         expect(isEmptyNode(field)).toBe(true);
       }
     );
 
     it.each(emptyFieldRepetitions)(
-      'should return true for an empty field repetition %#',
+      "should return true for an empty field repetition %#",
       (fieldRepetition) => {
         expect(isEmptyNode(fieldRepetition)).toBe(true);
       }
     );
 
     it.each(emptyComponents)(
-      'should return true for an empty component %#',
+      "should return true for an empty component %#",
       (component) => {
         expect(isEmptyNode(component)).toBe(true);
       }
     );
 
     it.each(emptySubcomponents)(
-      'should return true for an empty subcomponent %#',
+      "should return true for an empty subcomponent %#",
       (subcomponent) => {
         expect(isEmptyNode(subcomponent)).toBe(true);
       }
     );
   });
 
-  describe('non-empty nodes', () => {
-    it('should return false for a non-empty segment', () => {
-      const nonEmptySegment = u('segment', {
+  describe("non-empty nodes", () => {
+    it("should return false for a non-empty segment", () => {
+      const nonEmptySegment = u("segment", {
         children: [
-          u('field', {
+          u("field", {
             children: [
-              u('field-repetition', {
+              u("field-repetition", {
                 children: [
-                  u('component', {
-                    children: [u('subcomponent', { value: 'test' })],
+                  u("component", {
+                    children: [u("subcomponent", { value: "test" })],
                   }),
                 ],
               }),
@@ -113,25 +113,25 @@ describe('isEmptyNode', () => {
       expect(isEmptyNode(nonEmptySegment)).toBe(false);
     });
 
-    it('should return false for an empty segment with multiple empty field repetitions', () => {
-      const nonEmptySegment = u('segment', {
+    it("should return false for an empty segment with multiple empty field repetitions", () => {
+      const nonEmptySegment = u("segment", {
         children: [
-          u('field', {
+          u("field", {
             children: [
               // Empty field repetition
-              u('field-repetition', {
+              u("field-repetition", {
                 children: [
-                  u('component', {
-                    children: [u('subcomponent', { value: '' })],
+                  u("component", {
+                    children: [u("subcomponent", { value: "" })],
                   }),
                 ],
               }),
 
               // Empty field repetition
-              u('field-repetition', {
+              u("field-repetition", {
                 children: [
-                  u('component', {
-                    children: [u('subcomponent', { value: '' })],
+                  u("component", {
+                    children: [u("subcomponent", { value: "" })],
                   }),
                 ],
               }),
@@ -144,368 +144,368 @@ describe('isEmptyNode', () => {
     });
   });
 
-  describe('edge cases', () => {
-    it('should return true for a null node', () => {
+  describe("edge cases", () => {
+    it("should return true for a null node", () => {
       expect(isEmptyNode(null)).toBe(true);
     });
 
-    it('should return true for an undefined node', () => {
+    it("should return true for an undefined node", () => {
       expect(isEmptyNode(undefined)).toBe(true);
     });
 
-    it('should return false for an unknown node', () => {
-      const unknownNode = u('unknown', { value: 'test' }) as unknown;
+    it("should return false for an unknown node", () => {
+      const unknownNode = u("unknown", { value: "test" }) as unknown;
       expect(isEmptyNode(unknownNode as any)).toBe(false);
     });
   });
 });
 
-describe('utils: formatPath', () => {
-  describe('valid inputs', () => {
-    it('builds HL7 paths with valid 1-based numbers', () => {
-      expect(formatPath({ segmentId: 'PID' })).toBe('PID');
-      expect(formatPath({ segmentId: 'PID', field: 5 })).toBe('PID-5');
-      expect(formatPath({ segmentId: 'PID', field: 5, repetition: 1 })).toBe(
-        'PID-5[1]'
+describe("utils: formatPath", () => {
+  describe("valid inputs", () => {
+    it("builds HL7 paths with valid 1-based numbers", () => {
+      expect(formatPath({ segmentId: "PID" })).toBe("PID");
+      expect(formatPath({ segmentId: "PID", field: 5 })).toBe("PID-5");
+      expect(formatPath({ segmentId: "PID", field: 5, repetition: 1 })).toBe(
+        "PID-5[1]"
       );
       expect(
-        formatPath({ segmentId: 'PID', field: 5, repetition: 1, component: 2 })
-      ).toBe('PID-5[1].2');
+        formatPath({ segmentId: "PID", field: 5, repetition: 1, component: 2 })
+      ).toBe("PID-5[1].2");
       expect(
         formatPath({
-          segmentId: 'PID',
+          segmentId: "PID",
           field: 5,
           repetition: 1,
           component: 2,
           subcomponent: 3,
         })
-      ).toBe('PID-5[1].2.3');
+      ).toBe("PID-5[1].2.3");
     });
 
-    it('builds paths with various valid segment IDs', () => {
-      expect(formatPath({ segmentId: 'MSH' })).toBe('MSH');
-      expect(formatPath({ segmentId: 'OBX' })).toBe('OBX');
-      expect(formatPath({ segmentId: 'Z123' })).toBe('Z123'); // Custom segment
+    it("builds paths with various valid segment IDs", () => {
+      expect(formatPath({ segmentId: "MSH" })).toBe("MSH");
+      expect(formatPath({ segmentId: "OBX" })).toBe("OBX");
+      expect(formatPath({ segmentId: "Z123" })).toBe("Z123"); // Custom segment
     });
   });
 
-  describe('input validation', () => {
-    it('throws on invalid segment IDs', () => {
-      expect(() => formatPath({ segmentId: '' })).toThrow(
-        'segmentId must be a non-empty string'
+  describe("input validation", () => {
+    it("throws on invalid segment IDs", () => {
+      expect(() => formatPath({ segmentId: "" })).toThrow(
+        "segmentId must be a non-empty string"
       );
-      expect(() => formatPath({ segmentId: 'pid' })).toThrow(
-        'segmentId must be 2-4 uppercase letters/numbers'
+      expect(() => formatPath({ segmentId: "pid" })).toThrow(
+        "segmentId must be 2-4 uppercase letters/numbers"
       );
-      expect(() => formatPath({ segmentId: 'TOOLONG' })).toThrow(
-        'segmentId must be 2-4 uppercase letters/numbers'
+      expect(() => formatPath({ segmentId: "TOOLONG" })).toThrow(
+        "segmentId must be 2-4 uppercase letters/numbers"
       );
-      expect(() => formatPath({ segmentId: 'P' })).toThrow(
-        'segmentId must be 2-4 uppercase letters/numbers'
+      expect(() => formatPath({ segmentId: "P" })).toThrow(
+        "segmentId must be 2-4 uppercase letters/numbers"
       );
-      expect(() => formatPath({ segmentId: ' PID ' })).toThrow(
-        'segmentId cannot have leading/trailing whitespace'
+      expect(() => formatPath({ segmentId: " PID " })).toThrow(
+        "segmentId cannot have leading/trailing whitespace"
       );
-      expect(() => formatPath({ segmentId: 'PI-D' })).toThrow(
-        'segmentId must be 2-4 uppercase letters/numbers'
-      );
-    });
-
-    it('throws on non-positive field numbers', () => {
-      expect(() => formatPath({ segmentId: 'PID', field: 0 })).toThrow(
-        'field must be positive (1-based), got: 0'
-      );
-      expect(() => formatPath({ segmentId: 'PID', field: -1 })).toThrow(
-        'field must be positive (1-based), got: -1'
+      expect(() => formatPath({ segmentId: "PI-D" })).toThrow(
+        "segmentId must be 2-4 uppercase letters/numbers"
       );
     });
 
-    it('throws on non-integer field numbers', () => {
-      expect(() => formatPath({ segmentId: 'PID', field: 1.5 })).toThrow(
-        'field must be an integer, got: 1.5'
+    it("throws on non-positive field numbers", () => {
+      expect(() => formatPath({ segmentId: "PID", field: 0 })).toThrow(
+        "field must be positive (1-based), got: 0"
       );
-      expect(() => formatPath({ segmentId: 'PID', field: Number.NaN })).toThrow(
-        'field must be an integer, got: NaN'
+      expect(() => formatPath({ segmentId: "PID", field: -1 })).toThrow(
+        "field must be positive (1-based), got: -1"
+      );
+    });
+
+    it("throws on non-integer field numbers", () => {
+      expect(() => formatPath({ segmentId: "PID", field: 1.5 })).toThrow(
+        "field must be an integer, got: 1.5"
+      );
+      expect(() => formatPath({ segmentId: "PID", field: Number.NaN })).toThrow(
+        "field must be an integer, got: NaN"
       );
       expect(() =>
-        formatPath({ segmentId: 'PID', field: Number.POSITIVE_INFINITY })
-      ).toThrow('field must be an integer, got: Infinity');
+        formatPath({ segmentId: "PID", field: Number.POSITIVE_INFINITY })
+      ).toThrow("field must be an integer, got: Infinity");
     });
 
-    it('throws on invalid repetition numbers', () => {
+    it("throws on invalid repetition numbers", () => {
       expect(() =>
-        formatPath({ segmentId: 'PID', field: 1, repetition: 0 })
-      ).toThrow('repetition must be positive (1-based), got: 0');
+        formatPath({ segmentId: "PID", field: 1, repetition: 0 })
+      ).toThrow("repetition must be positive (1-based), got: 0");
       expect(() =>
-        formatPath({ segmentId: 'PID', field: 1, repetition: -1 })
-      ).toThrow('repetition must be positive (1-based), got: -1');
+        formatPath({ segmentId: "PID", field: 1, repetition: -1 })
+      ).toThrow("repetition must be positive (1-based), got: -1");
       expect(() =>
-        formatPath({ segmentId: 'PID', field: 1, repetition: 2.5 })
-      ).toThrow('repetition must be an integer, got: 2.5');
+        formatPath({ segmentId: "PID", field: 1, repetition: 2.5 })
+      ).toThrow("repetition must be an integer, got: 2.5");
     });
 
-    it('throws on invalid component numbers', () => {
+    it("throws on invalid component numbers", () => {
       expect(() =>
-        formatPath({ segmentId: 'PID', field: 1, component: 0 })
-      ).toThrow('component must be positive (1-based), got: 0');
+        formatPath({ segmentId: "PID", field: 1, component: 0 })
+      ).toThrow("component must be positive (1-based), got: 0");
       expect(() =>
-        formatPath({ segmentId: 'PID', field: 1, component: -1 })
-      ).toThrow('component must be positive (1-based), got: -1');
+        formatPath({ segmentId: "PID", field: 1, component: -1 })
+      ).toThrow("component must be positive (1-based), got: -1");
       expect(() =>
-        formatPath({ segmentId: 'PID', field: 1, component: 3.14 })
-      ).toThrow('component must be an integer, got: 3.14');
+        formatPath({ segmentId: "PID", field: 1, component: 3.14 })
+      ).toThrow("component must be an integer, got: 3.14");
     });
 
-    it('throws on invalid subcomponent numbers', () => {
+    it("throws on invalid subcomponent numbers", () => {
       expect(() =>
-        formatPath({ segmentId: 'PID', field: 1, subcomponent: 0 })
-      ).toThrow('subcomponent must be positive (1-based), got: 0');
+        formatPath({ segmentId: "PID", field: 1, subcomponent: 0 })
+      ).toThrow("subcomponent must be positive (1-based), got: 0");
       expect(() =>
-        formatPath({ segmentId: 'PID', field: 1, subcomponent: -1 })
-      ).toThrow('subcomponent must be positive (1-based), got: -1');
+        formatPath({ segmentId: "PID", field: 1, subcomponent: -1 })
+      ).toThrow("subcomponent must be positive (1-based), got: -1");
       expect(() =>
-        formatPath({ segmentId: 'PID', field: 1, subcomponent: 1.1 })
-      ).toThrow('subcomponent must be an integer, got: 1.1');
+        formatPath({ segmentId: "PID", field: 1, subcomponent: 1.1 })
+      ).toThrow("subcomponent must be an integer, got: 1.1");
     });
   });
 });
 
-describe('utils: pathFromIndices', () => {
-  describe('valid inputs', () => {
-    it('converts 0-based AST indices to HL7 paths', () => {
-      expect(pathFromIndices({ segmentId: 'PID', fieldIndex: 5 })).toBe(
-        'PID-5'
+describe("utils: pathFromIndices", () => {
+  describe("valid inputs", () => {
+    it("converts 0-based AST indices to HL7 paths", () => {
+      expect(pathFromIndices({ segmentId: "PID", fieldIndex: 5 })).toBe(
+        "PID-5"
       );
       expect(
-        pathFromIndices({ segmentId: 'PID', fieldIndex: 5, repetitionIndex: 0 })
-      ).toBe('PID-5[1]');
+        pathFromIndices({ segmentId: "PID", fieldIndex: 5, repetitionIndex: 0 })
+      ).toBe("PID-5[1]");
       expect(
         pathFromIndices({
-          segmentId: 'PID',
+          segmentId: "PID",
           fieldIndex: 5,
           repetitionIndex: 0,
           componentIndex: 1,
         })
-      ).toBe('PID-5[1].2');
+      ).toBe("PID-5[1].2");
       expect(
         pathFromIndices({
-          segmentId: 'PID',
+          segmentId: "PID",
           fieldIndex: 5,
           repetitionIndex: 0,
           componentIndex: 1,
           subcomponentIndex: 2,
         })
-      ).toBe('PID-5[1].2.3');
+      ).toBe("PID-5[1].2.3");
     });
 
-    it('demonstrates index conversion from AST to HL7', () => {
+    it("demonstrates index conversion from AST to HL7", () => {
       // AST repetition index 0 becomes HL7 [1]
       expect(
-        pathFromIndices({ segmentId: 'PID', fieldIndex: 3, repetitionIndex: 0 })
-      ).toBe('PID-3[1]');
+        pathFromIndices({ segmentId: "PID", fieldIndex: 3, repetitionIndex: 0 })
+      ).toBe("PID-3[1]");
 
       // AST component index 1 becomes HL7 .2
       expect(
-        pathFromIndices({ segmentId: 'PID', fieldIndex: 3, componentIndex: 1 })
-      ).toBe('PID-3.2');
+        pathFromIndices({ segmentId: "PID", fieldIndex: 3, componentIndex: 1 })
+      ).toBe("PID-3.2");
 
       // fieldIndex is already HL7 field number (1-based)
-      expect(pathFromIndices({ segmentId: 'PID', fieldIndex: 1 })).toBe(
-        'PID-1'
+      expect(pathFromIndices({ segmentId: "PID", fieldIndex: 1 })).toBe(
+        "PID-1"
       );
     });
   });
 
-  describe('input validation', () => {
-    it('throws on invalid segment IDs', () => {
-      expect(() => pathFromIndices({ segmentId: '' })).toThrow(
-        'segmentId must be a non-empty string'
+  describe("input validation", () => {
+    it("throws on invalid segment IDs", () => {
+      expect(() => pathFromIndices({ segmentId: "" })).toThrow(
+        "segmentId must be a non-empty string"
       );
-      expect(() => pathFromIndices({ segmentId: 'invalid' })).toThrow(
-        'segmentId must be 2-4 uppercase letters/numbers'
+      expect(() => pathFromIndices({ segmentId: "invalid" })).toThrow(
+        "segmentId must be 2-4 uppercase letters/numbers"
       );
     });
 
-    it('throws on invalid field indices', () => {
+    it("throws on invalid field indices", () => {
       expect(() =>
-        pathFromIndices({ segmentId: 'PID', fieldIndex: -1 })
-      ).toThrow('fieldIndex must be positive (1-based), got: -1');
+        pathFromIndices({ segmentId: "PID", fieldIndex: -1 })
+      ).toThrow("fieldIndex must be positive (1-based), got: -1");
       expect(() =>
-        pathFromIndices({ segmentId: 'PID', fieldIndex: 0 })
-      ).toThrow('fieldIndex must be positive (1-based), got: 0');
+        pathFromIndices({ segmentId: "PID", fieldIndex: 0 })
+      ).toThrow("fieldIndex must be positive (1-based), got: 0");
     });
 
-    it('throws on non-integer field indices', () => {
+    it("throws on non-integer field indices", () => {
       expect(() =>
-        pathFromIndices({ segmentId: 'PID', fieldIndex: 1.5 })
-      ).toThrow('fieldIndex must be an integer, got: 1.5');
+        pathFromIndices({ segmentId: "PID", fieldIndex: 1.5 })
+      ).toThrow("fieldIndex must be an integer, got: 1.5");
     });
 
-    it('throws on negative repetition indices', () => {
+    it("throws on negative repetition indices", () => {
       expect(() =>
         pathFromIndices({
-          segmentId: 'PID',
+          segmentId: "PID",
           fieldIndex: 1,
           repetitionIndex: -1,
         })
-      ).toThrow('repetitionIndex must be non-negative (0-based), got: -1');
+      ).toThrow("repetitionIndex must be non-negative (0-based), got: -1");
     });
 
-    it('throws on non-integer repetition indices', () => {
+    it("throws on non-integer repetition indices", () => {
       expect(() =>
         pathFromIndices({
-          segmentId: 'PID',
+          segmentId: "PID",
           fieldIndex: 1,
           repetitionIndex: 0.5,
         })
-      ).toThrow('repetitionIndex must be an integer, got: 0.5');
+      ).toThrow("repetitionIndex must be an integer, got: 0.5");
     });
 
-    it('throws on negative component indices', () => {
+    it("throws on negative component indices", () => {
       expect(() =>
-        pathFromIndices({ segmentId: 'PID', fieldIndex: 1, componentIndex: -1 })
-      ).toThrow('componentIndex must be non-negative (0-based), got: -1');
+        pathFromIndices({ segmentId: "PID", fieldIndex: 1, componentIndex: -1 })
+      ).toThrow("componentIndex must be non-negative (0-based), got: -1");
     });
 
-    it('throws on non-integer component indices', () => {
+    it("throws on non-integer component indices", () => {
       expect(() =>
         pathFromIndices({
-          segmentId: 'PID',
+          segmentId: "PID",
           fieldIndex: 1,
           componentIndex: 2.7,
         })
-      ).toThrow('componentIndex must be an integer, got: 2.7');
+      ).toThrow("componentIndex must be an integer, got: 2.7");
     });
 
-    it('throws on negative subcomponent indices', () => {
+    it("throws on negative subcomponent indices", () => {
       expect(() =>
         pathFromIndices({
-          segmentId: 'PID',
+          segmentId: "PID",
           fieldIndex: 1,
           subcomponentIndex: -1,
         })
-      ).toThrow('subcomponentIndex must be non-negative (0-based), got: -1');
+      ).toThrow("subcomponentIndex must be non-negative (0-based), got: -1");
     });
 
-    it('throws on non-integer subcomponent indices', () => {
+    it("throws on non-integer subcomponent indices", () => {
       expect(() =>
         pathFromIndices({
-          segmentId: 'PID',
+          segmentId: "PID",
           fieldIndex: 1,
           subcomponentIndex: 3.9,
         })
-      ).toThrow('subcomponentIndex must be an integer, got: 3.9');
+      ).toThrow("subcomponentIndex must be an integer, got: 3.9");
     });
   });
 
-  describe('edge cases', () => {
-    it('handles zero indices correctly for 0-based components', () => {
+  describe("edge cases", () => {
+    it("handles zero indices correctly for 0-based components", () => {
       // Zero is valid for 0-based AST indices (repetition, component, subcomponent)
       expect(
         pathFromIndices({
-          segmentId: 'PID',
+          segmentId: "PID",
           fieldIndex: 1, // HL7 field number (1-based)
           repetitionIndex: 0, // 0-based -> becomes [1]
           componentIndex: 0, // 0-based -> becomes .1
           subcomponentIndex: 0, // 0-based -> becomes .1
         })
-      ).toBe('PID-1[1].1.1');
+      ).toBe("PID-1[1].1.1");
     });
 
-    it('handles undefined indices correctly - only includes present components', () => {
+    it("handles undefined indices correctly - only includes present components", () => {
       // Should work fine with optional indices, only including present parts
-      expect(pathFromIndices({ segmentId: 'PID' })).toBe('PID');
+      expect(pathFromIndices({ segmentId: "PID" })).toBe("PID");
 
       expect(
         pathFromIndices({
-          segmentId: 'PID',
+          segmentId: "PID",
           fieldIndex: 3,
         })
-      ).toBe('PID-3');
+      ).toBe("PID-3");
 
       expect(
         pathFromIndices({
-          segmentId: 'PID',
+          segmentId: "PID",
           fieldIndex: 5,
           componentIndex: 1, // repetitionIndex omitted
         })
-      ).toBe('PID-5.2'); // No repetition part
+      ).toBe("PID-5.2"); // No repetition part
 
       expect(
         pathFromIndices({
-          segmentId: 'MSH',
+          segmentId: "MSH",
           fieldIndex: 9,
           repetitionIndex: 0,
           subcomponentIndex: 2, // componentIndex omitted
         })
-      ).toBe('MSH-9[1].3'); // No component part, goes directly to subcomponent
+      ).toBe("MSH-9[1].3"); // No component part, goes directly to subcomponent
     });
 
-    it('demonstrates partial path building for different node types', () => {
+    it("demonstrates partial path building for different node types", () => {
       // Segment-level path
       expect(
         pathFromIndices({
-          segmentId: 'PID',
+          segmentId: "PID",
         })
-      ).toBe('PID');
+      ).toBe("PID");
 
       // Field-level path
       expect(
         pathFromIndices({
-          segmentId: 'PID',
+          segmentId: "PID",
           fieldIndex: 5,
         })
-      ).toBe('PID-5');
+      ).toBe("PID-5");
 
       // Repetition-level path
       expect(
         pathFromIndices({
-          segmentId: 'PID',
+          segmentId: "PID",
           fieldIndex: 5,
           repetitionIndex: 0,
         })
-      ).toBe('PID-5[1]');
+      ).toBe("PID-5[1]");
 
       // Component-level path
       expect(
         pathFromIndices({
-          segmentId: 'PID',
+          segmentId: "PID",
           fieldIndex: 5,
           repetitionIndex: 0,
           componentIndex: 1,
         })
-      ).toBe('PID-5[1].2');
+      ).toBe("PID-5[1].2");
 
       // Subcomponent-level path
       expect(
         pathFromIndices({
-          segmentId: 'PID',
+          segmentId: "PID",
           fieldIndex: 5,
           repetitionIndex: 0,
           componentIndex: 1,
           subcomponentIndex: 0,
         })
-      ).toBe('PID-5[1].2.1');
+      ).toBe("PID-5[1].2.1");
     });
   });
 });
 
-describe('utils: getSegmentId', () => {
-  it('extracts segment id from first field', () => {
-    const seg = u('segment', [
-      u('field', [
-        u('field-repetition', [u('component', [u('subcomponent', 'PID')])]),
+describe("utils: getSegmentId", () => {
+  it("extracts segment id from first field", () => {
+    const seg = u("segment", [
+      u("field", [
+        u("field-repetition", [u("component", [u("subcomponent", "PID")])]),
       ]),
     ]) as unknown as Segment;
-    expect(getSegmentId(seg)).toBe('PID');
+    expect(getSegmentId(seg)).toBe("PID");
   });
 
-  it('returns null for malformed segments', () => {
-    const emptySegment = u('segment', []) as unknown as Segment;
+  it("returns null for malformed segments", () => {
+    const emptySegment = u("segment", []) as unknown as Segment;
     expect(getSegmentId(emptySegment)).toBe(null);
 
-    const incompleteSegment = u('segment', [
-      u('field', []),
+    const incompleteSegment = u("segment", [
+      u("field", []),
     ]) as unknown as Segment;
     expect(getSegmentId(incompleteSegment)).toBe(null);
   });

--- a/packages/hl7v2-utils/tsup.config.ts
+++ b/packages/hl7v2-utils/tsup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
@@ -6,11 +6,11 @@ export default defineConfig({
      * Directories and files should be bundled so that the resulting files line
      * up with the TSC generated type definitions.
      */
-    index: 'src/index.ts',
+    index: "src/index.ts",
     // "utils/index": "src/utils/index.ts",
   },
-  format: ['esm'],
-  target: 'es2022',
+  format: ["esm"],
+  target: "es2022",
   sourcemap: true,
   // treeshake: true,
 

--- a/packages/hl7v2-utils/vitest.config.ts
+++ b/packages/hl7v2-utils/vitest.config.ts
@@ -1,11 +1,11 @@
-import { baseConfig } from '@rethinkhealth/testing';
-import { defineConfig, mergeConfig } from 'vitest/config';
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
 
 export default mergeConfig(
   baseConfig,
   defineConfig({
     test: {
-      name: 'hl7-parser',
+      name: "hl7-parser",
     },
   })
 );

--- a/packages/hl7v2/package.json
+++ b/packages/hl7v2/package.json
@@ -34,7 +34,7 @@
     "@rethinkhealth/hl7v2-utils": "workspace:*",
     "@rethinkhealth/testing": "workspace:*",
     "@rethinkhealth/tsconfig": "workspace:*",
-    "@types/node": "24.3.0",
+    "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
     "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",

--- a/packages/hl7v2/package.json
+++ b/packages/hl7v2/package.json
@@ -36,7 +36,6 @@
     "@rethinkhealth/tsconfig": "workspace:*",
     "@types/node": "24.5.2",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "tsup": "8.5.0",
     "typescript": "^5.8.3",

--- a/packages/hl7v2/src/index.ts
+++ b/packages/hl7v2/src/index.ts
@@ -1,12 +1,13 @@
-import { hl7v2DecodeEscapes } from '@rethinkhealth/hl7v2-decode-escapes';
-import { hl7v2Jsonify } from '@rethinkhealth/hl7v2-jsonify';
-import { hl7v2Parser } from '@rethinkhealth/hl7v2-parser';
-import hl7v2PresetLintRecommended from '@rethinkhealth/hl7v2-preset-lint-recommended';
-import { unified } from 'unified';
+import { hl7v2DecodeEscapes } from "@rethinkhealth/hl7v2-decode-escapes";
+import { hl7v2Jsonify } from "@rethinkhealth/hl7v2-jsonify";
+import { hl7v2Parser } from "@rethinkhealth/hl7v2-parser";
+import hl7v2PresetLintRecommended from "@rethinkhealth/hl7v2-preset-lint-recommended";
+import { unified } from "unified";
 
 /**
  * Create a new unified processor that already uses `hl7v2-parser`.
  */
+// biome-ignore lint/style/useNamingConvention: HL7v2 is a special case
 export const parseHL7v2 = unified()
   .use(hl7v2Parser)
   .use(hl7v2DecodeEscapes)

--- a/packages/hl7v2/tests/index.test.ts
+++ b/packages/hl7v2/tests/index.test.ts
@@ -1,34 +1,34 @@
-import { DEFAULT_DELIMITERS } from '@rethinkhealth/hl7v2-utils';
-import { describe, expect, it } from 'vitest';
-import { parseHL7v2 } from '../src';
+import { DEFAULT_DELIMITERS } from "@rethinkhealth/hl7v2-utils";
+import { describe, expect, it } from "vitest";
+import { parseHL7v2 } from "../src";
 
-describe('parseHL7v2 (holistic)', () => {
-  it('parses MSH + PID and decodes escapes, then stringifies to JSON', async () => {
+describe("parseHL7v2 (holistic)", () => {
+  it("parses MSH + PID and decodes escapes, then stringifies to JSON", async () => {
     const msg = [
       // MSH with delimiters and sender
-      'MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5',
+      "MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5",
       // PID with components, repetitions and escapes (\S\ for ^)
-      'PID|1||12345^^^HOSP^MR||DOE\\S\\JOHN^A&J|19700101|M',
-    ].join('\r');
+      "PID|1||12345^^^HOSP^MR||DOE\\S\\JOHN^A&J|19700101|M",
+    ].join("\r");
 
     const file = await parseHL7v2.process(msg);
 
     expect(file.value).toMatchSnapshot();
   });
 
-  it('handles trailing delimiters and preserves empty structures appropriately', async () => {
-    const msg = 'PID|A^B&|C~|';
+  it("handles trailing delimiters and preserves empty structures appropriately", async () => {
+    const msg = "PID|A^B&|C~|";
     const file = await parseHL7v2.process(msg);
 
     expect(file.value).toMatchSnapshot();
   });
 
-  it('includes delimiters in the output', () => {
+  it("includes delimiters in the output", () => {
     const msg = [
-      'MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5',
-      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-    ].join('\r');
+      "MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5",
+      "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+    ].join("\r");
 
     const root = parseHL7v2.parse(msg);
 
@@ -36,113 +36,109 @@ describe('parseHL7v2 (holistic)', () => {
     expect(root.data?.delimiters).toEqual(DEFAULT_DELIMITERS);
   });
 
-  it('handles decoding escapes', async () => {
-    const msg = 'PID|1|Value\\F\\More\\S\\Stuff\\R\\Again\\T\\Sub\\E\\Escaped|';
+  it("handles decoding escapes", async () => {
+    const msg = "PID|1|Value\\F\\More\\S\\Stuff\\R\\Again\\T\\Sub\\E\\Escaped|";
     const file = await parseHL7v2.process(msg);
 
     expect(file.value).toMatchSnapshot();
   });
 
-  it('parses multiple segments with MSH as the first segment', async () => {
+  it("parses multiple segments with MSH as the first segment", async () => {
     const msg = [
       // MSH
-      'MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5',
+      "MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01|MSG00001|P|2.5",
       // PID
-      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
       // OBX
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-    ].join('\r');
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+    ].join("\r");
 
     const file = await parseHL7v2.process(msg);
     expect(file.value).toMatchSnapshot();
   });
 
-  it('parses multiple segments without MSH as the first segment', async () => {
+  it("parses multiple segments without MSH as the first segment", async () => {
     const msg = [
       // PID
-      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
       // OBX
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-    ].join('\r');
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+    ].join("\r");
 
     const file = await parseHL7v2.process(msg);
 
     expect(file.value).toMatchSnapshot();
   });
 
-  it('parses correctly similar messages with different carriage returns', async () => {
-    const msg_with_cr = [
+  it("parses correctly similar messages with different carriage returns", async () => {
+    const msgWithCr = [
       // PID
-      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
       // OBX
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-    ].join('\r');
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+    ].join("\r");
 
-    const msg_with_lf = [
+    const msgWithLf = [
       // PID
-      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
       // OBX
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-    ].join('\n');
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+    ].join("\n");
 
-    const file_cr = await parseHL7v2.process(msg_with_cr);
-    const file_lf = await parseHL7v2.process(msg_with_lf);
+    const fileCr = await parseHL7v2.process(msgWithCr);
+    const fileLf = await parseHL7v2.process(msgWithLf);
 
-    expect(file_cr.value).toEqual(file_lf.value);
+    expect(fileCr.value).toEqual(fileLf.value);
   });
 
-  it('parses correctly similar messages with or without trailing field separators', async () => {
-    const msg_with_trailing_field_separator = [
+  it("parses correctly similar messages with or without trailing field separators", async () => {
+    const msgWithTrailingFieldSeparator = [
       // PID
-      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC|',
+      "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC|",
       // OBX
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R|',
-    ].join('\r');
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R|",
+    ].join("\r");
 
-    const msg_without_trailing_field_separator = [
+    const msgWithoutTrailingFieldSeparator = [
       // PID
-      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
       // OBX
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R',
-    ].join('\r');
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^R",
+    ].join("\r");
 
-    const file_cr = await parseHL7v2.process(msg_with_trailing_field_separator);
-    const file_lf = await parseHL7v2.process(
-      msg_without_trailing_field_separator
-    );
+    const fileCr = await parseHL7v2.process(msgWithTrailingFieldSeparator);
+    const fileLf = await parseHL7v2.process(msgWithoutTrailingFieldSeparator);
 
-    expect(file_cr.value).toEqual(file_lf.value);
+    expect(fileCr.value).toEqual(fileLf.value);
   });
 
-  it('parses correctly similar messages with or without trailing field separators and empty last field', async () => {
-    const msg_with_trailing_field_separator = [
+  it("parses correctly similar messages with or without trailing field separators and empty last field", async () => {
+    const msgWithTrailingFieldSeparator = [
       // PID
-      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC|',
+      "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC|",
       // OBX
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^|',
-    ].join('\r');
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^|",
+    ].join("\r");
 
-    const msg_without_trailing_field_separator = [
+    const msgWithoutTrailingFieldSeparator = [
       // PID
-      'PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC',
+      "PID|||PATID1234^5^M11^ADT1^MR^UNIVERSITY HOSPITAL~123_456_789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19_610_615|M||C|1200 N ELM STREET^^GREENSBORO^NC^27_401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10^ADT1^AN^A|123_456_789|9-87_654^NC",
       // OBX
-      'OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^',
-    ].join('\r');
+      "OBR|1|845439^GHH OE|1045813^GHH LAB|1554-5^GLUCOSE^LN|||200202150730|||||||||DOCT^KILDARE^JAMES^A|||||||200202150930||F|||^^^^^",
+    ].join("\r");
 
-    const file_cr = await parseHL7v2.process(msg_with_trailing_field_separator);
-    const file_lf = await parseHL7v2.process(
-      msg_without_trailing_field_separator
-    );
+    const fileCr = await parseHL7v2.process(msgWithTrailingFieldSeparator);
+    const fileLf = await parseHL7v2.process(msgWithoutTrailingFieldSeparator);
 
-    expect(file_cr.value).toEqual(file_lf.value);
+    expect(fileCr.value).toEqual(fileLf.value);
   });
 
-  it('process immunization sample', async () => {
+  it("process immunization sample", async () => {
     const msg = [
-      'MSH|^~\\&|VALLEY CLINIC^^^|||WIR^^^|19991005032342||VXU^V04|682299|P^|2.4^^|||ER',
-      'PID|||79928^^^^PI|A5SMIT0071^^^^^|SMITH^MARY^T^^^^^|JOHNSON^^^^^^^|19951212|F||||',
-      'RXA|0|999|19970903|19970903|^^^90701^DTP^CPT|0.5',
-    ].join('\r');
+      "MSH|^~\\&|VALLEY CLINIC^^^|||WIR^^^|19991005032342||VXU^V04|682299|P^|2.4^^|||ER",
+      "PID|||79928^^^^PI|A5SMIT0071^^^^^|SMITH^MARY^T^^^^^|JOHNSON^^^^^^^|19951212|F||||",
+      "RXA|0|999|19970903|19970903|^^^90701^DTP^CPT|0.5",
+    ].join("\r");
 
     const file = await parseHL7v2.process(msg);
 

--- a/packages/hl7v2/tsup.config.ts
+++ b/packages/hl7v2/tsup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
@@ -6,11 +6,11 @@ export default defineConfig({
      * Directories and files should be bundled so that the resulting files line
      * up with the TSC generated type definitions.
      */
-    index: 'src/index.ts',
+    index: "src/index.ts",
     // "utils/index": "src/utils/index.ts",
   },
-  format: ['esm'],
-  target: 'es2022',
+  format: ["esm"],
+  target: "es2022",
   sourcemap: true,
   // treeshake: true,
 

--- a/packages/hl7v2/vitest.config.ts
+++ b/packages/hl7v2/vitest.config.ts
@@ -1,12 +1,12 @@
-import { baseConfig } from '@rethinkhealth/testing';
-import { defineConfig, mergeConfig } from 'vitest/config';
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
 
 export default mergeConfig(
   baseConfig,
   defineConfig({
     test: {
-      name: 'hl7v2',
-      include: ['tests/**/*.test.ts'],
+      name: "hl7v2",
+      include: ["tests/**/*.test.ts"],
     },
   })
 );

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -22,12 +22,12 @@
   },
   "devDependencies": {
     "@rethinkhealth/tsconfig": "workspace:*",
-    "@types/node": "24.3.0",
+    "@types/node": "24.5.2",
     "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
     "tsup": "8.5.0",
-    "tsx": "^4.20.4",
+    "tsx": "^4.20.5",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"
   },

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -15,7 +15,6 @@
     "check-types": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
     "vitest": "^3.2.4"
@@ -23,7 +22,6 @@
   "devDependencies": {
     "@rethinkhealth/tsconfig": "workspace:*",
     "@types/node": "24.5.2",
-    "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
     "tsup": "8.5.0",

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,2 +1,2 @@
 // biome-ignore lint/performance/noBarrelFile: unit test config
-export { default as baseConfig } from './vitest.config';
+export { default as baseConfig } from "./vitest.config";

--- a/packages/testing/src/vitest.config.ts
+++ b/packages/testing/src/vitest.config.ts
@@ -1,13 +1,13 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
     globals: true,
-    environment: 'node', // or 'jsdom' for browser-based tests
-    include: ['**/*.test.ts', '**/*.test.tsx'],
-    exclude: ['node_modules', 'dist'],
+    environment: "node", // or 'jsdom' for browser-based tests
+    include: ["**/*.test.ts", "**/*.test.tsx"],
+    exclude: ["node_modules", "dist"],
     coverage: {
-      reporter: ['text', 'html', 'json'],
+      reporter: ["text", "html", "json"],
     },
   },
 });

--- a/packages/testing/tsup.config.ts
+++ b/packages/testing/tsup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
@@ -6,11 +6,11 @@ export default defineConfig({
      * Directories and files should be bundled so that the resulting files line
      * up with the TSC generated type definitions.
      */
-    index: './src/index.ts',
+    index: "./src/index.ts",
     // "utils/index": "src/utils/index.ts",
   },
-  format: ['esm'],
-  target: 'es2022',
+  format: ["esm"],
+  target: "es2022",
   sourcemap: true,
   // treeshake: true,
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ^5.8.3
         version: 5.9.2
       ultracite:
-        specifier: 5.2.17
-        version: 5.2.17(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0)
+        specifier: 5.4.5
+        version: 5.4.5(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(effect@3.17.2)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0)
 
   packages/hl7v2:
     dependencies:
@@ -68,8 +68,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: 24.3.0
-        version: 24.3.0
+        specifier: 24.5.2
+        version: 24.5.2
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
@@ -81,32 +81,31 @@ importers:
         version: 3.2.4(vitest@3.2.4)
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0)
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   packages/hl7v2-ast:
-    dependencies:
-      '@types/unist':
-        specifier: 3.0.3
-        version: 3.0.3
     devDependencies:
       '@rethinkhealth/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: 24.3.0
-        version: 24.3.0
+        specifier: 24.5.2
+        version: 24.5.2
+      '@types/unist':
+        specifier: ^3.0.3
+        version: 3.0.3
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0)
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
@@ -118,7 +117,7 @@ importers:
         version: 4.0.0
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   packages/hl7v2-builder:
     dependencies:
@@ -126,7 +125,7 @@ importers:
         specifier: workspace:*
         version: link:../hl7v2-ast
       unist-builder:
-        specifier: ^4.0.0
+        specifier: 4.0.0
         version: 4.0.0
     devDependencies:
       '@rethinkhealth/hl7v2-to-hl7v2':
@@ -139,8 +138,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: 24.3.0
-        version: 24.3.0
+        specifier: 24.5.2
+        version: 24.5.2
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
@@ -152,16 +151,16 @@ importers:
         version: 3.2.4(vitest@3.2.4)
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0)
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
       unified:
-        specifier: 11.0.5
+        specifier: ^11.0.5
         version: 11.0.5
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   packages/hl7v2-cli:
     dependencies:
@@ -176,11 +175,11 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: 24.3.0
-        version: 24.3.0
+        specifier: 24.5.2
+        version: 24.5.2
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0)
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
@@ -210,8 +209,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: 24.3.0
-        version: 24.3.0
+        specifier: 24.5.2
+        version: 24.5.2
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
@@ -223,13 +222,13 @@ importers:
         version: 3.2.4(vitest@3.2.4)
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0)
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   packages/hl7v2-jsonify:
     dependencies:
@@ -253,8 +252,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: 24.3.0
-        version: 24.3.0
+        specifier: 24.5.2
+        version: 24.5.2
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
@@ -266,13 +265,13 @@ importers:
         version: 3.2.4(vitest@3.2.4)
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0)
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   packages/hl7v2-lint-max-message-size:
     dependencies:
@@ -302,8 +301,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: 24.3.0
-        version: 24.3.0
+        specifier: 24.5.2
+        version: 24.5.2
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
@@ -315,7 +314,7 @@ importers:
         version: 3.2.4(vitest@3.2.4)
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0)
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
@@ -324,7 +323,7 @@ importers:
         version: 8.1.1
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   packages/hl7v2-lint-no-trailing-empty-field:
     dependencies:
@@ -357,8 +356,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: 24.3.0
-        version: 24.3.0
+        specifier: 24.5.2
+        version: 24.5.2
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
@@ -370,7 +369,7 @@ importers:
         version: 3.2.4(vitest@3.2.4)
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0)
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
@@ -379,7 +378,7 @@ importers:
         version: 8.1.1
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   packages/hl7v2-lint-required-message-header:
     dependencies:
@@ -409,8 +408,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: 24.3.0
-        version: 24.3.0
+        specifier: 24.5.2
+        version: 24.5.2
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
@@ -422,7 +421,7 @@ importers:
         version: 3.2.4(vitest@3.2.4)
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0)
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
@@ -431,7 +430,7 @@ importers:
         version: 8.1.1
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   packages/hl7v2-lint-segment-header-length:
     dependencies:
@@ -464,8 +463,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: 24.3.0
-        version: 24.3.0
+        specifier: 24.5.2
+        version: 24.5.2
       '@types/pluralize':
         specifier: ^0.0.33
         version: 0.0.33
@@ -480,7 +479,7 @@ importers:
         version: 3.2.4(vitest@3.2.4)
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0)
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
@@ -489,7 +488,7 @@ importers:
         version: 8.1.1
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   packages/hl7v2-parser:
     dependencies:
@@ -510,8 +509,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: 24.3.0
-        version: 24.3.0
+        specifier: 24.5.2
+        version: 24.5.2
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
@@ -523,13 +522,13 @@ importers:
         version: 3.2.4(vitest@3.2.4)
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0)
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   packages/hl7v2-preset-lint-recommended:
     dependencies:
@@ -565,8 +564,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: 24.3.0
-        version: 24.3.0
+        specifier: 24.5.2
+        version: 24.5.2
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
@@ -578,7 +577,7 @@ importers:
         version: 3.2.4(vitest@3.2.4)
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0)
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
@@ -587,7 +586,7 @@ importers:
         version: 8.1.1
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   packages/hl7v2-to-hl7v2:
     dependencies:
@@ -614,8 +613,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: 24.3.0
-        version: 24.3.0
+        specifier: 24.5.2
+        version: 24.5.2
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
@@ -627,7 +626,7 @@ importers:
         version: 3.2.4(vitest@3.2.4)
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0)
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
@@ -636,7 +635,7 @@ importers:
         version: 4.0.0
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   packages/hl7v2-util-query:
     dependencies:
@@ -657,8 +656,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: 24.3.0
-        version: 24.3.0
+        specifier: 24.5.2
+        version: 24.5.2
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
@@ -670,13 +669,13 @@ importers:
         version: 3.2.4(vitest@3.2.4)
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0)
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   packages/hl7v2-utils:
     devDependencies:
@@ -690,8 +689,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: 24.3.0
-        version: 24.3.0
+        specifier: 24.5.2
+        version: 24.5.2
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
@@ -703,7 +702,7 @@ importers:
         version: 3.2.4(vitest@3.2.4)
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0)
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
@@ -712,7 +711,7 @@ importers:
         version: 4.0.0
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   packages/testing:
     devDependencies:
@@ -720,8 +719,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       '@types/node':
-        specifier: 24.3.0
-        version: 24.3.0
+        specifier: 24.5.2
+        version: 24.5.2
       '@vitest/coverage-c8':
         specifier: ^0.33.0
         version: 0.33.0(vitest@3.2.4)
@@ -733,16 +732,16 @@ importers:
         version: 3.2.4(vitest@3.2.4)
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0)
       tsx:
-        specifier: ^4.20.4
-        version: 4.20.4
+        specifier: ^4.20.5
+        version: 4.20.6
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   packages/tsconfig:
     devDependencies:
@@ -1411,8 +1410,8 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
-  '@trpc/server@11.4.4':
-    resolution: {integrity: sha512-VkJb2xnb4rCynuwlCvgPBh5aM+Dco6fBBIo6lWAdJJRYVwtyE5bxNZBgUvRRz/cFSEAy0vmzLxF7aABDJfK5Rg==}
+  '@trpc/server@11.6.0':
+    resolution: {integrity: sha512-skTso0AWbOZck40jwNeYv++AMZXNWLUWdyk+pB5iVaYmEKTuEeMoPrEudR12VafbEU6tZa8HK3QhBfTYYHDCdg==}
     peerDependencies:
       typescript: '>=5.7.2'
 
@@ -1446,14 +1445,8 @@ packages:
   '@types/node@22.15.31':
     resolution: {integrity: sha512-jnVe5ULKl6tijxUhvQeNbQG/84fHfg+yMak02cT8QVhBx/F05rAVxCGBYYTh2EKz22D6JF5ktXuNwdx7b9iEGw==}
 
-  '@types/node@24.3.0':
-    resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
-
   '@types/node@24.5.2':
     resolution: {integrity: sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==}
-
-  '@types/omelette@0.4.5':
-    resolution: {integrity: sha512-zUCJpVRwfMcZfkxSCGp73mgd3/xesvPz5tQJIORlfP/zkYEyp9KUfF7IP3RRjyZR3DwxkPs96/IFf70GmYZYHQ==}
 
   '@types/pluralize@0.0.33':
     resolution: {integrity: sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==}
@@ -2235,8 +2228,8 @@ packages:
     resolution: {integrity: sha512-nkc+3pIIhqHVQr085X9d2JzPzLyjzQS96zbruppqC9aZRm/x8xx6xhI98gHtsfELP2bE+loHq8ZaHFHhe+NauA==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  nypm@0.6.1:
-    resolution: {integrity: sha512-hlacBiRiv1k9hZFiphPUkfSQ/ZfQzZDzC+8z0wL3lvDAOUu/2NnChkKuMoMjNur/9OpKuz2QsIeiPVN0xM5Q0w==}
+  nypm@0.6.2:
+    resolution: {integrity: sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==}
     engines: {node: ^14.16.0 || >=16.10.0}
     hasBin: true
 
@@ -2365,8 +2358,8 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
-  pkg-types@2.2.0:
-    resolution: {integrity: sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==}
+  pkg-types@2.3.0:
+    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -2711,17 +2704,29 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
-  trpc-cli@0.10.2:
-    resolution: {integrity: sha512-zBkL88AeX0vQLXwEAcX6WUoT4Sopr97nFDFeD1zmW33wHQwBKbszylplNVk6BO/cuhgm/iq8/cG27NokqKA1mw==}
+  trpc-cli@0.11.0:
+    resolution: {integrity: sha512-cFt5LVl1EzwmhZtWa6xPBWr6rgLXGgEOqmcTMIYcI6fLQE1REgu6tS55LmqUJs5kVSXrOd1z5/aufJS71xUUyA==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      '@inquirer/prompts': '*'
-      omelette: '*'
+      '@orpc/server': ^1.0.0
+      '@trpc/server': ^10.45.2 || ^11.0.1
+      '@valibot/to-json-schema': ^1.1.0
+      effect: ^3.14.2 || ^4.0.0
+      valibot: ^1.1.0
+      zod: ^3.24.0 || ^4.0.0
     peerDependenciesMeta:
-      '@inquirer/prompts':
+      '@orpc/server':
         optional: true
-      omelette:
+      '@trpc/server':
+        optional: true
+      '@valibot/to-json-schema':
+        optional: true
+      effect:
+        optional: true
+      valibot:
+        optional: true
+      zod:
         optional: true
 
   ts-interface-checker@0.1.13:
@@ -2749,8 +2754,8 @@ packages:
       typescript:
         optional: true
 
-  tsx@4.20.4:
-    resolution: {integrity: sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==}
+  tsx@4.20.6:
+    resolution: {integrity: sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2803,15 +2808,12 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
-  ultracite@5.2.17:
-    resolution: {integrity: sha512-NQoChSZhY1eAcujTyz/h+dYR3XKv7b8SDNWM0HVO0zPFw9/WkjNCYqpyh8NSa4YLJYPrnDPCjiaQJvLtFMrbVw==}
+  ultracite@5.4.5:
+    resolution: {integrity: sha512-UWny94qR2w4I/hzX6zsAdK9GosnL3aNr7Yq21Ltgub/GmU9mriU8Us2M9AtiPCiGPVx1Ijn8hgn8/btDLDROTg==}
     hasBin: true
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici-types@7.10.0:
-    resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
 
   undici-types@7.12.0:
     resolution: {integrity: sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==}
@@ -3019,14 +3021,6 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-  zod-to-json-schema@3.24.6:
-    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
-    peerDependencies:
-      zod: ^3.24.1
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
@@ -3598,7 +3592,7 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
-  '@trpc/server@11.4.4(typescript@5.9.2)':
+  '@trpc/server@11.6.0(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
 
@@ -3608,7 +3602,7 @@ snapshots:
 
   '@types/concat-stream@2.0.3':
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 24.5.2
 
   '@types/debug@4.1.12':
     dependencies:
@@ -3630,16 +3624,9 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@24.3.0':
-    dependencies:
-      undici-types: 7.10.0
-
   '@types/node@24.5.2':
     dependencies:
       undici-types: 7.12.0
-    optional: true
-
-  '@types/omelette@0.4.5': {}
 
   '@types/pluralize@0.0.33': {}
 
@@ -3656,7 +3643,7 @@ snapshots:
       magic-string: 0.30.17
       picocolors: 1.1.1
       std-env: 3.9.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4)':
     dependencies:
@@ -3673,7 +3660,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3685,21 +3672,13 @@ snapshots:
       chai: 5.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.0.6(@types/node@24.3.0)(tsx@4.20.4)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.4(vite@7.0.6(@types/node@24.5.2)(tsx@4.20.6)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.0.6(@types/node@24.3.0)(tsx@4.20.4)(yaml@2.8.0)
-
-  '@vitest/mocker@3.2.4(vite@7.0.6(@types/node@24.5.2)(tsx@4.20.4)(yaml@2.8.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 7.0.6(@types/node@24.5.2)(tsx@4.20.4)(yaml@2.8.0)
+      vite: 7.0.6(@types/node@24.5.2)(tsx@4.20.6)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3730,7 +3709,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -4451,12 +4430,12 @@ snapshots:
       npm-package-arg: 11.0.3
       semver: 7.7.2
 
-  nypm@0.6.1:
+  nypm@0.6.2:
     dependencies:
       citty: 0.1.6
       consola: 3.4.2
       pathe: 2.0.3
-      pkg-types: 2.2.0
+      pkg-types: 2.3.0
       tinyexec: 1.0.1
 
   object-assign@4.1.1: {}
@@ -4576,7 +4555,7 @@ snapshots:
       mlly: 1.7.4
       pathe: 2.0.3
 
-  pkg-types@2.2.0:
+  pkg-types@2.3.0:
     dependencies:
       confbox: 0.2.2
       exsolve: 1.0.7
@@ -4584,12 +4563,12 @@ snapshots:
 
   pluralize@8.0.0: {}
 
-  postcss-load-config@6.0.1(postcss@8.5.6)(tsx@4.20.4)(yaml@2.8.0):
+  postcss-load-config@6.0.1(postcss@8.5.6)(tsx@4.20.6)(yaml@2.8.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       postcss: 8.5.6
-      tsx: 4.20.4
+      tsx: 4.20.6
       yaml: 2.8.0
 
   postcss@8.5.6:
@@ -4911,22 +4890,19 @@ snapshots:
 
   trough@2.2.0: {}
 
-  trpc-cli@0.10.2(typescript@5.9.2):
+  trpc-cli@0.11.0(@trpc/server@11.6.0(typescript@5.9.2))(effect@3.17.2)(zod@4.1.11):
     dependencies:
-      '@trpc/server': 11.4.4(typescript@5.9.2)
-      '@types/omelette': 0.4.5
       commander: 14.0.0
-      picocolors: 1.1.1
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
-    transitivePeerDependencies:
-      - typescript
+    optionalDependencies:
+      '@trpc/server': 11.6.0(typescript@5.9.2)
+      effect: 3.17.2
+      zod: 4.1.11
 
   ts-interface-checker@0.1.13: {}
 
   ts-toolbelt@9.6.0: {}
 
-  tsup@8.5.0(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0):
+  tsup@8.5.0(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.9)
       cac: 6.7.14
@@ -4937,7 +4913,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.6)(tsx@4.20.4)(yaml@2.8.0)
+      postcss-load-config: 6.0.1(postcss@8.5.6)(tsx@4.20.6)(yaml@2.8.0)
       resolve-from: 5.0.0
       rollup: 4.45.3
       source-map: 0.8.0-beta.0
@@ -4954,7 +4930,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsx@4.20.4:
+  tsx@4.20.6:
     dependencies:
       esbuild: 0.25.9
       get-tsconfig: 4.10.1
@@ -4996,29 +4972,31 @@ snapshots:
 
   ufo@1.6.1: {}
 
-  ultracite@5.2.17(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.0):
+  ultracite@5.4.5(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(effect@3.17.2)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.0):
     dependencies:
       '@clack/prompts': 0.11.0
+      '@trpc/server': 11.6.0(typescript@5.9.2)
       deepmerge: 4.3.1
       jsonc-parser: 3.3.1
-      nypm: 0.6.1
-      trpc-cli: 0.10.2(typescript@5.9.2)
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0)
+      nypm: 0.6.2
+      trpc-cli: 0.11.0(@trpc/server@11.6.0(typescript@5.9.2))(effect@3.17.2)(zod@4.1.11)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
       zod: 4.1.11
     transitivePeerDependencies:
       - '@edge-runtime/vm'
-      - '@inquirer/prompts'
+      - '@orpc/server'
       - '@types/debug'
       - '@types/node'
+      - '@valibot/to-json-schema'
       - '@vitest/browser'
       - '@vitest/ui'
+      - effect
       - happy-dom
       - jiti
       - jsdom
       - less
       - lightningcss
       - msw
-      - omelette
       - sass
       - sass-embedded
       - stylus
@@ -5027,14 +5005,12 @@ snapshots:
       - terser
       - tsx
       - typescript
+      - valibot
       - yaml
 
   undici-types@6.21.0: {}
 
-  undici-types@7.10.0: {}
-
-  undici-types@7.12.0:
-    optional: true
+  undici-types@7.12.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -5174,13 +5150,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@24.3.0)(tsx@4.20.4)(yaml@2.8.0):
+  vite-node@3.2.4(@types/node@24.5.2)(tsx@4.20.6)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.0.6(@types/node@24.3.0)(tsx@4.20.4)(yaml@2.8.0)
+      vite: 7.0.6(@types/node@24.5.2)(tsx@4.20.6)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5195,42 +5171,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@24.5.2)(tsx@4.20.4)(yaml@2.8.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.0.6(@types/node@24.5.2)(tsx@4.20.4)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vite@7.0.6(@types/node@24.3.0)(tsx@4.20.4)(yaml@2.8.0):
-    dependencies:
-      esbuild: 0.25.8
-      fdir: 6.4.6(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.45.3
-      tinyglobby: 0.2.14
-    optionalDependencies:
-      '@types/node': 24.3.0
-      fsevents: 2.3.3
-      tsx: 4.20.4
-      yaml: 2.8.0
-
-  vite@7.0.6(@types/node@24.5.2)(tsx@4.20.4)(yaml@2.8.0):
+  vite@7.0.6(@types/node@24.5.2)(tsx@4.20.6)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.8
       fdir: 6.4.6(picomatch@4.0.3)
@@ -5241,14 +5182,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.5.2
       fsevents: 2.3.3
-      tsx: 4.20.4
+      tsx: 4.20.6
       yaml: 2.8.0
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.0.6(@types/node@24.3.0)(tsx@4.20.4)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(vite@7.0.6(@types/node@24.5.2)(tsx@4.20.6)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5266,51 +5207,8 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.0.6(@types/node@24.3.0)(tsx@4.20.4)(yaml@2.8.0)
-      vite-node: 3.2.4(@types/node@24.3.0)(tsx@4.20.4)(yaml@2.8.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.12
-      '@types/node': 24.3.0
-      '@vitest/ui': 3.2.4(vitest@3.2.4)
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.4)(yaml@2.8.0):
-    dependencies:
-      '@types/chai': 5.2.2
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.0.6(@types/node@24.5.2)(tsx@4.20.4)(yaml@2.8.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.2.1
-      debug: 4.4.1
-      expect-type: 1.2.2
-      magic-string: 0.30.17
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.9.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.0.6(@types/node@24.5.2)(tsx@4.20.4)(yaml@2.8.0)
-      vite-node: 3.2.4(@types/node@24.5.2)(tsx@4.20.4)(yaml@2.8.0)
+      vite: 7.0.6(@types/node@24.5.2)(tsx@4.20.6)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@24.5.2)(tsx@4.20.6)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -5386,11 +5284,5 @@ snapshots:
       yargs-parser: 20.2.9
 
   yocto-queue@0.1.0: {}
-
-  zod-to-json-schema@3.24.6(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
-
-  zod@3.25.76: {}
 
   zod@4.1.11: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,9 +73,6 @@ importers:
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -143,9 +140,6 @@ importers:
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -214,9 +208,6 @@ importers:
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -257,9 +248,6 @@ importers:
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -306,9 +294,6 @@ importers:
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -361,9 +346,6 @@ importers:
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -413,9 +395,6 @@ importers:
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -471,9 +450,6 @@ importers:
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -514,9 +490,6 @@ importers:
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -569,9 +542,6 @@ importers:
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -618,9 +588,6 @@ importers:
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -661,9 +628,6 @@ importers:
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -694,9 +658,6 @@ importers:
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -721,9 +682,6 @@ importers:
       '@types/node':
         specifier: 24.5.2
         version: 24.5.2
-      '@vitest/coverage-c8':
-        specifier: ^0.33.0
-        version: 0.33.0(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -779,9 +737,6 @@ packages:
   '@babel/types@7.28.2':
     resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
-
-  '@bcoe/v8-coverage@0.2.3':
-    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -1433,9 +1388,6 @@ packages:
   '@types/is-empty@1.2.3':
     resolution: {integrity: sha512-4J1l5d79hoIvsrKh5VUKVRA1aIdsOb10Hu5j3J2VfP/msDnfTdGPmNp2E1Wg+vs97Bktzo+MZePFFXSGoykYJw==}
 
-  '@types/istanbul-lib-coverage@2.0.6':
-    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
-
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
@@ -1459,12 +1411,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@vitest/coverage-c8@0.33.0':
-    resolution: {integrity: sha512-DaF1zJz4dcOZS4k/neiQJokmOWqsGXwhthfmUdPGorXIQHjdPvV6JQSYhQDI41MyI8c+IieQUdIDs5XAMHtDDw==}
-    deprecated: v8 coverage is moved to @vitest/coverage-v8 package
-    peerDependencies:
-      vitest: '>=0.30.0 <1'
 
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
@@ -1576,9 +1522,6 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
-
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
@@ -1594,11 +1537,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.18'
-
-  c8@7.14.0:
-    resolution: {integrity: sha512-i04rtkkcNcCf7zsQcSv/T9EbUn4RXQ6mropeMcjFOsQXQ0iGLAr/xT6TImQg4+U9hmNpN9XdvPkjUL1IzbgxJw==}
-    engines: {node: '>=10.12.0'}
-    hasBin: true
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1654,9 +1592,6 @@ packages:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
 
-  cliui@7.0.4:
-    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
-
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1679,9 +1614,6 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
@@ -1695,9 +1627,6 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
-
-  convert-source-map@2.0.0:
-    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cosmiconfig@9.0.0:
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
@@ -1786,10 +1715,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
-
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -1841,19 +1766,11 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
-  find-up@5.0.0:
-    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
-    engines: {node: '>=10'}
-
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
-
-  foreground-child@2.0.0:
-    resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
-    engines: {node: '>=8.0.0'}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -1867,17 +1784,10 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-
-  get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-east-asian-width@1.3.0:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
@@ -1898,10 +1808,6 @@ packages:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
     hasBin: true
-
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -1955,10 +1861,6 @@ packages:
 
   import-meta-resolve@4.1.0:
     resolution: {integrity: sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==}
-
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -2109,10 +2011,6 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
-  locate-path@6.0.0:
-    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
-    engines: {node: '>=10'}
-
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
@@ -2158,9 +2056,6 @@ packages:
   minimatch@10.0.3:
     resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
     engines: {node: 20 || >=22}
-
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
@@ -2237,9 +2132,6 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
@@ -2263,17 +2155,9 @@ packages:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
 
-  p-limit@3.1.0:
-    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
-    engines: {node: '>=10'}
-
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
-
-  p-locate@5.0.0:
-    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
-    engines: {node: '>=10'}
 
   p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
@@ -2304,10 +2188,6 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -2453,10 +2333,6 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
-  require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2479,11 +2355,6 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
-  rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
 
   rimraf@6.0.1:
     resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
@@ -2519,9 +2390,6 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-
-  signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -2637,10 +2505,6 @@ packages:
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
-    engines: {node: '>=8'}
-
-  test-exclude@6.0.0:
-    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
   test-exclude@7.0.1:
@@ -2859,10 +2723,6 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  v8-to-istanbul@9.3.0:
-    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
-    engines: {node: '>=10.12.0'}
-
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
@@ -2998,29 +2858,10 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
-  y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-
   yaml@2.8.0:
     resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
     engines: {node: '>= 14.6'}
     hasBin: true
-
-  yargs-parser@20.2.9:
-    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
-    engines: {node: '>=10'}
-
-  yargs@16.2.0:
-    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
-    engines: {node: '>=10'}
-
-  yocto-queue@0.1.0:
-    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
-    engines: {node: '>=10'}
 
   zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
@@ -3052,8 +2893,6 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
-
-  '@bcoe/v8-coverage@0.2.3': {}
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -3614,8 +3453,6 @@ snapshots:
 
   '@types/is-empty@1.2.3': {}
 
-  '@types/istanbul-lib-coverage@2.0.6': {}
-
   '@types/ms@2.1.0': {}
 
   '@types/node@12.20.55': {}
@@ -3635,15 +3472,6 @@ snapshots:
   '@types/text-table@0.2.5': {}
 
   '@types/unist@3.0.3': {}
-
-  '@vitest/coverage-c8@0.33.0(vitest@3.2.4)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      c8: 7.14.0
-      magic-string: 0.30.17
-      picocolors: 1.1.1
-      std-env: 3.9.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@3.2.4)(tsx@4.20.6)(yaml@2.8.0)
 
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4)':
     dependencies:
@@ -3766,11 +3594,6 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  brace-expansion@1.1.12:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
@@ -3785,21 +3608,6 @@ snapshots:
     dependencies:
       esbuild: 0.25.9
       load-tsconfig: 0.2.5
-
-  c8@7.14.0:
-    dependencies:
-      '@bcoe/v8-coverage': 0.2.3
-      '@istanbuljs/schema': 0.1.3
-      find-up: 5.0.0
-      foreground-child: 2.0.0
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-reports: 3.1.7
-      rimraf: 3.0.2
-      test-exclude: 6.0.0
-      v8-to-istanbul: 9.3.0
-      yargs: 16.2.0
-      yargs-parser: 20.2.9
 
   cac@6.7.14: {}
 
@@ -3853,12 +3661,6 @@ snapshots:
 
   cli-spinners@2.9.2: {}
 
-  cliui@7.0.4:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3873,8 +3675,6 @@ snapshots:
 
   commander@4.1.1: {}
 
-  concat-map@0.0.1: {}
-
   concat-stream@2.0.0:
     dependencies:
       buffer-from: 1.1.2
@@ -3887,8 +3687,6 @@ snapshots:
   confbox@0.2.2: {}
 
   consola@3.4.2: {}
-
-  convert-source-map@2.0.0: {}
 
   cosmiconfig@9.0.0(typescript@5.9.2):
     dependencies:
@@ -4011,8 +3809,6 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.9
       '@esbuild/win32-x64': 0.25.9
 
-  escalade@3.2.0: {}
-
   esprima@4.0.1: {}
 
   estree-walker@3.0.3:
@@ -4058,11 +3854,6 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
-  find-up@5.0.0:
-    dependencies:
-      locate-path: 6.0.0
-      path-exists: 4.0.0
-
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
       magic-string: 0.30.17
@@ -4070,11 +3861,6 @@ snapshots:
       rollup: 4.45.3
 
   flatted@3.3.3: {}
-
-  foreground-child@2.0.0:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 3.0.7
 
   foreground-child@3.3.1:
     dependencies:
@@ -4093,12 +3879,8 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
-  fs.realpath@1.0.0: {}
-
   fsevents@2.3.3:
     optional: true
-
-  get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.3.0: {}
 
@@ -4127,15 +3909,6 @@ snapshots:
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
-
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
 
   globby@11.1.0:
     dependencies:
@@ -4187,11 +3960,6 @@ snapshots:
       resolve-from: 4.0.0
 
   import-meta-resolve@4.1.0: {}
-
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
 
   inherits@2.0.4: {}
 
@@ -4312,10 +4080,6 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
-  locate-path@6.0.0:
-    dependencies:
-      p-locate: 5.0.0
-
   lodash.sortby@4.7.0: {}
 
   lodash.startcase@4.4.0: {}
@@ -4357,10 +4121,6 @@ snapshots:
   minimatch@10.0.3:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
-
-  minimatch@3.1.2:
-    dependencies:
-      brace-expansion: 1.1.12
 
   minimatch@9.0.5:
     dependencies:
@@ -4440,10 +4200,6 @@ snapshots:
 
   object-assign@4.1.1: {}
 
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
-
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
@@ -4474,17 +4230,9 @@ snapshots:
     dependencies:
       p-try: 2.2.0
 
-  p-limit@3.1.0:
-    dependencies:
-      yocto-queue: 0.1.0
-
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
-
-  p-locate@5.0.0:
-    dependencies:
-      p-limit: 3.1.0
 
   p-map@2.1.0: {}
 
@@ -4516,8 +4264,6 @@ snapshots:
       type-fest: 3.13.1
 
   path-exists@4.0.0: {}
-
-  path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -4632,8 +4378,6 @@ snapshots:
 
   readdirp@4.1.2: {}
 
-  require-directory@2.1.1: {}
-
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -4648,10 +4392,6 @@ snapshots:
   retry@0.12.0: {}
 
   reusify@1.1.0: {}
-
-  rimraf@3.0.2:
-    dependencies:
-      glob: 7.2.3
 
   rimraf@6.0.1:
     dependencies:
@@ -4701,8 +4441,6 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
-
-  signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 
@@ -4834,12 +4572,6 @@ snapshots:
       - typescript
 
   term-size@2.2.1: {}
-
-  test-exclude@6.0.0:
-    dependencies:
-      '@istanbuljs/schema': 0.1.3
-      glob: 7.2.3
-      minimatch: 3.1.2
 
   test-exclude@7.0.1:
     dependencies:
@@ -5104,12 +4836,6 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  v8-to-istanbul@9.3.0:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.29
-      '@types/istanbul-lib-coverage': 2.0.6
-      convert-source-map: 2.0.0
-
   validate-npm-package-license@3.0.4:
     dependencies:
       spdx-correct: 3.2.0
@@ -5265,24 +4991,6 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.0
 
-  wrappy@1.0.2: {}
-
-  y18n@5.0.8: {}
-
   yaml@2.8.0: {}
-
-  yargs-parser@20.2.9: {}
-
-  yargs@16.2.0:
-    dependencies:
-      cliui: 7.0.4
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 20.2.9
-
-  yocto-queue@0.1.0: {}
 
   zod@4.1.11: {}


### PR DESCRIPTION
This pull request primarily standardizes code style across multiple packages by switching all string literals to double quotes, and updates several dependencies to their latest versions. It also cleans up and reorders dependency sections in `package.json` files for consistency. No functional changes were made to business logic; all updates are related to code formatting, dependency maintenance, and configuration.

**Code style standardization:**

* All source and test files in `hl7v2-builder` and `hl7v2-decode-escapes` packages now use double quotes for string literals, imports, and object keys instead of single quotes. This affects files such as `src/index.ts`, `tsup.config.ts`, `vitest.config.ts`, and test files. [[1]](diffhunk://#diff-27937ab96c9e79fcee96063cb0dae26f0982ea0ca84deeeda8aed80eb2cbea16L9-R17) [[2]](diffhunk://#diff-27937ab96c9e79fcee96063cb0dae26f0982ea0ca84deeeda8aed80eb2cbea16L29-R37) [[3]](diffhunk://#diff-27937ab96c9e79fcee96063cb0dae26f0982ea0ca84deeeda8aed80eb2cbea16L46-R51) [[4]](diffhunk://#diff-27937ab96c9e79fcee96063cb0dae26f0982ea0ca84deeeda8aed80eb2cbea16L72-R83) [[5]](diffhunk://#diff-27937ab96c9e79fcee96063cb0dae26f0982ea0ca84deeeda8aed80eb2cbea16L94-R122) [[6]](diffhunk://#diff-f237bb73c3fb83c6ed059a89052024e2387d643294be2aca34efb92445878c64L1-R8) [[7]](diffhunk://#diff-1cc6c3ba04186ff45ca28106656161fae847fdc1390209ddfe95b1aebcab9aa9L1-R8) [[8]](diffhunk://#diff-9aef929dbd3ff5f81624ebbd466396109b94a8e44648ff8fb45a6131971dc96bL1-R6) [[9]](diffhunk://#diff-9aef929dbd3ff5f81624ebbd466396109b94a8e44648ff8fb45a6131971dc96bL18-R25) [[10]](diffhunk://#diff-9aef929dbd3ff5f81624ebbd466396109b94a8e44648ff8fb45a6131971dc96bL51-R49) [[11]](diffhunk://#diff-9aef929dbd3ff5f81624ebbd466396109b94a8e44648ff8fb45a6131971dc96bL65-R86) [[12]](diffhunk://#diff-9aef929dbd3ff5f81624ebbd466396109b94a8e44648ff8fb45a6131971dc96bL110-R108) [[13]](diffhunk://#diff-2cefeab91061b800ed326530263422c5b98dcff3460d08d3a728b3b545900095L1-R25) [[14]](diffhunk://#diff-2cefeab91061b800ed326530263422c5b98dcff3460d08d3a728b3b545900095L41-R108) [[15]](diffhunk://#diff-584098e30cfd8a6e6e0f77460ab8e1a1c7101ac0c9d8eb82afc10d817d89eaf3L1-R13) [[16]](diffhunk://#diff-0d7ec8f4f234411606a2a948d2fc3b1c29781d1d32f5d3009010cdb07aadd4fbL1-R8) [[17]](diffhunk://#diff-88c143413bc448b2e380cb27858da544e50cf9d88ec4a09fd54f8855234b80a6L1-R13) [[18]](diffhunk://#diff-c227b889d43d47336308dd2b7a35c319c565fdab5504fae77aeb06f9567dd1ccL1-R13)

**Dependency and configuration updates:**

* Updated `@types/node` to version `24.5.2` in all relevant `package.json` files for consistency and latest type support. [[1]](diffhunk://#diff-4fae150722f0e76976c8f5f332544e62ced6cef8dc8638e80e257fc123084801L17-R25) [[2]](diffhunk://#diff-59dd3489c533ae0292e409aab219db759e0114d94055299f97f74a685b471826L27-R39) [[3]](diffhunk://#diff-21147ffe3083b49cc0c26e6f6ecb0d8500beb71be21bbd3d2dafeda9623b56a6L25-R25) [[4]](diffhunk://#diff-f7494b149b1aaa01e9a44d09f5746fd1fe44d861ea7a83f7d9636aa81208914eL35-L37) [[5]](diffhunk://#diff-b83f410af24e9f871d6a74619b89e82b7b951cf73fce478a453afcf4d5e30c5aL34-L36)
* Updated `ultracite` dependency to version `5.4.5` in the root `package.json`.
* Reordered and deduplicated dependencies and devDependencies in several `package.json` files, moving all type dependencies to devDependencies and ensuring workspace references are consistent. [[1]](diffhunk://#diff-4fae150722f0e76976c8f5f332544e62ced6cef8dc8638e80e257fc123084801L17-R25) [[2]](diffhunk://#diff-59dd3489c533ae0292e409aab219db759e0114d94055299f97f74a685b471826L27-R39)
* Updated the format and target options in all `tsup.config.ts` files to use double quotes and to ensure ES module output and ES2022 target. [[1]](diffhunk://#diff-f237bb73c3fb83c6ed059a89052024e2387d643294be2aca34efb92445878c64L1-R8) [[2]](diffhunk://#diff-584098e30cfd8a6e6e0f77460ab8e1a1c7101ac0c9d8eb82afc10d817d89eaf3L1-R13) [[3]](diffhunk://#diff-c227b889d43d47336308dd2b7a35c319c565fdab5504fae77aeb06f9567dd1ccL1-R13)

These changes improve maintainability and consistency across the codebase without affecting runtime behavior.