### PR TITLE
feat: add hl7v2-lint-profile-table-values rule

### DIFF
--- a/packages/hl7v2-lint-profile-table-values/package.json
+++ b/packages/hl7v2-lint-profile-table-values/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@rethinkhealth/hl7v2-lint-profile-table-values",
+  "version": "0.0.0",
+  "description": "Linting based on HL7-type table value validation",
+  "keywords": [
+    "health",
+    "healthcare",
+    "hl7",
+    "hl7v2",
+    "nodejs",
+    "typescript"
+  ],
+  "homepage": "https://www.rethinkhealth.io/hl7v2/docs",
+  "license": "MIT",
+  "author": {
+    "name": "Melek Somai",
+    "email": "melek@rethinkhealth.io"
+  },
+  "repository": "rethinkhealth/hl7v2.git",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup && tsc --emitDeclarationOnly",
+    "check-types": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@rethinkhealth/hl7v2-ast": "workspace:*",
+    "@rethinkhealth/hl7v2-lint-profile-utils": "workspace:*",
+    "@rethinkhealth/hl7v2-util-visit": "workspace:*",
+    "unified-lint-rule": "3.0.1"
+  },
+  "devDependencies": {
+    "@rethinkhealth/hl7v2-builder": "workspace:*",
+    "@rethinkhealth/testing": "workspace:*",
+    "@rethinkhealth/tsconfig": "workspace:*",
+    "@types/node": "^24.10.1",
+    "@vitest/coverage-v8": "4.0.18",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "unified": "11.0.5",
+    "vfile": "^6.0.3",
+    "vitest": "4.0.18"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "packageManager": "pnpm@10.14.0"
+}

--- a/packages/hl7v2-lint-profile-table-values/src/index.ts
+++ b/packages/hl7v2-lint-profile-table-values/src/index.ts
@@ -1,0 +1,160 @@
+import type { Field, Nodes, Root, Segment } from "@rethinkhealth/hl7v2-ast";
+import type { OnMissingProfile } from "@rethinkhealth/hl7v2-lint-profile-utils";
+import {
+  getFieldValue,
+  resolveFieldDefinition,
+  resolveTableDefinition,
+  resolveVersion,
+} from "@rethinkhealth/hl7v2-lint-profile-utils";
+import { visit } from "@rethinkhealth/hl7v2-util-visit";
+import { lintRule } from "unified-lint-rule";
+
+export type { OnMissingProfile };
+
+/**
+ * Options for the table values lint rule.
+ */
+export interface TableValuesOptions {
+  /**
+   * Behaviour when a required profile (field or table) is not available.
+   *
+   * - `"skip"` (default) — silently skip validation
+   * - `"warn"` — emit a warning via VFile
+   * - `"fail"` — emit an error via VFile
+   */
+  onMissingProfile?: OnMissingProfile;
+}
+
+const HL7_PREFIX = /^HL7/;
+
+/**
+ * Lint rule that validates coded field values against HL7-type tables.
+ *
+ * For each segment field that references an HL7 table, the rule checks
+ * whether the field value is a valid code in that table. User-defined
+ * tables are skipped entirely.
+ *
+ * @example
+ * ```typescript
+ * unified().use(hl7v2LintTableValues);
+ * unified().use(hl7v2LintTableValues, { onMissingProfile: "warn" });
+ * ```
+ */
+const hl7v2LintTableValues = lintRule<Root, TableValuesOptions>(
+  {
+    origin: "hl7v2-lint:table-values",
+  },
+  async (tree, file, options) => {
+    const onMissing = options?.onMissingProfile ?? "skip";
+
+    // 1. Resolve version — bail if unavailable.
+    const versionResult = resolveVersion(tree);
+    if (!versionResult.ok) {
+      file.message(versionResult.reason, {
+        ancestors: [tree],
+        place: tree.position,
+      });
+      return;
+    }
+
+    // 2. Collect segments to process (visit is sync, profile loads are async).
+    const segmentWork: {
+      segmentId: string;
+      fields: Field[];
+      parents: Nodes[];
+      node: Segment;
+    }[] = [];
+
+    visit(tree, "segment", (node, parents) => {
+      segmentWork.push({
+        segmentId: node.name,
+        fields: node.children,
+        parents: [...parents],
+        node,
+      });
+    });
+
+    // 3. Process each segment.
+    for (const { segmentId, fields, parents, node } of segmentWork) {
+      // Skip Z-segments (site-defined) — no standard profile available.
+      if (segmentId.startsWith("Z")) {
+        continue;
+      }
+
+      const fieldDefResult = await resolveFieldDefinition(tree, segmentId);
+      if (!fieldDefResult.ok) {
+        if (onMissing === "warn") {
+          file.message(fieldDefResult.reason, {
+            ancestors: [...parents, node],
+            place: node.position,
+          });
+        } else if (onMissing === "fail") {
+          file.fail(fieldDefResult.reason, {
+            ancestors: [...parents, node],
+            place: node.position,
+          });
+        }
+        continue;
+      }
+
+      const fieldDef = fieldDefResult.value;
+
+      for (let i = 0; i < fields.length; i++) {
+        const fieldNode = fields[i];
+        if (!fieldNode) {
+          continue;
+        }
+
+        const profile = fieldDef.bySequence.get(i + 1);
+        if (!profile?.table) {
+          continue;
+        }
+
+        // Strip "HL7" prefix: profile stores "HL70003", loader expects "0003".
+        const tableId = profile.table.replace(HL7_PREFIX, "");
+
+        const tableResult = await resolveTableDefinition(tree, tableId);
+        if (!tableResult.ok) {
+          if (onMissing === "warn") {
+            file.message(tableResult.reason, {
+              ancestors: [...parents, node, fieldNode],
+              place: fieldNode.position,
+            });
+          } else if (onMissing === "fail") {
+            file.fail(tableResult.reason, {
+              ancestors: [...parents, node, fieldNode],
+              place: fieldNode.position,
+            });
+          }
+          continue;
+        }
+
+        const tableDef = tableResult.value;
+
+        // Only validate HL7-type tables. Skip user-defined tables.
+        if (tableDef.type !== "hl7") {
+          continue;
+        }
+
+        const value = getFieldValue(fieldNode);
+        if (!value) {
+          continue;
+        }
+
+        if (!tableDef.codes.has(value)) {
+          const sequence = i + 1;
+          const name = profile.name ?? profile.id;
+          file.message(
+            `Field ${segmentId}-${sequence} (${name}) value '${value}' is not in table ${tableId} (${tableDef.description})`,
+            {
+              ancestors: [...parents, node, fieldNode],
+              place: fieldNode.position,
+            }
+          );
+        }
+      }
+    }
+  }
+);
+
+export default hl7v2LintTableValues;

