### PR TITLE
feat: add hl7v2-lint-profile-field-repetition rule

### DIFF
--- a/packages/hl7v2-lint-profile-field-repetition/package.json
+++ b/packages/hl7v2-lint-profile-field-repetition/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@rethinkhealth/hl7v2-lint-profile-field-repetition",
+  "version": "0.0.0",
+  "description": "Lint rule that flags fields with multiple repetitions when the profile says repeatable: false",
+  "keywords": [
+    "health",
+    "healthcare",
+    "hl7",
+    "hl7v2",
+    "nodejs",
+    "typescript"
+  ],
+  "homepage": "https://www.rethinkhealth.io/hl7v2/docs",
+  "license": "MIT",
+  "author": {
+    "name": "Melek Somai",
+    "email": "melek@rethinkhealth.io"
+  },
+  "repository": "rethinkhealth/hl7v2.git",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup && tsc --emitDeclarationOnly",
+    "check-types": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@rethinkhealth/hl7v2-ast": "workspace:*",
+    "@rethinkhealth/hl7v2-lint-profile-utils": "workspace:*",
+    "@rethinkhealth/hl7v2-util-visit": "workspace:*",
+    "unified-lint-rule": "3.0.1"
+  },
+  "devDependencies": {
+    "@rethinkhealth/hl7v2-builder": "workspace:*",
+    "@rethinkhealth/testing": "workspace:*",
+    "@rethinkhealth/tsconfig": "workspace:*",
+    "@types/node": "^24.10.1",
+    "@vitest/coverage-v8": "4.0.18",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "unified": "11.0.5",
+    "vfile": "^6.0.3",
+    "vitest": "4.0.18"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "packageManager": "pnpm@10.14.0"
+}

--- a/packages/hl7v2-lint-profile-field-repetition/src/index.ts
+++ b/packages/hl7v2-lint-profile-field-repetition/src/index.ts
@@ -1,0 +1,79 @@
+import type { Nodes, Root, Segment } from "@rethinkhealth/hl7v2-ast";
+import type { OnMissingProfile } from "@rethinkhealth/hl7v2-lint-profile-utils";
+import {
+  resolveFieldDefinition,
+  resolveVersion,
+} from "@rethinkhealth/hl7v2-lint-profile-utils";
+import { visit } from "@rethinkhealth/hl7v2-util-visit";
+import { lintRule } from "unified-lint-rule";
+
+export interface FieldRepetitionOptions {
+  onMissingProfile?: OnMissingProfile;
+}
+
+const hl7v2LintFieldRepetition = lintRule<Root, FieldRepetitionOptions>(
+  {
+    origin: "hl7v2-lint:field-repetition",
+  },
+  async (tree, file, options) => {
+    const versionResult = resolveVersion(tree);
+    if (!versionResult.ok) {
+      file.message(versionResult.reason, {
+        ancestors: [tree],
+        place: tree.position,
+      });
+      return;
+    }
+
+    const onMissing = options?.onMissingProfile ?? "skip";
+
+    const segments: { node: Segment; ancestors: Nodes[] }[] = [];
+    visit(tree, "segment", (node, parents) => {
+      segments.push({ node, ancestors: [...parents] });
+    });
+
+    for (const { node, ancestors } of segments) {
+      const result = await resolveFieldDefinition(tree, node.name);
+
+      if (!result.ok) {
+        if (onMissing === "warn") {
+          file.message(result.reason, {
+            ancestors: [...ancestors, node],
+            place: node.position,
+          });
+        } else if (onMissing === "fail") {
+          file.fail(result.reason, {
+            ancestors: [...ancestors, node],
+            place: node.position,
+          });
+        }
+        continue;
+      }
+
+      const fieldDef = result.value;
+
+      for (let i = 0; i < node.children.length; i++) {
+        const fieldNode = node.children[i]!;
+        const sequence = i + 1;
+        const profile = fieldDef.bySequence.get(sequence);
+
+        if (!profile) {continue;}
+        if (profile.repeatable) {continue;}
+
+        const repetitionCount = fieldNode.children.length;
+        if (repetitionCount > 1) {
+          const name = profile.name ? ` (${profile.name})` : "";
+          file.message(
+            `Field ${node.name}-${sequence}${name} is not repeatable but has ${repetitionCount} repetitions`,
+            {
+              ancestors: [...ancestors, node, fieldNode],
+              place: fieldNode.position,
+            }
+          );
+        }
+      }
+    }
+  }
+);
+
+export default hl7v2LintFieldRepetition;

