### PR TITLE
feat: add hl7v2-lint-profile-required-fields rule

### DIFF
--- a/packages/hl7v2-lint-profile-required-fields/package.json
+++ b/packages/hl7v2-lint-profile-required-fields/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@rethinkhealth/hl7v2-lint-profile-required-fields",
+  "version": "0.0.0",
+  "description": "Lint rule to validate required fields per HL7v2 profile",
+  "keywords": [
+    "health",
+    "healthcare",
+    "hl7",
+    "hl7v2",
+    "nodejs",
+    "typescript"
+  ],
+  "homepage": "https://www.rethinkhealth.io/hl7v2/docs",
+  "license": "MIT",
+  "author": {
+    "name": "Melek Somai",
+    "email": "melek@rethinkhealth.io"
+  },
+  "repository": "rethinkhealth/hl7v2.git",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup && tsc --emitDeclarationOnly",
+    "check-types": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@rethinkhealth/hl7v2-ast": "workspace:*",
+    "@rethinkhealth/hl7v2-lint-profile-utils": "workspace:*",
+    "@rethinkhealth/hl7v2-util-visit": "workspace:*",
+    "unified-lint-rule": "3.0.1"
+  },
+  "devDependencies": {
+    "@rethinkhealth/hl7v2-builder": "workspace:*",
+    "@rethinkhealth/testing": "workspace:*",
+    "@rethinkhealth/tsconfig": "workspace:*",
+    "@types/node": "^24.10.1",
+    "@vitest/coverage-v8": "4.0.18",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "unified": "11.0.5",
+    "vfile": "^6.0.3",
+    "vitest": "4.0.18"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "packageManager": "pnpm@10.14.0"
+}

--- a/packages/hl7v2-lint-profile-required-fields/src/index.ts
+++ b/packages/hl7v2-lint-profile-required-fields/src/index.ts
@@ -1,0 +1,82 @@
+import type { Nodes, Root, Segment } from "@rethinkhealth/hl7v2-ast";
+import type { OnMissingProfile } from "@rethinkhealth/hl7v2-lint-profile-utils";
+import {
+  getFieldValue,
+  resolveFieldDefinition,
+  resolveVersion,
+} from "@rethinkhealth/hl7v2-lint-profile-utils";
+import { visit } from "@rethinkhealth/hl7v2-util-visit";
+import { lintRule } from "unified-lint-rule";
+
+export interface RequiredFieldsOptions {
+  onMissingProfile?: OnMissingProfile;
+}
+
+const hl7v2LintRequiredFields = lintRule<Root, RequiredFieldsOptions>(
+  {
+    origin: "hl7v2-lint:required-fields",
+  },
+  async (tree, file, options) => {
+    const versionResult = resolveVersion(tree);
+    if (!versionResult.ok) {
+      file.message(versionResult.reason, {
+        ancestors: [tree],
+        place: tree.position,
+      });
+      return;
+    }
+
+    const onMissing = options?.onMissingProfile ?? "skip";
+
+    const segments: { node: Segment; ancestors: Nodes[] }[] = [];
+    visit(tree, "segment", (node, parents) => {
+      segments.push({
+        node: node as Segment,
+        ancestors: [...parents] as Nodes[],
+      });
+    });
+
+    for (const { node, ancestors } of segments) {
+      const result = await resolveFieldDefinition(tree, node.name);
+
+      if (!result.ok) {
+        if (onMissing === "warn") {
+          file.message(result.reason, {
+            ancestors: [...ancestors, node],
+            place: node.position,
+          });
+        } else if (onMissing === "fail") {
+          file.fail(result.reason, {
+            ancestors: [...ancestors, node],
+            place: node.position,
+          });
+        }
+        continue;
+      }
+
+      const fieldDef = result.value;
+
+      for (const sequence of fieldDef.requiredSequences) {
+        const fieldNode = node.children[sequence - 1];
+        const profile = fieldDef.bySequence.get(sequence);
+
+        if (!fieldNode || !getFieldValue(fieldNode)) {
+          const name = profile?.name ? ` (${profile.name})` : "";
+          file.message(
+            `Required field ${node.name}-${sequence}${name} is missing or empty`,
+            {
+              ancestors: [
+                ...ancestors,
+                node,
+                ...(fieldNode ? [fieldNode] : []),
+              ],
+              place: fieldNode?.position ?? node.position,
+            }
+          );
+        }
+      }
+    }
+  }
+);
+
+export default hl7v2LintRequiredFields;