--- a/packages/hl7v2-lint-profile-table-values/tests/index.test.ts
+++ b/packages/hl7v2-lint-profile-table-values/tests/index.test.ts
@@ -1,0 +1,124 @@
+import { f, m, s } from "@rethinkhealth/hl7v2-builder";
+import { unified } from "unified";
+import { VFile } from "vfile";
+import { describe, expect, it } from "vitest";
+
+import hl7v2LintTableValues from "../src";
+
+/**
+ * Helper: build a v2.5 tree with annotated version info.
+ */
+function v25Tree(...segments: ReturnType<typeof s>[]) {
+  const tree = m(...segments);
+  tree.data = {
+    messageInfo: { version: "2.5" },
+  };
+  return tree;
+}
+
+describe("hl7v2LintTableValues", () => {
+  describe("valid table values", () => {
+    it("accepts a valid code in an HL7 table (EVN-1 = A01)", async () => {
+      // EVN-1 (Event Type Code) references table HL70003 → "0003" (hl7 type).
+      // "A01" is a valid code.
+      const tree = v25Tree(s("MSH"), s("EVN", f("A01")));
+      const file = new VFile();
+
+      await unified().use(hl7v2LintTableValues).run(tree, file);
+
+      const tableErrors = file.messages.filter((msg) =>
+        msg.message.includes("is not in table")
+      );
+      expect(tableErrors).toHaveLength(0);
+    });
+  });
+
+  describe("invalid table values", () => {
+    it("reports an invalid code in an HL7 table (EVN-1 = ZZZ)", async () => {
+      const tree = v25Tree(s("MSH"), s("EVN", f("ZZZ")));
+      const file = new VFile();
+
+      await unified().use(hl7v2LintTableValues).run(tree, file);
+
+      const tableErrors = file.messages.filter((msg) =>
+        msg.message.includes("is not in table")
+      );
+      expect(tableErrors).toHaveLength(1);
+      expect(tableErrors[0]?.message).toContain("EVN-1");
+      expect(tableErrors[0]?.message).toContain("ZZZ");
+      expect(tableErrors[0]).toMatchObject({
+        ruleId: "table-values",
+        source: "hl7v2-lint",
+      });
+    });
+  });
+
+  describe("empty fields", () => {
+    it("skips empty fields without reporting", async () => {
+      const tree = v25Tree(s("MSH"), s("EVN", f("")));
+      const file = new VFile();
+
+      await unified().use(hl7v2LintTableValues).run(tree, file);
+
+      const tableErrors = file.messages.filter((msg) =>
+        msg.message.includes("is not in table")
+      );
+      expect(tableErrors).toHaveLength(0);
+    });
+  });
+
+  describe("user-type tables", () => {
+    it("skips user-type tables (PID-8 references table 0001 with type user)", async () => {
+      // PID-8 (Administrative Sex) references table HL70001 → "0001" (user type).
+      // Even an invalid value should not produce a warning.
+      const tree = v25Tree(
+        s("MSH"),
+        s(
+          "PID",
+          f(""), // PID-1
+          f(""), // PID-2
+          f(""), // PID-3
+          f(""), // PID-4
+          f(""), // PID-5
+          f(""), // PID-6
+          f(""), // PID-7
+          f("INVALID_SEX") // PID-8 — user-type table, should be skipped
+        )
+      );
+      const file = new VFile();
+
+      await unified().use(hl7v2LintTableValues).run(tree, file);
+
+      const tableErrors = file.messages.filter((msg) =>
+        msg.message.includes("is not in table")
+      );
+      expect(tableErrors).toHaveLength(0);
+    });
+  });
+
+  describe("Z-segments", () => {
+    it("skips Z-segments by default", async () => {
+      const tree = v25Tree(s("MSH"), s("ZZZ", f("ANYTHING")));
+      const file = new VFile();
+
+      await unified().use(hl7v2LintTableValues).run(tree, file);
+
+      const tableErrors = file.messages.filter((msg) =>
+        msg.message.includes("is not in table")
+      );
+      expect(tableErrors).toHaveLength(0);
+    });
+  });
+
+  describe("missing version", () => {
+    it("reports when version is missing", async () => {
+      const tree = m(s("MSH"), s("EVN", f("A01")));
+      const file = new VFile();
+
+      await unified().use(hl7v2LintTableValues).run(tree, file);
+
+      expect(file.messages).toHaveLength(1);
+      expect(file.messages[0]?.message).toContain("Missing version");
+    });
+  });
+});

