### PR TITLE
feat: add hl7v2-lint-profile-table-values rule

### DIFF
--- a/.changeset/lint-profile-table-values.md
+++ b/.changeset/lint-profile-table-values.md
@@ -1,0 +1,5 @@
+---
+"@rethinkhealth/hl7v2-lint-profile-table-values": minor
+---
+
+Add lint rule that validates coded field values against HL7v2 tables. Only validates HL7-type tables, skips user-type tables.

--- a/packages/hl7v2-lint-profile-table-values/bench/table-values.bench.ts
+++ b/packages/hl7v2-lint-profile-table-values/bench/table-values.bench.ts
@@ -1,0 +1,79 @@
+/**
+ * Benchmarks for hl7v2-lint-profile-table-values.
+ *
+ * Run: pnpm bench
+ */
+import { c, f, m, s } from "@rethinkhealth/hl7v2-builder";
+import { unified } from "unified";
+import { VFile } from "vfile";
+import { bench, describe } from "vitest";
+
+import hl7v2LintTableValues from "../src";
+
+function msh(version: string) {
+  return s(
+    "MSH",
+    f("|"),
+    f("^~\\&"),
+    f("SENDER"),
+    f("FAC"),
+    f("RECV"),
+    f("RFAC"),
+    f("20241201"),
+    f(""),
+    f(c("ADT"), c("A01"), c("ADT_A01")),
+    f("MSG001"),
+    f("P"),
+    f(version)
+  );
+}
+
+function obx(index: number) {
+  return s(
+    "OBX",
+    f(String(index)),
+    f("NM"),
+    f(c("8302-2")),
+    f(""),
+    f("185"),
+    f("cm")
+  );
+}
+
+const processor = unified().use(hl7v2LintTableValues);
+
+describe("table-values performance", () => {
+  const small = m(msh("2.5"), s("EVN", f("A01")));
+
+  bench("small (MSH + EVN)", async () => {
+    await processor.run(small, new VFile());
+  });
+
+  const segments = [
+    msh("2.5"),
+    s("EVN", f("A01")),
+    s("PID", f("1"), f(""), f("12345"), f(""), f("Doe")),
+  ];
+  for (let i = 1; i <= 50; i++) {
+    segments.push(obx(i));
+  }
+  const large = m(...segments);
+
+  bench("large (53 segments)", async () => {
+    await processor.run(large, new VFile());
+  });
+
+  const xlSegments = [
+    msh("2.5"),
+    s("EVN", f("A01")),
+    s("PID", f("1"), f(""), f("12345"), f(""), f("Doe")),
+  ];
+  for (let i = 1; i <= 100; i++) {
+    xlSegments.push(obx(i));
+  }
+  const xl = m(...xlSegments);
+
+  bench("xl (103 segments)", async () => {
+    await processor.run(xl, new VFile());
+  });
+});

--- a/packages/hl7v2-lint-profile-table-values/package.json
+++ b/packages/hl7v2-lint-profile-table-values/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@rethinkhealth/hl7v2-lint-profile-table-values",
+  "version": "0.0.0",
+  "description": "Lint rule to validate coded field values against HL7v2 tables",
+  "keywords": [
+    "health",
+    "healthcare",
+    "hl7",
+    "hl7v2",
+    "nodejs",
+    "typescript"
+  ],
+  "homepage": "https://www.rethinkhealth.io/hl7v2/docs",
+  "license": "MIT",
+  "author": {
+    "name": "Melek Somai",
+    "email": "melek@rethinkhealth.io"
+  },
+  "repository": "rethinkhealth/hl7v2.git",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup && tsc --emitDeclarationOnly",
+    "check-types": "tsc --noEmit",
+    "bench": "vitest bench",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@rethinkhealth/hl7v2-ast": "workspace:*",
+    "@rethinkhealth/hl7v2-profiles": "workspace:*",
+    "@rethinkhealth/hl7v2-util-query": "workspace:*",
+    "@rethinkhealth/hl7v2-util-visit": "workspace:*",
+    "@rethinkhealth/hl7v2-utils": "workspace:*",
+    "unified-lint-rule": "3.0.1"
+  },
+  "devDependencies": {
+    "@rethinkhealth/hl7v2-builder": "workspace:*",
+    "@rethinkhealth/testing": "workspace:*",
+    "@rethinkhealth/tsconfig": "workspace:*",
+    "@types/node": "^24.10.1",
+    "@vitest/coverage-v8": "4.0.18",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "unified": "11.0.5",
+    "vfile": "^6.0.3",
+    "vitest": "4.0.18"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "packageManager": "pnpm@10.14.0"
+}

