### PR TITLE
feat: add hl7v2-preset-lint-profile preset

### DIFF
--- a/.changeset/preset-lint-profile.md
+++ b/.changeset/preset-lint-profile.md
@@ -1,0 +1,5 @@
+---
+"@rethinkhealth/hl7v2-preset-lint-profile-recommended": minor
+---
+
+Add preset that bundles all profile-based lint rules: required-fields, field-max-length, field-repetition, required-components, and table-values.

--- a/packages/hl7v2-preset-lint-profile-recommended/bench/preset.bench.ts
+++ b/packages/hl7v2-preset-lint-profile-recommended/bench/preset.bench.ts
@@ -1,0 +1,176 @@
+/**
+ * Benchmarks for hl7v2-preset-lint-profile.
+ *
+ * Measures the end-to-end cost of running all 5 profile lint rules
+ * as a preset on messages of varying sizes.
+ *
+ * Run: pnpm bench
+ */
+import { c, f, m, r, s } from "@rethinkhealth/hl7v2-builder";
+import { profiles } from "@rethinkhealth/hl7v2-profiles";
+import { unified } from "unified";
+import { VFile } from "vfile";
+import { bench, describe } from "vitest";
+
+import hl7v2PresetLintProfileRecommended from "../src";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** Complete MSH with all required fields */
+function msh(version: string) {
+  return s(
+    "MSH",
+    f("|"),
+    f("^~\\&"),
+    f("SENDER"),
+    f("FAC"),
+    f("RECV"),
+    f("RFAC"),
+    f("20241201"),
+    f(""),
+    f(c("ADT"), c("A01"), c("ADT_A01")),
+    f("MSG001"),
+    f("P"),
+    f(version)
+  );
+}
+
+/** Valid PID with all required fields */
+function validPid() {
+  return s(
+    "PID",
+    f("1"),
+    f(""),
+    f("12345"),
+    f(""),
+    f("Doe^John"),
+    f(""),
+    f(""),
+    f("M")
+  );
+}
+
+/** OBX segment */
+function obx(index: number) {
+  return s(
+    "OBX",
+    f(String(index)),
+    f("NM"),
+    f(c("8302-2")),
+    f(""),
+    f("185"),
+    f("cm")
+  );
+}
+
+/** EVN segment with valid event code */
+function evn() {
+  return s("EVN", f("A01"), f("20241201120000"));
+}
+
+// ---------------------------------------------------------------------------
+// Processors
+// ---------------------------------------------------------------------------
+
+const presetProcessor = unified().use(hl7v2PresetLintProfileRecommended);
+
+// ---------------------------------------------------------------------------
+// Benchmarks: valid messages (no warnings)
+// ---------------------------------------------------------------------------
+
+describe("preset — valid messages (no warnings)", () => {
+  const small = m(msh("2.5"), evn(), validPid());
+
+  bench("small (MSH + EVN + PID)", async () => {
+    await presetProcessor.run(small, new VFile());
+  });
+
+  const mediumSegments = [msh("2.5"), evn(), validPid()];
+  for (let i = 1; i <= 10; i++) {
+    mediumSegments.push(obx(i));
+  }
+  const medium = m(...mediumSegments);
+
+  bench("medium (13 segments)", async () => {
+    await presetProcessor.run(medium, new VFile());
+  });
+
+  const largeSegments = [msh("2.5"), evn(), validPid()];
+  for (let i = 1; i <= 50; i++) {
+    largeSegments.push(obx(i));
+  }
+  const large = m(...largeSegments);
+
+  bench("large (53 segments)", async () => {
+    await presetProcessor.run(large, new VFile());
+  });
+
+  const xlSegments = [msh("2.5"), evn(), validPid()];
+  for (let i = 1; i <= 100; i++) {
+    xlSegments.push(obx(i));
+  }
+  const xl = m(...xlSegments);
+
+  bench("xl (103 segments)", async () => {
+    await presetProcessor.run(xl, new VFile());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Benchmarks: messages with violations
+// ---------------------------------------------------------------------------
+
+describe("preset — messages with violations", () => {
+  const violations = m(
+    msh("2.5"),
+    s("EVN", f("ZZZ")), // table violation
+    s(
+      "PID",
+      f(r("12345"), r("67890")), // maxLength + repetition
+      f(""),
+      f(""), // required field empty
+      f(""),
+      f("Doe")
+    )
+  );
+
+  bench("multiple violations (MSH + EVN + PID)", async () => {
+    await presetProcessor.run(violations, new VFile());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Benchmarks: cold vs warm (profile caching)
+// ---------------------------------------------------------------------------
+
+describe("preset — cold vs warm (small message)", () => {
+  const tree = m(msh("2.5"), evn(), validPid());
+
+  bench("cold (cache reset each iteration)", async () => {
+    profiles.reset();
+    await presetProcessor.run(tree, new VFile());
+  });
+
+  bench("warm (cached profiles)", async () => {
+    await presetProcessor.run(tree, new VFile());
+  });
+});
+
+describe("preset — cold vs warm (large message)", () => {
+  const segments = [msh("2.5"), evn(), validPid()];
+  for (let i = 1; i <= 50; i++) {
+    segments.push(obx(i));
+  }
+  const tree = m(...segments);
+
+  bench("cold (cache reset each iteration)", async () => {
+    profiles.reset();
+    await presetProcessor.run(tree, new VFile());
+  });
+
+  bench("warm (cached profiles)", async () => {
+    await presetProcessor.run(tree, new VFile());
+  });
+});

--- a/packages/hl7v2-preset-lint-profile-recommended/package.json
+++ b/packages/hl7v2-preset-lint-profile-recommended/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@rethinkhealth/hl7v2-preset-lint-profile-recommended",
+  "version": "0.0.0",
+  "description": "hl7v2-lint preset with profile-based validation rules",
+  "keywords": [
+    "hl7",
+    "hl7v2",
+    "hl7v2-lint",
+    "lint",
+    "nodejs",
+    "profile",
+    "typescript"
+  ],
+  "homepage": "https://www.rethinkhealth.io/hl7v2/docs",
+  "license": "MIT",
+  "author": {
+    "name": "Melek Somai",
+    "email": "melek@rethinkhealth.io"
+  },
+  "repository": "rethinkhealth/hl7v2.git",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup && tsc --emitDeclarationOnly",
+    "check-types": "tsc --noEmit",
+    "bench": "vitest bench",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@rethinkhealth/hl7v2-lint-profile-events-segments-order": "workspace:*",
+    "@rethinkhealth/hl7v2-lint-profile-field-max-length": "workspace:*",
+    "@rethinkhealth/hl7v2-lint-profile-field-repetition": "workspace:*",
+    "@rethinkhealth/hl7v2-lint-profile-required-components": "workspace:*",
+    "@rethinkhealth/hl7v2-lint-profile-required-fields": "workspace:*",
+    "@rethinkhealth/hl7v2-lint-profile-table-values": "workspace:*",
+    "unified": "11.0.5"
+  },
+  "devDependencies": {
+    "@rethinkhealth/hl7v2-ast": "workspace:*",
+    "@rethinkhealth/hl7v2-builder": "workspace:*",
+    "@rethinkhealth/hl7v2-profiles": "workspace:*",
+    "@rethinkhealth/testing": "workspace:*",
+    "@rethinkhealth/tsconfig": "workspace:*",
+    "@types/node": "^24.10.1",
+    "@vitest/coverage-v8": "4.0.18",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "unified": "11.0.5",
+    "vfile": "^6.0.3",
+    "vitest": "4.0.18"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "packageManager": "pnpm@10.14.0"
+}

--- a/packages/hl7v2-preset-lint-profile-recommended/src/index.ts
+++ b/packages/hl7v2-preset-lint-profile-recommended/src/index.ts
@@ -1,0 +1,49 @@
+import hl7v2LintFieldMaxLength from "@rethinkhealth/hl7v2-lint-profile-field-max-length";
+import hl7v2LintFieldRepetition from "@rethinkhealth/hl7v2-lint-profile-field-repetition";
+import hl7v2LintRequiredComponents from "@rethinkhealth/hl7v2-lint-profile-required-components";
+import hl7v2LintRequiredFields from "@rethinkhealth/hl7v2-lint-profile-required-fields";
+import hl7v2LintTableValues from "@rethinkhealth/hl7v2-lint-profile-table-values";
+import type { Preset } from "unified";
+
+/**
+ * Preset of profile-based hl7v2-lint rules.
+ *
+ * Validates HL7v2 messages against field definitions, datatype definitions,
+ * and table definitions from the HL7v2 profiles.
+ *
+ * ## Rules included
+ *
+ * - **required-fields** — validates required fields are present and non-empty
+ * - **field-max-length** — validates field value lengths against maxLength
+ * - **field-repetition** — flags non-repeatable fields with multiple repetitions
+ * - **required-components** — validates required components in composite datatypes
+ * - **table-values** — validates coded values against HL7-type tables
+ *
+ * All rules read the HL7v2 version from MSH-12 and load profiles accordingly.
+ * Unknown segments (Z-segments) are silently skipped.
+ *
+ * ## Usage
+ *
+ * ```typescript
+ * import { unified } from "unified";
+ * import { hl7v2Parser } from "@rethinkhealth/hl7v2-parser";
+ * import hl7v2PresetLintProfileRecommended from "@rethinkhealth/hl7v2-preset-lint-profile-recommended";
+ *
+ * const processor = unified()
+ *   .use(hl7v2Parser)
+ *   .use(hl7v2PresetLintProfileRecommended);
+ * ```
+ *
+ * Rules can be reconfigured individually after applying the preset.
+ */
+const hl7v2PresetLintProfileRecommended: Preset = {
+  plugins: [
+    hl7v2LintRequiredFields,
+    hl7v2LintFieldMaxLength,
+    hl7v2LintFieldRepetition,
+    hl7v2LintRequiredComponents,
+    hl7v2LintTableValues,
+  ],
+};
+
+export default hl7v2PresetLintProfileRecommended;

--- a/packages/hl7v2-preset-lint-profile-recommended/tests/index.test.ts
+++ b/packages/hl7v2-preset-lint-profile-recommended/tests/index.test.ts
@@ -1,0 +1,168 @@
+import { c, f, m, r, s } from "@rethinkhealth/hl7v2-builder";
+import { unified } from "unified";
+import { VFile } from "vfile";
+import { describe, expect, it } from "vitest";
+
+import hl7v2PresetLintProfileRecommended from "../src";
+
+/** Complete MSH with all required fields for v2.7.1 */
+function msh(version: string) {
+  return s(
+    "MSH",
+    f("|"),
+    f("^~\\&"),
+    f("SENDER"),
+    f("FAC"),
+    f("RECV"),
+    f("RFAC"),
+    f("20241201"),
+    f(""),
+    f(c("ADT"), c("A01"), c("ADT_A01")),
+    f("MSG001"),
+    f("P"),
+    f(version)
+  );
+}
+
+describe("hl7v2PresetLintProfileRecommended", () => {
+  it("produces no warnings for a valid message", async () => {
+    const tree = m(
+      msh("2.5"),
+      s("PID", f("1"), f(""), f("12345"), f(""), f("Doe^John"))
+    );
+    const file = new VFile();
+
+    await unified().use(hl7v2PresetLintProfileRecommended).run(tree, file);
+
+    expect(file.messages).toHaveLength(0);
+  });
+
+  it("reports required field violations", async () => {
+    // PID-3 is required but empty
+    const tree = m(msh("2.5"), s("PID", f("1"), f(""), f(""), f(""), f("Doe")));
+    const file = new VFile();
+
+    await unified().use(hl7v2PresetLintProfileRecommended).run(tree, file);
+
+    const requiredErrors = file.messages.filter(
+      (msg) => msg.ruleId === "required-fields"
+    );
+    expect(requiredErrors.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("reports field max length violations", async () => {
+    // PID-1 maxLength=4, "12345" exceeds
+    const tree = m(msh("2.5"), s("PID", f("12345")));
+    const file = new VFile();
+
+    await unified().use(hl7v2PresetLintProfileRecommended).run(tree, file);
+
+    const lengthErrors = file.messages.filter(
+      (msg) => msg.ruleId === "field-max-length"
+    );
+    expect(lengthErrors.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("reports field repetition violations", async () => {
+    // PID-1 is not repeatable
+    const tree = m(msh("2.5"), s("PID", f(r("1"), r("2"))));
+    const file = new VFile();
+
+    await unified().use(hl7v2PresetLintProfileRecommended).run(tree, file);
+
+    const repErrors = file.messages.filter(
+      (msg) => msg.ruleId === "field-repetition"
+    );
+    expect(repErrors.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("reports table value violations", async () => {
+    // EVN-1 = "ZZZ" is not in HL7 table 0003
+    const tree = m(msh("2.5"), s("EVN", f("ZZZ")));
+    const file = new VFile();
+
+    await unified().use(hl7v2PresetLintProfileRecommended).run(tree, file);
+
+    const tableErrors = file.messages.filter(
+      (msg) => msg.ruleId === "table-values"
+    );
+    expect(tableErrors.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("reports required component violations", async () => {
+    // MSH-9 in v2.7.1 has 3 required components, only 2 provided
+    const tree = m(
+      s(
+        "MSH",
+        f("|"),
+        f("^~\\&"),
+        f("SENDER"),
+        f("FAC"),
+        f("RECV"),
+        f("RFAC"),
+        f("20241201"),
+        f(""),
+        f(c("ADT"), c("A01")), // missing component 3
+        f("MSG001"),
+        f("P"),
+        f("2.7.1")
+      )
+    );
+    const file = new VFile();
+
+    await unified().use(hl7v2PresetLintProfileRecommended).run(tree, file);
+
+    const compErrors = file.messages.filter(
+      (msg) => msg.ruleId === "required-components"
+    );
+    expect(compErrors.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("all five rules produce distinct ruleIds", async () => {
+    // Craft a v2.5 message triggering 4 rules + a v2.7.1 message for required-components
+    // v2.5: EVN-1 has table HL70003 (type "hl7"), PID fields for other rules
+    const tree1 = m(
+      msh("2.5"),
+      s("EVN", f("ZZZ")), // invalid table value → table-values
+      s(
+        "PID",
+        f(r("12345"), r("67890")), // PID-1: exceeds maxLength + not repeatable
+        f(""),
+        f(""), // PID-3 required but empty → required-fields
+        f(""),
+        f("Doe")
+      )
+    );
+    const file1 = new VFile();
+    await unified().use(hl7v2PresetLintProfileRecommended).run(tree1, file1);
+
+    // v2.7.1: MSG has required components
+    const tree2 = m(
+      s(
+        "MSH",
+        f("|"),
+        f("^~\\&"),
+        f("SENDER"),
+        f("FAC"),
+        f("RECV"),
+        f("RFAC"),
+        f("20241201"),
+        f(""),
+        f(c("ADT"), c("A01")), // missing MSH-9.3 → required-components
+        f("MSG001"),
+        f("P"),
+        f("2.7.1")
+      )
+    );
+    const file2 = new VFile();
+    await unified().use(hl7v2PresetLintProfileRecommended).run(tree2, file2);
+
+    const allMessages = [...file1.messages, ...file2.messages];
+    const ruleIds = new Set(allMessages.map((msg) => msg.ruleId));
+    expect(ruleIds.has("required-fields")).toBe(true);
+    expect(ruleIds.has("field-max-length")).toBe(true);
+    expect(ruleIds.has("field-repetition")).toBe(true);
+    expect(ruleIds.has("table-values")).toBe(true);
+    expect(ruleIds.has("required-components")).toBe(true);
+  });
+});

--- a/packages/hl7v2-preset-lint-profile-recommended/tsconfig.json
+++ b/packages/hl7v2-preset-lint-profile-recommended/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@rethinkhealth/tsconfig/library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "strictNullChecks": true
+  }
+}

--- a/packages/hl7v2-preset-lint-profile-recommended/tsup.config.ts
+++ b/packages/hl7v2-preset-lint-profile-recommended/tsup.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    /**
+     * Directories and files should be bundled so that the resulting files line
+     * up with the TSC generated type definitions.
+     */
+    index: "src/index.ts",
+    // "utils/index": "src/utils/index.ts",
+  },
+  format: ["esm"],
+  sourcemap: true,
+  target: "es2022",
+  // treeshake: true,
+
+  /**
+   * Do not use tsup for generating d.ts files because it can not generate type
+   * the definition maps required for go-to-definition to work in our IDE. We
+   * use tsc for that.
+   */
+});

--- a/packages/hl7v2-preset-lint-profile-recommended/vitest.config.ts
+++ b/packages/hl7v2-preset-lint-profile-recommended/vitest.config.ts
@@ -1,0 +1,11 @@
+import { baseConfig } from "@rethinkhealth/testing";
+import { defineConfig, mergeConfig } from "vitest/config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      name: "hl7v2-preset-lint-profile-recommended",
+    },
+  })
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -858,6 +858,58 @@ importers:
         specifier: 4.0.18
         version: 4.0.18(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.8.1)
 
+  packages/hl7v2-lint-profile-table-values:
+    dependencies:
+      '@rethinkhealth/hl7v2-ast':
+        specifier: workspace:*
+        version: link:../hl7v2-ast
+      '@rethinkhealth/hl7v2-profiles':
+        specifier: workspace:*
+        version: link:../hl7v2-profiles
+      '@rethinkhealth/hl7v2-util-query':
+        specifier: workspace:*
+        version: link:../hl7v2-util-query
+      '@rethinkhealth/hl7v2-util-visit':
+        specifier: workspace:*
+        version: link:../hl7v2-util-visit
+      '@rethinkhealth/hl7v2-utils':
+        specifier: workspace:*
+        version: link:../hl7v2-utils
+      unified-lint-rule:
+        specifier: 3.0.1
+        version: 3.0.1
+    devDependencies:
+      '@rethinkhealth/hl7v2-builder':
+        specifier: workspace:*
+        version: link:../hl7v2-builder
+      '@rethinkhealth/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@rethinkhealth/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.10.1
+      '@vitest/coverage-v8':
+        specifier: 4.0.18
+        version: 4.0.18(vitest@4.0.18(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.8.1))
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      unified:
+        specifier: 11.0.5
+        version: 11.0.5
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.0.18
+        version: 4.0.18(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.8.1)
+
   packages/hl7v2-lint-required-message-header:
     dependencies:
       unified:
@@ -1118,6 +1170,64 @@ importers:
       unist:
         specifier: ^0.0.1
         version: 0.0.1
+      vitest:
+        specifier: 4.0.18
+        version: 4.0.18(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.8.1)
+
+  packages/hl7v2-preset-lint-profile-recommended:
+    dependencies:
+      '@rethinkhealth/hl7v2-lint-profile-events-segments-order':
+        specifier: workspace:*
+        version: link:../hl7v2-lint-profile-events-segments-order
+      '@rethinkhealth/hl7v2-lint-profile-field-max-length':
+        specifier: workspace:*
+        version: link:../hl7v2-lint-profile-field-max-length
+      '@rethinkhealth/hl7v2-lint-profile-field-repetition':
+        specifier: workspace:*
+        version: link:../hl7v2-lint-profile-field-repetition
+      '@rethinkhealth/hl7v2-lint-profile-required-components':
+        specifier: workspace:*
+        version: link:../hl7v2-lint-profile-required-components
+      '@rethinkhealth/hl7v2-lint-profile-required-fields':
+        specifier: workspace:*
+        version: link:../hl7v2-lint-profile-required-fields
+      '@rethinkhealth/hl7v2-lint-profile-table-values':
+        specifier: workspace:*
+        version: link:../hl7v2-lint-profile-table-values
+      unified:
+        specifier: 11.0.5
+        version: 11.0.5
+    devDependencies:
+      '@rethinkhealth/hl7v2-ast':
+        specifier: workspace:*
+        version: link:../hl7v2-ast
+      '@rethinkhealth/hl7v2-builder':
+        specifier: workspace:*
+        version: link:../hl7v2-builder
+      '@rethinkhealth/hl7v2-profiles':
+        specifier: workspace:*
+        version: link:../hl7v2-profiles
+      '@rethinkhealth/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@rethinkhealth/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.10.1
+      '@vitest/coverage-v8':
+        specifier: 4.0.18
+        version: 4.0.18(vitest@4.0.18(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.8.1))
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.0.18
         version: 4.0.18(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.8.1)


### PR DESCRIPTION
## Summary

Preset that bundles all profile-based lint rules into a single `.use()` call.

### Rules included

- **required-fields** — validates required fields are present and non-empty
- **field-max-length** — validates field value lengths against maxLength
- **field-repetition** — flags non-repeatable fields with multiple repetitions
- **required-components** — validates required components in composite datatypes
- **table-values** — validates coded values against HL7-type tables

### Usage

```typescript
import { unified } from "unified";
import { hl7v2Parser } from "@rethinkhealth/hl7v2-parser";
import hl7v2PresetLintProfile from "@rethinkhealth/hl7v2-preset-lint-profile";

const processor = unified()
  .use(hl7v2Parser)
  .use(hl7v2PresetLintProfile);
```

### Tests

7 tests verifying each rule fires independently + an integration test that triggers all 5 rules and checks for distinct ruleIds.

## Test plan
- [x] 7 tests pass
- [x] Build and type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)