--- a/packages/hl7v2-lint-profile-table-values/tsconfig.json
+++ b/packages/hl7v2-lint-profile-table-values/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@rethinkhealth/tsconfig/library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "strictNullChecks": true
+  }
+}

--- a/packages/hl7v2-lint-profile-table-values/tsup.config.ts
+++ b/packages/hl7v2-lint-profile-table-values/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    /**
+     * Directories and files should be bundled so that the resulting files line
+     * up with the TSC generated type definitions.
+     */
+    index: "src/index.ts",
+  },
+  format: ["esm"],
+  sourcemap: true,
+  target: "es2022",
+
+  /**
+   * Do not use tsup for generating d.ts files because it can not generate type
+   * the definition maps required for go-to-definition to work in our IDE. We
+   * use tsc for that.
+   */
+});

--- a/packages/hl7v2-lint-profile-table-values/vitest.config.ts
+++ b/packages/hl7v2-lint-profile-table-values/vitest.config.ts
@@ -1,0 +1,11 @@
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      name: "hl7v2-lint-profile-table-values",
+    },
+  })
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -751,6 +751,52 @@ importers:
         specifier: 4.0.18
         version: 4.0.18(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.8.1)
 
+  packages/hl7v2-lint-profile-table-values:
+    dependencies:
+      '@rethinkhealth/hl7v2-ast':
+        specifier: workspace:*
+        version: link:../hl7v2-ast
+      '@rethinkhealth/hl7v2-lint-profile-utils':
+        specifier: workspace:*
+        version: link:../hl7v2-lint-profile-utils
+      '@rethinkhealth/hl7v2-util-visit':
+        specifier: workspace:*
+        version: link:../hl7v2-util-visit
+      unified-lint-rule:
+        specifier: 3.0.1
+        version: 3.0.1
+    devDependencies:
+      '@rethinkhealth/hl7v2-builder':
+        specifier: workspace:*
+        version: link:../hl7v2-builder
+      '@rethinkhealth/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@rethinkhealth/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.10.1
+      '@vitest/coverage-v8':
+        specifier: 4.0.18
+        version: 4.0.18(vitest@4.0.18(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.8.1))
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      unified:
+        specifier: 11.0.5
+        version: 11.0.5
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.0.18
+        version: 4.0.18(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.8.1)
+
   packages/hl7v2-lint-profile-utils:
     dependencies:
       '@rethinkhealth/hl7v2-ast':


### PR DESCRIPTION
## Summary [3/7]

Lint rule that validates coded field values against HL7-type tables.

- Strips `HL7` prefix from table references (e.g., `HL70003` → `0003`)
- Only validates `hl7`-type tables, skips `user`-type
- Uses EVN-1 (Event Type Code, table 0003) as primary test case
- `onMissingProfile` option (default: `"skip"`)

**Stack:** PR 3 of 7. Depends on #420.

## Test plan
- [x] 6 tests pass (valid code, invalid code, empty field, user table skip, Z-segment skip, missing version)
- [x] Build and type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)