--- a/packages/hl7v2-lint-profile-table-values/src/index.ts
+++ b/packages/hl7v2-lint-profile-table-values/src/index.ts
@@ -1,0 +1,158 @@
+import type { Root, Segment } from "@rethinkhealth/hl7v2-ast";
+import type {
+  FieldDefinition,
+  TableDefinition,
+} from "@rethinkhealth/hl7v2-profiles";
+import { profiles } from "@rethinkhealth/hl7v2-profiles";
+import { value } from "@rethinkhealth/hl7v2-util-query";
+import { SKIP, visit } from "@rethinkhealth/hl7v2-util-visit";
+import { isEmptyNode } from "@rethinkhealth/hl7v2-utils";
+import { lintRule } from "unified-lint-rule";
+
+/**
+ * Strip the "HL7" prefix from table IDs in field profiles.
+ * Field profiles reference tables as "HL70001"; the tables store uses "0001".
+ */
+function normalizeTableId(tableRef: string): string {
+  return tableRef.replace(/^HL7/, "");
+}
+
+/**
+ * Lint rule that validates coded field values against HL7-type tables.
+ *
+ * For each field that references a table in its profile, loads the table
+ * definition and checks that the field's first component value is a valid
+ * code in that table.
+ *
+ * Only `hl7`-type tables are validated. `user`-type tables are skipped
+ * (they contain site-specific codes).
+ *
+ * Empty fields are skipped. Segments without a known profile are skipped.
+ *
+ * @example
+ * ```typescript
+ * unified().use(hl7v2LintTableValues);
+ * ```
+ */
+const hl7v2LintTableValues = lintRule<Root>(
+  { origin: "hl7v2-lint:table-values" },
+  async (tree, file) => {
+    const version = value(tree, "MSH-12")?.value;
+    if (!version) {
+      file.message("Cannot validate table values: missing version (MSH-12)", {
+        ancestors: [tree],
+        place: tree.position,
+      });
+      return;
+    }
+
+    const fieldDefs = await loadFieldDefinitions(tree, version);
+    const tableDefs = await loadTableDefinitions(fieldDefs, version);
+
+    visit(tree, "field", (fieldNode, ancestors, info) => {
+      // Check emptiness first — avoids lookups for the majority of fields
+      if (isEmptyNode(fieldNode)) {
+        return SKIP;
+      }
+
+      const segment = ancestors.at(-1) as Segment | undefined;
+      if (!segment || segment.type !== "segment") {
+        return SKIP;
+      }
+
+      const fieldDef = fieldDefs.get(segment.name);
+      if (!fieldDef) {
+        return SKIP;
+      }
+
+      const fieldProfile = fieldDef.bySequence.get(info.sequence);
+      if (!fieldProfile?.table) {
+        return SKIP;
+      }
+
+      // Get the coded value directly from the field node
+      // (can't use value(tree, path) — would always hit the first segment of this type)
+      const sub = fieldNode.children[0]?.children[0]?.children[0];
+      if (!sub || !sub.value) {
+        return SKIP;
+      }
+      const val = sub.value;
+
+      const tableId = normalizeTableId(fieldProfile.table);
+      const tableDef = tableDefs.get(tableId);
+      if (!tableDef) {
+        return SKIP;
+      }
+
+      // Only validate HL7-defined tables
+      if (tableDef.type !== "hl7") {
+        return SKIP;
+      }
+
+      if (!tableDef.codes.has(val)) {
+        const name = fieldProfile.name ? ` (${fieldProfile.name})` : "";
+        file.message(
+          `Field ${segment.name}-${info.sequence}${name} value '${val}' is not in table ${tableId} (${tableDef.description})`,
+          {
+            ancestors: [...ancestors, fieldNode],
+            place: fieldNode.position,
+          }
+        );
+      }
+
+      return SKIP;
+    });
+  }
+);
+
+/**
+ * Collect unique segment names and load their field definitions.
+ */
+async function loadFieldDefinitions(
+  tree: Root,
+  version: string
+): Promise<Map<string, FieldDefinition>> {
+  const names = new Set<string>();
+  visit(tree, "segment", (node) => {
+    names.add(node.name);
+  });
+
+  const definitions = new Map<string, FieldDefinition>();
+  for (const name of names) {
+    try {
+      definitions.set(name, await profiles.fields.load(version, name));
+    } catch {
+      // Unknown segment — skip
+    }
+  }
+  return definitions;
+}
+
+/**
+ * Load table definitions for all tables referenced by field profiles.
+ */
+async function loadTableDefinitions(
+  fieldDefs: Map<string, FieldDefinition>,
+  version: string
+): Promise<Map<string, TableDefinition>> {
+  const tableIds = new Set<string>();
+  for (const def of fieldDefs.values()) {
+    for (const field of def.bySequence.values()) {
+      if (field.table) {
+        tableIds.add(normalizeTableId(field.table));
+      }
+    }
+  }
+
+  const definitions = new Map<string, TableDefinition>();
+  for (const id of tableIds) {
+    try {
+      definitions.set(id, await profiles.tables.load(version, id));
+    } catch {
+      // Unknown table — skip
+    }
+  }
+  return definitions;
+}
+
+export default hl7v2LintTableValues;

