### PR TITLE
bench: add query utility benchmark to CodSpeed

### DIFF
--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -15,6 +15,7 @@
     "@rethinkhealth/hl7v2-parser": "workspace:*",
     "@rethinkhealth/hl7v2-preset-lint-profile-recommended": "workspace:*",
     "@rethinkhealth/hl7v2-profiles": "workspace:*",
+    "@rethinkhealth/hl7v2-util-query": "workspace:*",
     "@rethinkhealth/tsconfig": "workspace:*",
     "unified": "11.0.5",
     "vfile": "^6.0.3",

--- a/benchmarks/query.bench.ts
+++ b/benchmarks/query.bench.ts
@@ -1,0 +1,55 @@
+/**
+ * Query utility benchmarks — measures path parsing and AST traversal.
+ *
+ * Focuses on MSH field reads since multiple lint rules and plugins
+ * read MSH-9, MSH-12, etc. on every message.
+ */
+import { parseHL7v2 } from "@rethinkhealth/hl7v2-parser";
+import { select, value } from "@rethinkhealth/hl7v2-util-query";
+import { bench, describe } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SMALL_MESSAGE =
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20241201120000||ADT^A01^ADT_A01|MSG001|P|2.5.1\rPID|1||12345||Doe^John||19800101|M";
+
+const LARGE_MESSAGE = [
+  "MSH|^~\\&|LAB|FAC|EMR|RFAC|20241201120000||ORU^R01^ORU_R01|MSG002|P|2.5.1",
+  "PID|1||12345^^^MRN||Doe^John^Q||19800101|M",
+  ...Array.from(
+    { length: 50 },
+    (_, i) =>
+      `OBX|${i + 1}|NM|8302-${i}^Test${i}^LN||${(100 + i).toFixed(1)}|mg/dL|50-200|N|||F`
+  ),
+].join("\r");
+
+const smallTree = parseHL7v2(SMALL_MESSAGE);
+const largeTree = parseHL7v2(LARGE_MESSAGE);
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+describe("query", () => {
+  bench("query: value(tree, 'MSH-12') — small message", () => {
+    value(smallTree, "MSH-12");
+  });
+
+  bench("query: value(tree, 'MSH-12') — large message", () => {
+    value(largeTree, "MSH-12");
+  });
+
+  bench("query: value(tree, 'MSH-9.1') — small message", () => {
+    value(smallTree, "MSH-9.1");
+  });
+
+  bench("query: select(tree, 'PID-5') — small message", () => {
+    select(smallTree, "PID-5");
+  });
+
+  bench("query: select(tree, 'OBX-5') — large message (first match)", () => {
+    select(largeTree, "OBX-5");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@rethinkhealth/hl7v2-profiles':
         specifier: workspace:*
         version: link:../packages/hl7v2-profiles
+      '@rethinkhealth/hl7v2-util-query':
+        specifier: workspace:*
+        version: link:../packages/hl7v2-util-query
       '@rethinkhealth/tsconfig':
         specifier: workspace:*
         version: link:../packages/tsconfig


### PR DESCRIPTION
## Summary

Adds a `query` benchmark to the centralized CodSpeed suite to establish a baseline for query path performance.

Benchmarks:
- `query: value(tree, 'MSH-12')` — small and large messages
- `query: value(tree, 'MSH-9.1')` — component-level MSH read
- `query: select(tree, 'PID-5')` — non-MSH segment selection
- `query: select(tree, 'OBX-5')` — first match in large message

This baseline is needed before #460 (segment lookup optimization) can show a measurable delta in CodSpeed.

## Test plan

- [x] `pnpm bench:ci` runs all benchmarks including query
- [x] No changes to query implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)