--- a/packages/hl7v2-lint-profile-required-fields/tests/index.test.ts
+++ b/packages/hl7v2-lint-profile-required-fields/tests/index.test.ts
@@ -1,0 +1,186 @@
+import type { Root } from "@rethinkhealth/hl7v2-ast";
+import { c, f, m, s } from "@rethinkhealth/hl7v2-builder";
+import { unified } from "unified";
+import { VFile } from "vfile";
+import { describe, expect, it } from "vitest";
+
+import hl7v2LintRequiredFields from "../src";
+
+/**
+ * Create a tree with version metadata pre-set (as if the annotator ran).
+ */
+function treeWithVersion(
+  version: string,
+  ...segments: Parameters<typeof m>
+): Root {
+  const tree = m(...segments);
+  tree.data = {
+    messageInfo: {
+      version,
+    },
+  };
+  return tree;
+}
+
+/**
+ * Build a valid MSH segment with all required fields populated.
+ * In v2.5, MSH-1, MSH-2, MSH-7, MSH-9, MSH-10, MSH-11, MSH-12 are required.
+ */
+function validMshSegment() {
+  return s(
+    "MSH",
+    f("|"), // MSH-1: Field Separator (required)
+    f("^~\\&"), // MSH-2: Encoding Characters (required)
+    f("SendApp"), // MSH-3: Sending Application
+    f("SendFac"), // MSH-4: Sending Facility
+    f("RecvApp"), // MSH-5: Receiving Application
+    f("RecvFac"), // MSH-6: Receiving Facility
+    f("20060101120000"), // MSH-7: Date/Time Of Message (required)
+    f(), // MSH-8: Security
+    f(c("ADT"), c("A01"), c("ADT_A01")), // MSH-9: Message Type (required)
+    f("MSG00001"), // MSH-10: Message Control ID (required)
+    f("P"), // MSH-11: Processing ID (required)
+    f("2.5") // MSH-12: Version ID (required)
+  );
+}
+
+/**
+ * Build a PID segment with all required fields populated.
+ * In v2.5, PID-3 (Patient Identifier List) and PID-5 (Patient Name) are required.
+ */
+function validPidSegment() {
+  return s(
+    "PID",
+    f("1"), // PID-1: Set ID
+    f(), // PID-2: Patient ID (optional)
+    f("12345"), // PID-3: Patient Identifier List (required)
+    f(), // PID-4: Alternate Patient ID (optional)
+    f("DOE^JOHN") // PID-5: Patient Name (required)
+  );
+}
+
+describe("hl7v2LintRequiredFields", () => {
+  describe("valid messages", () => {
+    it("reports no warnings when all required fields are present", async () => {
+      const tree = treeWithVersion("2.5", validMshSegment(), validPidSegment());
+      const file = new VFile();
+
+      await unified().use(hl7v2LintRequiredFields).run(tree, file);
+
+      const requiredFieldWarnings = file.messages.filter(
+        (msg) => msg.ruleId === "required-fields"
+      );
+      expect(requiredFieldWarnings).toHaveLength(0);
+    });
+  });
+
+  describe("empty required field", () => {
+    it("reports warning when PID-3 is empty", async () => {
+      const tree = treeWithVersion(
+        "2.5",
+        validMshSegment(),
+        s(
+          "PID",
+          f("1"), // PID-1
+          f(), // PID-2
+          f(), // PID-3: empty (required)
+          f(), // PID-4
+          f("DOE^JOHN") // PID-5 (required, present)
+        )
+      );
+      const file = new VFile();
+
+      await unified().use(hl7v2LintRequiredFields).run(tree, file);
+
+      const pid3Warnings = file.messages.filter(
+        (msg) =>
+          msg.ruleId === "required-fields" && msg.message.includes("PID-3")
+      );
+      expect(pid3Warnings).toHaveLength(1);
+      expect(pid3Warnings[0]?.message).toContain("missing or empty");
+    });
+  });
+
+  describe("missing required field (segment too short)", () => {
+    it("reports warning when segment has fewer fields than required", async () => {
+      const tree = treeWithVersion(
+        "2.5",
+        validMshSegment(),
+        s(
+          "PID",
+          f("1") // PID-1 only — PID-3 and PID-5 are missing
+        )
+      );
+      const file = new VFile();
+
+      await unified().use(hl7v2LintRequiredFields).run(tree, file);
+
+      const warnings = file.messages.filter(
+        (msg) =>
+          msg.ruleId === "required-fields" && msg.message.includes("PID-")
+      );
+      // Should report at least PID-3 and PID-5
+      expect(warnings.length).toBeGreaterThanOrEqual(2);
+
+      const pid3Warning = warnings.find((msg) => msg.message.includes("PID-3"));
+      const pid5Warning = warnings.find((msg) => msg.message.includes("PID-5"));
+      expect(pid3Warning).toBeDefined();
+      expect(pid5Warning).toBeDefined();
+    });
+  });
+
+  describe("Z-segments", () => {
+    it("skips Z-segments by default (onMissingProfile: skip)", async () => {
+      const tree = treeWithVersion(
+        "2.5",
+        validMshSegment(),
+        validPidSegment(),
+        s("ZZZ", f("custom data"))
+      );
+      const file = new VFile();
+
+      await unified().use(hl7v2LintRequiredFields).run(tree, file);
+
+      const zWarnings = file.messages.filter(
+        (msg) => msg.ruleId === "required-fields" && msg.message.includes("ZZZ")
+      );
+      expect(zWarnings).toHaveLength(0);
+    });
+
+    it("warns about Z-segments when onMissingProfile is 'warn'", async () => {
+      const tree = treeWithVersion(
+        "2.5",
+        validMshSegment(),
+        validPidSegment(),
+        s("ZZZ", f("custom data"))
+      );
+      const file = new VFile();
+
+      await unified()
+        .use(hl7v2LintRequiredFields, { onMissingProfile: "warn" })
+        .run(tree, file);
+
+      const zWarnings = file.messages.filter(
+        (msg) => msg.ruleId === "required-fields" && msg.message.includes("ZZZ")
+      );
+      expect(zWarnings).toHaveLength(1);
+      expect(zWarnings[0]?.message).toContain("ZZZ");
+    });
+  });
+
+  describe("missing version", () => {
+    it("reports warning when version is missing", async () => {
+      const tree = m(s("MSH"), s("PID"));
+      const file = new VFile();
+
+      await unified().use(hl7v2LintRequiredFields).run(tree, file);
+
+      expect(file.messages).toHaveLength(1);
+      expect(file.messages[0]?.message).toContain("MSH-12");
+      expect(file.messages[0]).toMatchObject({
+        ruleId: "required-fields",
+        source: "hl7v2-lint",
+      });
+    });
+  });
+});