--- a/packages/hl7v2-lint-profile-table-values/tests/index.test.ts
+++ b/packages/hl7v2-lint-profile-table-values/tests/index.test.ts
@@ -1,0 +1,130 @@
+import { c, f, m, s } from "@rethinkhealth/hl7v2-builder";
+import { unified } from "unified";
+import { VFile } from "vfile";
+import { describe, expect, it } from "vitest";
+
+import hl7v2LintTableValues from "../src";
+
+/** Complete MSH with all required fields */
+function msh(version: string) {
+  return s(
+    "MSH",
+    f("|"),
+    f("^~\\&"),
+    f("SENDER"),
+    f("FAC"),
+    f("RECV"),
+    f("RFAC"),
+    f("20241201"),
+    f(""),
+    f(c("ADT"), c("A01"), c("ADT_A01")),
+    f("MSG001"),
+    f("P"),
+    f(version)
+  );
+}
+
+describe("hl7v2LintTableValues", () => {
+  it("no warnings for valid coded value in HL7 table", async () => {
+    // EVN-1 (Event Type Code) references HL70003 (type: "hl7")
+    // "A01" is a valid code
+    const tree = m(msh("2.5"), s("EVN", f("A01")));
+    const file = new VFile();
+
+    await unified().use(hl7v2LintTableValues).run(tree, file);
+
+    const errors = file.messages.filter((msg) => msg.ruleId === "table-values");
+    expect(errors).toHaveLength(0);
+  });
+
+  it("reports invalid coded value in HL7 table", async () => {
+    // EVN-1 = "ZZZ" is not a valid code in table 0003
+    const tree = m(msh("2.5"), s("EVN", f("ZZZ")));
+    const file = new VFile();
+
+    await unified().use(hl7v2LintTableValues).run(tree, file);
+
+    const errors = file.messages.filter((msg) => msg.ruleId === "table-values");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toContain("EVN-1");
+    expect(errors[0]?.message).toContain("ZZZ");
+    expect(errors[0]?.source).toBe("hl7v2-lint");
+  });
+
+  it("skips empty field values", async () => {
+    const tree = m(msh("2.5"), s("EVN", f("")));
+    const file = new VFile();
+
+    await unified().use(hl7v2LintTableValues).run(tree, file);
+
+    const errors = file.messages.filter((msg) => msg.ruleId === "table-values");
+    expect(errors).toHaveLength(0);
+  });
+
+  it("skips user-type tables", async () => {
+    // PID-8 (Administrative Sex) references HL70001 which is type "user"
+    const tree = m(
+      msh("2.5"),
+      s(
+        "PID",
+        f(""),
+        f(""),
+        f("12345"),
+        f(""),
+        f("Doe"),
+        f(""),
+        f(""),
+        f("INVALID_BUT_USER_TABLE")
+      )
+    );
+    const file = new VFile();
+
+    await unified().use(hl7v2LintTableValues).run(tree, file);
+
+    const errors = file.messages.filter(
+      (msg) => msg.ruleId === "table-values" && msg.message.includes("PID-8")
+    );
+    expect(errors).toHaveLength(0);
+  });
+
+  it("skips Z-segments silently", async () => {
+    const tree = m(msh("2.5"), s("ZPD", f("INVALID")));
+    const file = new VFile();
+
+    await unified().use(hl7v2LintTableValues).run(tree, file);
+
+    expect(file.messages).toHaveLength(0);
+  });
+
+  it("reports when version is missing", async () => {
+    const tree = m(s("MSH"), s("EVN", f("A01")));
+    const file = new VFile();
+
+    await unified().use(hl7v2LintTableValues).run(tree, file);
+
+    expect(file.messages).toHaveLength(1);
+    expect(file.messages[0]?.message).toContain("MSH-12");
+  });
+
+  it("validates each repeated segment independently", async () => {
+    // Two EVN segments: first valid, second invalid
+    const tree = m(msh("2.5"), s("EVN", f("A01")), s("EVN", f("INVALID")));
+    const file = new VFile();
+
+    await unified().use(hl7v2LintTableValues).run(tree, file);
+
+    const errors = file.messages.filter((msg) => msg.ruleId === "table-values");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toContain("INVALID");
+  });
+
+  it("includes table description in error message", async () => {
+    const tree = m(msh("2.5"), s("EVN", f("INVALID")));
+    const file = new VFile();
+
+    await unified().use(hl7v2LintTableValues).run(tree, file);
+
+    const error = file.messages.find((msg) => msg.ruleId === "table-values");
+    expect(error?.message).toContain("Event type");
+  });
+});