--- a/packages/hl7v2-lint-profile-field-repetition/tests/index.test.ts
+++ b/packages/hl7v2-lint-profile-field-repetition/tests/index.test.ts
@@ -1,0 +1,142 @@
+import { f, m, r, s } from "@rethinkhealth/hl7v2-builder";
+import { unified } from "unified";
+import { VFile } from "vfile";
+import { describe, expect, it } from "vitest";
+
+import hl7v2LintFieldRepetition from "../src";
+
+/**
+ * Build a minimal MSH segment with version in MSH-12.
+ * MSH fields: MSH-1 (|), MSH-2 (^~\\&), MSH-3..MSH-11 (empty), MSH-12 (version).
+ */
+function mshWithVersion(version: string) {
+  return s(
+    "MSH",
+    f("|"),
+    f("^~\\&"),
+    f(""),
+    f(""),
+    f(""),
+    f(""),
+    f(""),
+    f(""),
+    f(""),
+    f(""),
+    f(""),
+    f(version)
+  );
+}
+
+describe("hl7v2LintFieldRepetition", () => {
+  describe("non-repeatable field with single value", () => {
+    it("produces no warnings", async () => {
+      // PID-1 (Set ID) is repeatable: false in v2.5
+      const tree = m(
+        mshWithVersion("2.5"),
+        s("PID", f("1")) // PID-1 with single value
+      );
+      const file = new VFile();
+
+      await unified().use(hl7v2LintFieldRepetition).run(tree, file);
+
+      const repetitionErrors = file.messages.filter((msg) =>
+        msg.message.includes("not repeatable")
+      );
+      expect(repetitionErrors).toHaveLength(0);
+    });
+  });
+
+  describe("repeatable field with multiple repetitions", () => {
+    it("produces no warnings for PID-3", async () => {
+      // PID-3 (Patient Identifier List) is repeatable: true in v2.5
+      const tree = m(
+        mshWithVersion("2.5"),
+        s(
+          "PID",
+          f("1"), // PID-1
+          f(""), // PID-2
+          f(r("ID1"), r("ID2"), r("ID3")) // PID-3 with 3 repetitions
+        )
+      );
+      const file = new VFile();
+
+      await unified().use(hl7v2LintFieldRepetition).run(tree, file);
+
+      const repetitionErrors = file.messages.filter((msg) =>
+        msg.message.includes("not repeatable")
+      );
+      expect(repetitionErrors).toHaveLength(0);
+    });
+  });
+
+  describe("non-repeatable field with multiple repetitions", () => {
+    it("reports PID-1 with 2 repetitions", async () => {
+      // PID-1 (Set ID) is repeatable: false in v2.5
+      const tree = m(
+        mshWithVersion("2.5"),
+        s(
+          "PID",
+          f(r("1"), r("2")) // PID-1 with 2 repetitions
+        )
+      );
+      const file = new VFile();
+
+      await unified().use(hl7v2LintFieldRepetition).run(tree, file);
+
+      const repetitionErrors = file.messages.filter((msg) =>
+        msg.message.includes("not repeatable")
+      );
+      expect(repetitionErrors).toHaveLength(1);
+      expect(repetitionErrors[0]?.message).toContain("PID-1");
+      expect(repetitionErrors[0]?.message).toContain("not repeatable");
+      expect(repetitionErrors[0]?.message).toContain("2 repetitions");
+      expect(repetitionErrors[0]).toMatchObject({
+        ruleId: "field-repetition",
+        source: "hl7v2-lint",
+      });
+    });
+  });
+
+  describe("Z-segments", () => {
+    it("skips Z-segments by default", async () => {
+      const tree = m(
+        mshWithVersion("2.5"),
+        s("ZZZ", f(r("1"), r("2"))) // Z-segment with repeated field
+      );
+      const file = new VFile();
+
+      await unified().use(hl7v2LintFieldRepetition).run(tree, file);
+
+      expect(file.messages).toHaveLength(0);
+    });
+
+    it("warns about Z-segments when onMissingProfile is warn", async () => {
+      const tree = m(mshWithVersion("2.5"), s("ZZZ", f(r("1"), r("2"))));
+      const file = new VFile();
+
+      await unified()
+        .use(hl7v2LintFieldRepetition, { onMissingProfile: "warn" })
+        .run(tree, file);
+
+      expect(file.messages).toHaveLength(1);
+      expect(file.messages[0]?.message).toContain("ZZZ");
+      expect(file.messages[0]?.message).toContain("ZZZ");
+    });
+  });
+
+  describe("missing version", () => {
+    it("reports missing version", async () => {
+      const tree = m(s("MSH", f("|"), f("^~\\&")), s("PID", f("1")));
+      const file = new VFile();
+
+      await unified().use(hl7v2LintFieldRepetition).run(tree, file);
+
+      expect(file.messages).toHaveLength(1);
+      expect(file.messages[0]?.message).toContain("MSH-12");
+      expect(file.messages[0]).toMatchObject({
+        ruleId: "field-repetition",
+        source: "hl7v2-lint",
+      });
+    });
+  });
+});

--- a/packages/hl7v2-lint-profile-field-repetition/tsconfig.json
+++ b/packages/hl7v2-lint-profile-field-repetition/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@rethinkhealth/tsconfig/library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "strictNullChecks": true
+  }
+}

--- a/packages/hl7v2-lint-profile-field-repetition/tsup.config.ts
+++ b/packages/hl7v2-lint-profile-field-repetition/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    /**
+     * Directories and files should be bundled so that the resulting files line
+     * up with the TSC generated type definitions.
+     */
+    index: "src/index.ts",
+  },
+  format: ["esm"],
+  sourcemap: true,
+  target: "es2022",
+
+  /**
+   * Do not use tsup for generating d.ts files because it can not generate type
+   * the definition maps required for go-to-definition to work in our IDE. We
+   * use tsc for that.
+   */
+});

--- a/packages/hl7v2-lint-profile-field-repetition/vitest.config.ts
+++ b/packages/hl7v2-lint-profile-field-repetition/vitest.config.ts
@@ -1,0 +1,11 @@
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      name: "hl7v2-lint-profile-field-repetition",
+    },
+  })
+);


### PR DESCRIPTION
## Summary [4/7]

Lint rule that flags fields with multiple repetitions when the profile declares `repeatable: false`.

- Checks `fieldNode.children.length > 1` for non-repeatable fields
- Reports count of repetitions in message
- `onMissingProfile` option (default: `"skip"`)

**Stack:** PR 4 of 7. Depends on #421.

## Test plan
- [x] 6 tests pass (single value, repeatable field, non-repeatable with reps, Z-segment skip, warn mode, missing version)
- [x] Build and type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)