### PR TITLE
feat: add profile-based lint preset to parseHL7v2 pipeline

### DIFF
--- a/.changeset/add-profile-lint-to-pipeline.md
+++ b/.changeset/add-profile-lint-to-pipeline.md
@@ -1,0 +1,5 @@
+---
+"@rethinkhealth/hl7v2": minor
+---
+
+Add profile-based lint preset to the default `parseHL7v2` pipeline. Messages are now validated against HL7v2 field definitions, datatype constraints, and table values out of the box.

--- a/packages/hl7v2/README.md
+++ b/packages/hl7v2/README.md
@@ -1,20 +1,38 @@
-# @rethinlhealth/hl7v2
+# @rethinkhealth/hl7v2
 
-A processor based on **[unified](https://github.com/unifiedjs/unified)** framework to parse from HL7v2 and serialize to JSON.
+A processor based on **[unified](https://github.com/unifiedjs/unified)** framework to parse, validate, and serialize HL7v2 messages.
 
 ## What is this?
 
-See [the monorepo readme][rehype] for info on what the rehype ecosystem is.
+This package provides a pre-configured `unified` processor pipeline that handles the full lifecycle of an HL7v2 message:
+
+1. **Parse** — convert raw HL7v2 text into an AST
+2. **Annotate** — extract message structure metadata
+3. **Decode** — resolve HL7v2 escape sequences
+4. **Lint** — apply recommended validation rules
+5. **Profile lint** — validate against HL7v2 field definitions, datatypes, and table values
+6. **Serialize** — convert to JSON
 
 ## When should I use this?
 
-You can use this package when you want to use unified, have HL7v2 as input, and want JSON as output. This package is a shortcut for `unified().use(hl7v2Parser).use(hl7v2Jsonify)`
+Use this package when you want the full, batteries-included pipeline. It is a shortcut for:
+
+```typescript
+unified()
+  .use(hl7v2Parser)
+  .use(hl7v2MessageStructure)
+  .use(hl7v2DecodeEscapes)
+  .use(hl7v2PresetLintRecommended)
+  .use(hl7v2PresetLintProfileRecommended)
+  .use(hl7v2Jsonify)
+  .freeze();
+```
 
 If you want to inspect and format HL7v2 files in a project on the command line, you can use [`@rethinkhealth/hl7v2-cli`](../hl7v2-cli/).
 
 ## Install
 
-This package is [ESM only](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c). In Node.js (version 16+), install with [npm](https://docs.npmjs.com/cli/install):
+This package is [ESM only](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c). In Node.js (version 18+), install with [npm](https://docs.npmjs.com/cli/install):
 
 ```sh
 npm install @rethinkhealth/hl7v2
@@ -25,9 +43,10 @@ npm install @rethinkhealth/hl7v2
 ```typescript
 import { parseHL7v2 } from "@rethinkhealth/hl7v2";
 
-const results = await rehype().process("PID|....");
+const result = await parseHL7v2.process("MSH|^~\\&|...\rPID|1||12345...");
 
-console.error(String(file));
+console.log(result.messages); // validation messages (warnings/errors)
+console.log(result.result); // JSON output
 ```
 
 ## Syntax tree

--- a/packages/hl7v2/bench/pipeline.bench.ts
+++ b/packages/hl7v2/bench/pipeline.bench.ts
@@ -1,0 +1,72 @@
+/**
+ * Package-level pipeline benchmarks — measures the full parseHL7v2 pipeline
+ * including the profile-based lint preset.
+ *
+ * Run: pnpm bench
+ */
+import { bench, describe } from "vitest";
+
+import { parseHL7v2 } from "../src";
+
+// ---------------------------------------------------------------------------
+// Fixtures — realistic HL7v2 messages
+// ---------------------------------------------------------------------------
+
+const ADT_A01_SMALL = [
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20241201120000||ADT^A01^ADT_A01|MSG001|P|2.5.1",
+  "EVN|A01|20241201120000",
+  "PID|1||12345^^^MRN||Doe^John^Q||19800101|M|||123 Main St^^Springfield^IL^62701",
+].join("\r");
+
+const ORU_R01_MEDIUM = [
+  "MSH|^~\\&|LAB|FAC|EMR|RFAC|20241201120000||ORU^R01^ORU_R01|MSG002|P|2.5.1",
+  "PID|1||12345^^^MRN||Doe^John^Q||19800101|M",
+  "ORC|RE|ORD001|LAB001",
+  "OBR|1|ORD001|LAB001|CBC^Complete Blood Count|||20241201",
+  ...Array.from(
+    { length: 10 },
+    (_, i) =>
+      `OBX|${i + 1}|NM|WBC-${i}^White Blood Cell||${(5 + i * 0.3).toFixed(1)}|10*9/L|4.5-11.0|N|||F`
+  ),
+].join("\r");
+
+function buildLargeMessage(obxCount: number): string {
+  const segments = [
+    "MSH|^~\\&|LAB|FAC|EMR|RFAC|20241201120000||ORU^R01^ORU_R01|MSG003|P|2.5.1",
+    "PID|1||12345^^^MRN||Doe^John^Q^^Dr||19800101|M|||123 Main St^^Springfield^IL^62701^USA",
+    "PV1|1|I|ICU^101^A",
+    "ORC|RE|ORD001|LAB001",
+    "OBR|1|ORD001|LAB001|CBC^Complete Blood Count|||20241201",
+  ];
+  for (let i = 1; i <= obxCount; i++) {
+    segments.push(
+      `OBX|${i}|NM|8302-${i}^Test${i}^LN||${(100 + i * 0.5).toFixed(1)}|mg/dL|50-200|N|||F`
+    );
+  }
+  return segments.join("\r");
+}
+
+const LARGE_50 = buildLargeMessage(50);
+const LARGE_200 = buildLargeMessage(200);
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+describe("pipeline", () => {
+  bench("pipeline: process ADT^A01 (3 segments)", async () => {
+    await parseHL7v2.process(ADT_A01_SMALL);
+  });
+
+  bench("pipeline: process ORU^R01 (14 segments)", async () => {
+    await parseHL7v2.process(ORU_R01_MEDIUM);
+  });
+
+  bench("pipeline: process ORU^R01 (55 segments)", async () => {
+    await parseHL7v2.process(LARGE_50);
+  });
+
+  bench("pipeline: process ORU^R01 (205 segments)", async () => {
+    await parseHL7v2.process(LARGE_200);
+  });
+});

--- a/packages/hl7v2/package.json
+++ b/packages/hl7v2/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "build": "tsup && tsc --emitDeclarationOnly",
     "check-types": "tsc --noEmit",
+    "bench": "vitest bench --run",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest"
@@ -41,6 +42,7 @@
     "@rethinkhealth/hl7v2-jsonify": "workspace:*",
     "@rethinkhealth/hl7v2-message-structure": "workspace:*",
     "@rethinkhealth/hl7v2-parser": "workspace:*",
+    "@rethinkhealth/hl7v2-preset-lint-profile-recommended": "workspace:*",
     "@rethinkhealth/hl7v2-preset-lint-recommended": "workspace:*",
     "unified": "11.0.5"
   },

--- a/packages/hl7v2/src/index.ts
+++ b/packages/hl7v2/src/index.ts
@@ -2,6 +2,7 @@ import { hl7v2DecodeEscapes } from "@rethinkhealth/hl7v2-decode-escapes";
 import { hl7v2Jsonify } from "@rethinkhealth/hl7v2-jsonify";
 import { hl7v2MessageStructure } from "@rethinkhealth/hl7v2-message-structure";
 import { hl7v2Parser } from "@rethinkhealth/hl7v2-parser";
+import hl7v2PresetLintProfileRecommended from "@rethinkhealth/hl7v2-preset-lint-profile-recommended";
 import hl7v2PresetLintRecommended from "@rethinkhealth/hl7v2-preset-lint-recommended";
 import { unified } from "unified";
 
@@ -13,5 +14,6 @@ export const parseHL7v2 = unified()
   .use(hl7v2MessageStructure)
   .use(hl7v2DecodeEscapes)
   .use(hl7v2PresetLintRecommended)
+  .use(hl7v2PresetLintProfileRecommended)
   .use(hl7v2Jsonify)
   .freeze();

--- a/packages/hl7v2/vitest.config.ts
+++ b/packages/hl7v2/vitest.config.ts
@@ -6,6 +6,9 @@ export default mergeConfig(
   defineConfig({
     test: {
       include: ["tests/**/*.test.ts"],
+      benchmark: {
+        include: ["bench/**/*.bench.ts"],
+      },
       name: "hl7v2",
     },
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       '@rethinkhealth/hl7v2-parser':
         specifier: workspace:*
         version: link:../hl7v2-parser
+      '@rethinkhealth/hl7v2-preset-lint-profile-recommended':
+        specifier: workspace:*
+        version: link:../hl7v2-preset-lint-profile-recommended
       '@rethinkhealth/hl7v2-preset-lint-recommended':
         specifier: workspace:*
         version: link:../hl7v2-preset-lint-recommended


### PR DESCRIPTION
## Summary

- Add `hl7v2PresetLintProfileRecommended` to the default `parseHL7v2` unified pipeline, enabling out-of-the-box validation against HL7v2 field definitions, datatype constraints, and table values
- Add package-level pipeline benchmark (`packages/hl7v2/bench/pipeline.bench.ts`) mirroring the centralized CodSpeed benchmarks
- Update `packages/hl7v2/README.md` with accurate pipeline description and usage examples

## Pipeline (before → after)

```
parse → structure → decode → lint → jsonify                          # before
parse → structure → decode → lint → profile-lint → jsonify           # after
```

## Benchmark results

| Message size | ops/sec |
|---|---|
| ADT^A01 (3 segments) | ~2,800 |
| ORU^R01 (14 segments) | ~620 |
| ORU^R01 (55 segments) | ~140 |
| ORU^R01 (205 segments) | ~35 |

## Test plan

- [x] `pnpm test` passes (all 10 tests in hl7v2 package)
- [x] `pnpm bench` runs in both `packages/hl7v2` and centralized `benchmarks/`
- [x] `ultracite check` passes on all changed files
- [x] Build succeeds across all 33 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)