--- a/packages/hl7v2-lint-profile-table-values/tsconfig.json
+++ b/packages/hl7v2-lint-profile-table-values/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@rethinkhealth/tsconfig/library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "strictNullChecks": true
+  }
+}

--- a/packages/hl7v2-lint-profile-table-values/tsup.config.ts
+++ b/packages/hl7v2-lint-profile-table-values/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+  },
+  format: ["esm"],
+  sourcemap: true,
+  target: "es2022",
+});

--- a/packages/hl7v2-lint-profile-table-values/vitest.config.ts
+++ b/packages/hl7v2-lint-profile-table-values/vitest.config.ts
@@ -1,0 +1,11 @@
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      name: "hl7v2-lint-profile-table-values",
+    },
+  })
+);


### PR DESCRIPTION
## Summary

Lint rule that validates coded field values against HL7-type tables.

- Strips `HL7` prefix from table references (`HL70003` → `0003`)
- Only validates `hl7`-type tables, skips `user`-type
- Pre-loads all referenced table definitions upfront
- Single `visit("field")` pattern with `info.sequence` and `ancestors`
- Tests with EVN-1 (table 0003, type "hl7") and PID-8 (table 0001, type "user")
- 7 tests + benchmarks

### Example output

```
Field EVN-1 (Event Type Code) value 'ZZZ' is not in table 0003 (Event type)
```

## Test plan
- [x] 7 tests pass
- [x] Build and type-check clean
- [x] Benchmarks included

🤖 Generated with [Claude Code](https://claude.com/claude-code)