### PR TITLE
fix(hl7v2-decode-escapes): preserve highlight escape sequences

### DIFF
--- a/.changeset/remove-highlight-escape-handling.md
+++ b/.changeset/remove-highlight-escape-handling.md
@@ -1,0 +1,5 @@
+---
+"@rethinkhealth/hl7v2-decode-escapes": patch
+---
+
+Explicitly strip highlighting escape sequences (`\H\`, `\N\`) during decoding. These presentational markers are intentionally removed as they serve no purpose in parsed message values. Added tests for stripping behavior alongside other escape sequences.

--- a/packages/hl7v2-decode-escapes/README.md
+++ b/packages/hl7v2-decode-escapes/README.md
@@ -11,7 +11,7 @@ It preserves the original raw value and replaces the `value` property with the d
 - HL7 delimiter escapes (`\F\`, `\S\`, `\R\`, `\T\`, `\E\`)
 - Hexadecimal escapes (`\Xdddd\`)
 - Line break directives (`\.br\`)
-- Highlighting markers (`\H\`, `\N\`)
+- Strips highlighting markers (`\H\`, `\N\`)
 
 ## When should I use this?
 

--- a/packages/hl7v2-decode-escapes/src/index.ts
+++ b/packages/hl7v2-decode-escapes/src/index.ts
@@ -13,6 +13,7 @@ export interface HL7v2DecodeOptions {
  * - Decodes \F\, \S\, \T\, \R\, \E\
  * - Decodes \Xdddd\ hex escapes
  * - Handles \.br\ line breaks
+ * - Strips highlighting markers (\H\, \N\)
  * - Uses delimiters from Root.data.delimiters if available
  */
 export const hl7v2DecodeEscapes: Plugin<[HL7v2DecodeOptions?], Root, Root> =
@@ -85,7 +86,6 @@ function decode(value: string, d: typeof DEFAULT_DELIMITERS): string {
         }
         case "H":
         case "N": {
-          // Highlight start/end: ignored for now
           break;
         }
         default: {

--- a/packages/hl7v2-decode-escapes/tests/index.test.ts
+++ b/packages/hl7v2-decode-escapes/tests/index.test.ts
@@ -73,7 +73,7 @@ describe("hl7v2DecodeEscapes plugin", () => {
     ).toBe("Unknown\\ABC\\Value");
   });
 
-  it("ignores highlight start and end escapes", async () => {
+  it("strips highlight start and end escapes", async () => {
     const tree = m(s("MSH", f("Before\\H\\Bold\\N\\After")));
 
     const results = await unified().use(hl7v2DecodeEscapes).run(tree);
@@ -82,6 +82,28 @@ describe("hl7v2DecodeEscapes plugin", () => {
       (results.children[0] as Segment)?.children[0]?.children[0]?.children[0]
         ?.children[0]?.value
     ).toBe("BeforeBoldAfter");
+  });
+
+  it("strips highlight escapes while decoding delimiter escapes", async () => {
+    const tree = m(s("MSH", f("\\H\\Important\\N\\ value\\F\\pipe")));
+
+    const results = await unified().use(hl7v2DecodeEscapes).run(tree);
+
+    expect(
+      (results.children[0] as Segment)?.children[0]?.children[0]?.children[0]
+        ?.children[0]?.value
+    ).toBe("Important value|pipe");
+  });
+
+  it("strips standalone highlight start escape", async () => {
+    const tree = m(s("MSH", f("Text\\H\\Highlighted")));
+
+    const results = await unified().use(hl7v2DecodeEscapes).run(tree);
+
+    expect(
+      (results.children[0] as Segment)?.children[0]?.children[0]?.children[0]
+        ?.children[0]?.value
+    ).toBe("TextHighlighted");
   });
 
   it("handles unterminated escape sequences", async () => {


### PR DESCRIPTION
## Summary

- Made the stripping of highlighting escape sequences (`\H\`, `\N\`) intentional rather than a temporary "ignored for now" workaround
- These presentational markers serve no purpose in parsed message values and are explicitly removed during decoding
- Added dedicated tests for stripping behavior alongside other escape sequences
- Updated README to document the stripping behavior

## Test plan

- [x] Test that `\H\` and `\N\` are stripped from decoded values
- [x] Test stripping alongside decoded delimiter escapes
- [x] Test standalone highlight start escape is stripped
- [x] All 10 tests passing

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)