--- a/packages/hl7v2-lint-profile-required-fields/tsconfig.json
+++ b/packages/hl7v2-lint-profile-required-fields/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@rethinkhealth/tsconfig/library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "strictNullChecks": true
+  }
+}

--- a/packages/hl7v2-lint-profile-required-fields/tsup.config.ts
+++ b/packages/hl7v2-lint-profile-required-fields/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    /**
+     * Directories and files should be bundled so that the resulting files line
+     * up with the TSC generated type definitions.
+     */
+    index: "src/index.ts",
+  },
+  format: ["esm"],
+  sourcemap: true,
+  target: "es2022",
+
+  /**
+   * Do not use tsup for generating d.ts files because it can not generate type
+   * the definition maps required for go-to-definition to work in our IDE. We
+   * use tsc for that.
+   */
+});

--- a/packages/hl7v2-lint-profile-required-fields/vitest.config.ts
+++ b/packages/hl7v2-lint-profile-required-fields/vitest.config.ts
@@ -1,0 +1,11 @@
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      name: "hl7v2-lint-profile-required-fields",
+    },
+  })
+);


### PR DESCRIPTION
## Summary [6/7]

Lint rule that validates required fields per HL7v2 profile.

- Iterates `fieldDefinition.requiredSequences` for each segment
- Reports missing or empty fields marked as required
- PID-3 and PID-5 are required in v2.5
- `onMissingProfile` option (default: `"skip"`)

**Stack:** PR 6 of 7. Depends on #416.

## Test plan
- [x] 6 tests pass
- [x] Build and type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)