### PR TITLE
feat: add hl7v2-lint-profile-required-components rule

### DIFF
--- a/packages/hl7v2-lint-profile-required-components/package.json
+++ b/packages/hl7v2-lint-profile-required-components/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@rethinkhealth/hl7v2-lint-profile-required-components",
+  "version": "0.0.0",
+  "description": "Linting based on profiles for required components in composite datatype fields",
+  "keywords": [
+    "health",
+    "healthcare",
+    "hl7",
+    "hl7v2",
+    "nodejs",
+    "typescript"
+  ],
+  "homepage": "https://www.rethinkhealth.io/hl7v2/docs",
+  "license": "MIT",
+  "author": {
+    "name": "Melek Somai",
+    "email": "melek@rethinkhealth.io"
+  },
+  "repository": "rethinkhealth/hl7v2.git",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup && tsc --emitDeclarationOnly",
+    "check-types": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@rethinkhealth/hl7v2-ast": "workspace:*",
+    "@rethinkhealth/hl7v2-lint-profile-utils": "workspace:*",
+    "@rethinkhealth/hl7v2-util-visit": "workspace:*",
+    "unified-lint-rule": "3.0.1"
+  },
+  "devDependencies": {
+    "@rethinkhealth/hl7v2-builder": "workspace:*",
+    "@rethinkhealth/testing": "workspace:*",
+    "@rethinkhealth/tsconfig": "workspace:*",
+    "@types/node": "^24.10.1",
+    "@vitest/coverage-v8": "4.0.18",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "unified": "11.0.5",
+    "vfile": "^6.0.3",
+    "vitest": "4.0.18"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "packageManager": "pnpm@10.14.0"
+}

--- a/packages/hl7v2-lint-profile-required-components/src/index.ts
+++ b/packages/hl7v2-lint-profile-required-components/src/index.ts
@@ -1,0 +1,141 @@
+import type {
+  Field,
+  FieldRepetition,
+  Nodes,
+  Root,
+  Segment,
+} from "@rethinkhealth/hl7v2-ast";
+import type { OnMissingProfile } from "@rethinkhealth/hl7v2-lint-profile-utils";
+import {
+  getFieldValue,
+  resolveDatatypeDefinition,
+  resolveFieldDefinition,
+  resolveVersion,
+} from "@rethinkhealth/hl7v2-lint-profile-utils";
+import type { DatatypeDefinition } from "@rethinkhealth/hl7v2-profiles";
+import { visit } from "@rethinkhealth/hl7v2-util-visit";
+import { lintRule } from "unified-lint-rule";
+import type { VFile } from "vfile";
+
+export interface RequiredComponentsOptions {
+  onMissingProfile?: OnMissingProfile;
+}
+
+/** Check a single field repetition for missing required components. */
+function checkRepetition(
+  file: VFile,
+  dtDef: DatatypeDefinition,
+  repetition: FieldRepetition,
+  segmentName: string,
+  sequence: number,
+  ancestors: Nodes[],
+  node: Segment,
+  fieldNode: Field
+): void {
+  for (const compSeq of dtDef.requiredSequences) {
+    const component = repetition.children[compSeq - 1];
+
+    const hasValue =
+      component?.children?.[0]?.value !== undefined &&
+      component.children[0].value.length > 0;
+
+    if (!hasValue) {
+      const compProfile = dtDef.componentsBySequence.get(compSeq);
+      const compName = compProfile?.name ? ` (${compProfile.name})` : "";
+      file.message(
+        `Required component ${segmentName}-${sequence}.${compSeq}${compName} is missing or empty`,
+        {
+          ancestors: [
+            ...ancestors,
+            node,
+            fieldNode,
+            repetition,
+            ...(component ? [component] : []),
+          ],
+          place:
+            component?.position ?? repetition.position ?? fieldNode.position,
+        }
+      );
+    }
+  }
+}
+
+const hl7v2LintRequiredComponents = lintRule<Root, RequiredComponentsOptions>(
+  {
+    origin: "hl7v2-lint:required-components",
+  },
+  async (tree, file, options) => {
+    const versionResult = resolveVersion(tree);
+    if (!versionResult.ok) {
+      file.message(versionResult.reason, {
+        ancestors: [tree],
+        place: tree.position,
+      });
+      return;
+    }
+
+    const onMissing = options?.onMissingProfile ?? "skip";
+
+    const segments: { node: Segment; ancestors: Nodes[] }[] = [];
+    visit(tree, "segment", (node, parents) => {
+      segments.push({
+        node: node as Segment,
+        ancestors: [...parents] as Nodes[],
+      });
+    });
+
+    for (const { node, ancestors } of segments) {
+      const fieldResult = await resolveFieldDefinition(tree, node.name);
+
+      if (!fieldResult.ok) {
+        if (onMissing === "warn") {
+          file.message(fieldResult.reason, {
+            ancestors: [...ancestors, node],
+            place: node.position,
+          });
+        } else if (onMissing === "fail") {
+          file.fail(fieldResult.reason, {
+            ancestors: [...ancestors, node],
+            place: node.position,
+          });
+        }
+        continue;
+      }
+
+      const fieldDef = fieldResult.value;
+
+      for (let i = 0; i < node.children.length; i++) {
+        const fieldNode = node.children[i]!;
+        const sequence = i + 1;
+        const fieldProfile = fieldDef.bySequence.get(sequence);
+
+        if (!fieldProfile || !getFieldValue(fieldNode)) {
+          continue;
+        }
+
+        const dtResult = await resolveDatatypeDefinition(
+          tree,
+          fieldProfile.datatype
+        );
+        if (!dtResult.ok || dtResult.value.kind !== "composite") {
+          continue;
+        }
+
+        for (const repetition of fieldNode.children) {
+          checkRepetition(
+            file,
+            dtResult.value,
+            repetition,
+            node.name,
+            sequence,
+            ancestors,
+            node,
+            fieldNode
+          );
+        }
+      }
+    }
+  }
+);
+
+export default hl7v2LintRequiredComponents;

