### PR TITLE
fix(hl7v2-mllp-ack): move hl7v2-mllp from peerDependencies to dependencies

### DIFF
--- a/packages/hl7v2-mllp-ack/package.json
+++ b/packages/hl7v2-mllp-ack/package.json
@@ -40,12 +40,12 @@
   },
   "dependencies": {
     "@rethinkhealth/hl7v2-ack": "workspace:*",
+    "@rethinkhealth/hl7v2-mllp": "workspace:*",
     "@rethinkhealth/hl7v2-to-hl7v2": "workspace:*"
   },
   "devDependencies": {
     "@rethinkhealth/hl7v2-ast": "workspace:*",
     "@rethinkhealth/hl7v2-builder": "workspace:*",
-    "@rethinkhealth/hl7v2-mllp": "workspace:*",
     "@rethinkhealth/testing": "workspace:*",
     "@rethinkhealth/tsconfig": "workspace:*",
     "@types/node": "^24.10.1",
@@ -53,9 +53,6 @@
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "4.1.0"
-  },
-  "peerDependencies": {
-    "@rethinkhealth/hl7v2-mllp": "workspace:*"
   },
   "engines": {
     "node": ">=18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1141,6 +1141,9 @@ importers:
       '@rethinkhealth/hl7v2-ack':
         specifier: workspace:*
         version: link:../hl7v2-ack
+      '@rethinkhealth/hl7v2-mllp':
+        specifier: workspace:*
+        version: link:../hl7v2-mllp
       '@rethinkhealth/hl7v2-to-hl7v2':
         specifier: workspace:*
         version: link:../hl7v2-to-hl7v2
@@ -1151,9 +1154,6 @@ importers:
       '@rethinkhealth/hl7v2-builder':
         specifier: workspace:*
         version: link:../hl7v2-builder
-      '@rethinkhealth/hl7v2-mllp':
-        specifier: workspace:*
-        version: link:../hl7v2-mllp
       '@rethinkhealth/testing':
         specifier: workspace:*
         version: link:../testing


### PR DESCRIPTION
## Summary

- Move `@rethinkhealth/hl7v2-mllp` from `peerDependencies` to `dependencies` in `hl7v2-mllp-ack`
- Fixes unintended `0.5.0 → 1.0.0` version bump in PR #399

**Root cause:** Changesets' `shouldBumpMajor()` promotes dependents to `major` when a peer dependency gets a non-patch bump. Combined with the `fixed` group (which forces all packages to share the highest bump type), a single `minor` changeset cascaded into a `major` bump for the entire monorepo.

**Verified:** After this change, `pnpm changeset version` correctly produces `0.6.0` instead of `1.0.0`.

## Test plan

- [x] `pnpm build` passes for hl7v2-mllp-ack
- [x] All 14 tests pass for hl7v2-mllp-ack
- [x] `pnpm changeset version` produces `0.6.0` (not `1.0.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)