--- a/packages/hl7v2-lint-profile-required-components/tests/index.test.ts
+++ b/packages/hl7v2-lint-profile-required-components/tests/index.test.ts
@@ -1,0 +1,256 @@
+import type { Root } from "@rethinkhealth/hl7v2-ast";
+import { c, f, m, r, s } from "@rethinkhealth/hl7v2-builder";
+import { unified } from "unified";
+import { VFile } from "vfile";
+import { describe, expect, it } from "vitest";
+
+import hl7v2LintRequiredComponents from "../src";
+
+/**
+ * Helper to create a tree with a specific version set in messageInfo.
+ */
+function treeWithVersion(
+  version: string,
+  ...segments: Parameters<typeof m>
+): Root {
+  const tree = m(...segments);
+  tree.data = {
+    messageInfo: {
+      version,
+    },
+  };
+  return tree;
+}
+
+describe("hl7v2LintRequiredComponents", () => {
+  describe("valid messages", () => {
+    it("reports no warnings when all required components are present (MSH-9 with 3 components)", async () => {
+      // MSH-9 (Message Type) is a MSG datatype with 3 required components in v2.7.1:
+      // 1: Message Code, 2: Trigger Event, 3: Message Structure
+      const tree = treeWithVersion(
+        "2.7.1",
+        s(
+          "MSH",
+          f("|"), // MSH-1: field separator
+          f("^~\\&"), // MSH-2: encoding characters
+          f(""), // MSH-3
+          f(""), // MSH-4
+          f(""), // MSH-5
+          f(""), // MSH-6
+          f(""), // MSH-7
+          f(""), // MSH-8
+          f(c("ADT"), c("A01"), c("ADT_A01")), // MSH-9: all 3 components
+          f(""), // MSH-10
+          f(""), // MSH-11
+          f("2.7.1") // MSH-12
+        )
+      );
+      const file = new VFile();
+
+      await unified().use(hl7v2LintRequiredComponents).run(tree, file);
+
+      const requiredComponentWarnings = file.messages.filter(
+        (msg) => msg.ruleId === "required-components"
+      );
+      expect(requiredComponentWarnings).toHaveLength(0);
+    });
+  });
+
+  describe("missing required components", () => {
+    it("reports when MSH-9 has only 2 components (missing Message Structure)", async () => {
+      const tree = treeWithVersion(
+        "2.7.1",
+        s(
+          "MSH",
+          f("|"),
+          f("^~\\&"),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(c("ADT"), c("A01")), // MSH-9: only 2 components, missing component 3
+          f(""),
+          f(""),
+          f("2.7.1")
+        )
+      );
+      const file = new VFile();
+
+      await unified().use(hl7v2LintRequiredComponents).run(tree, file);
+
+      const requiredComponentWarnings = file.messages.filter(
+        (msg) => msg.ruleId === "required-components"
+      );
+      expect(requiredComponentWarnings.length).toBeGreaterThanOrEqual(1);
+      const msh9Warning = requiredComponentWarnings.find((msg) =>
+        msg.message.includes("MSH-9")
+      );
+      expect(msh9Warning).toBeDefined();
+    });
+  });
+
+  describe("simple datatype fields", () => {
+    it("skips simple datatype fields (PID-1, datatype SI)", async () => {
+      const tree = treeWithVersion(
+        "2.7.1",
+        s(
+          "MSH",
+          f("|"),
+          f("^~\\&"),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(c("ADT"), c("A01"), c("ADT_A01")),
+          f(""),
+          f(""),
+          f("2.7.1")
+        ),
+        s(
+          "PID",
+          f("1") // PID-1: Set ID (SI — simple datatype)
+        )
+      );
+      const file = new VFile();
+
+      await unified().use(hl7v2LintRequiredComponents).run(tree, file);
+
+      // No warnings related to PID-1
+      const pid1Warnings = file.messages.filter(
+        (msg) =>
+          msg.ruleId === "required-components" && msg.message.includes("PID-1")
+      );
+      expect(pid1Warnings).toHaveLength(0);
+    });
+  });
+
+  describe("empty fields", () => {
+    it("skips empty fields (MSH-9 empty)", async () => {
+      const tree = treeWithVersion(
+        "2.7.1",
+        s(
+          "MSH",
+          f("|"),
+          f("^~\\&"),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(""), // MSH-9: empty
+          f(""),
+          f(""),
+          f("2.7.1")
+        )
+      );
+      const file = new VFile();
+
+      await unified().use(hl7v2LintRequiredComponents).run(tree, file);
+
+      const requiredComponentWarnings = file.messages.filter(
+        (msg) => msg.ruleId === "required-components"
+      );
+      expect(requiredComponentWarnings).toHaveLength(0);
+    });
+  });
+
+  describe("multiple repetitions", () => {
+    it("reports when second repetition is missing a required component", async () => {
+      const tree = treeWithVersion(
+        "2.7.1",
+        s(
+          "MSH",
+          f("|"),
+          f("^~\\&"),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(
+            r(c("ADT"), c("A01"), c("ADT_A01")), // rep 1: all components
+            r(c("ADT"), c("A01")) // rep 2: missing component 3
+          ),
+          f(""),
+          f(""),
+          f("2.7.1")
+        )
+      );
+      const file = new VFile();
+
+      await unified().use(hl7v2LintRequiredComponents).run(tree, file);
+
+      const requiredComponentWarnings = file.messages.filter(
+        (msg) =>
+          msg.ruleId === "required-components" && msg.message.includes("MSH-9")
+      );
+      expect(requiredComponentWarnings.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("Z-segments", () => {
+    it("skips Z-segments by default", async () => {
+      const tree = treeWithVersion(
+        "2.7.1",
+        s(
+          "MSH",
+          f("|"),
+          f("^~\\&"),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(c("ADT"), c("A01"), c("ADT_A01")),
+          f(""),
+          f(""),
+          f("2.7.1")
+        ),
+        s("ZZZ", f("some value"))
+      );
+      const file = new VFile();
+
+      await unified().use(hl7v2LintRequiredComponents).run(tree, file);
+
+      const zSegmentWarnings = file.messages.filter(
+        (msg) =>
+          msg.ruleId === "required-components" && msg.message.includes("ZZZ")
+      );
+      expect(zSegmentWarnings).toHaveLength(0);
+    });
+  });
+
+  describe("missing version", () => {
+    it("reports when version cannot be resolved", async () => {
+      const tree = m(
+        s(
+          "MSH",
+          f("|"),
+          f("^~\\&"),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(""),
+          f(c("ADT"), c("A01"), c("ADT_A01"))
+        )
+      );
+      const file = new VFile();
+
+      await unified().use(hl7v2LintRequiredComponents).run(tree, file);
+
+      expect(file.messages).toHaveLength(1);
+      expect(file.messages[0]?.message).toContain("MSH-12");
+      expect(file.messages[0]?.ruleId).toBe("required-components");
+      expect(file.messages[0]?.source).toBe("hl7v2-lint");
+    });
+  });
+});

--- a/packages/hl7v2-lint-profile-required-components/tsconfig.json
+++ b/packages/hl7v2-lint-profile-required-components/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@rethinkhealth/tsconfig/library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "strictNullChecks": true
+  }
+}

--- a/packages/hl7v2-lint-profile-required-components/tsup.config.ts
+++ b/packages/hl7v2-lint-profile-required-components/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+  },
+  format: ["esm"],
+  sourcemap: true,
+  target: "es2022",
+});

--- a/packages/hl7v2-lint-profile-required-components/vitest.config.ts
+++ b/packages/hl7v2-lint-profile-required-components/vitest.config.ts
@@ -1,0 +1,11 @@
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      name: "hl7v2-lint-profile-required-components",
+    },
+  })
+);


### PR DESCRIPTION
## Summary [5/7]

Lint rule that validates required components in composite datatype fields.

- Uses v2.7.1+ profiles (v2.5 has no required components in any datatype)
- MSH-9 (MSG datatype) has 3 required components in v2.7.1
- Checks each field repetition independently
- Skips empty fields and non-composite datatypes
- `onMissingProfile` option (default: `"skip"`)

**Stack:** PR 5 of 7. Depends on #422.

## Test plan
- [x] 7 tests pass
- [x] Build and type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)