### PR TITLE
fix(hl7v2-decode-escapes): options.delimiters now override tree.data.delimiters

### DIFF
--- a/.changeset/fix-delimiter-option-precedence.md
+++ b/.changeset/fix-delimiter-option-precedence.md
@@ -1,0 +1,5 @@
+---
+"@rethinkhealth/hl7v2-decode-escapes": patch
+---
+
+Fix delimiter precedence so that `options.delimiters` override `tree.data.delimiters`. Previously, explicit options were ignored when the tree already had delimiters set.

--- a/packages/hl7v2-decode-escapes/src/index.ts
+++ b/packages/hl7v2-decode-escapes/src/index.ts
@@ -18,16 +18,15 @@ export interface HL7v2DecodeOptions {
  */
 export const hl7v2DecodeEscapes: Plugin<[HL7v2DecodeOptions?], Root, Root> =
   (options) => (tree: Root) => {
-    const delimiters =
-      (tree.data as { delimiters?: Partial<Delimiters> })?.delimiters ||
-      options?.delimiters;
+    const d = {
+      ...DEFAULT_DELIMITERS,
+      ...(tree.data as { delimiters?: Partial<Delimiters> })?.delimiters,
+      ...options?.delimiters,
+    };
 
     visit(tree, "subcomponent", (node: Subcomponent) => {
       const raw = node.value;
-      node.value = decode(raw, {
-        ...DEFAULT_DELIMITERS,
-        ...delimiters,
-      });
+      node.value = decode(raw, d);
     });
 
     return tree;

--- a/packages/hl7v2-decode-escapes/tests/index.test.ts
+++ b/packages/hl7v2-decode-escapes/tests/index.test.ts
@@ -117,6 +117,32 @@ describe("hl7v2DecodeEscapes plugin", () => {
     ).toBe("Value\\Unterminated");
   });
 
+  it("options.delimiters override tree.data.delimiters", async () => {
+    const tree = m(s("MSH", f("Value\\F\\More")));
+
+    // Set tree delimiters to defaults (field = "|")
+    (tree as { data: { delimiters: Partial<Delimiters> } }).data = {
+      delimiters: {
+        field: "|",
+        component: "^",
+        escape: "\\",
+        repetition: "~",
+        subcomponent: "&",
+        segment: "\r",
+      },
+    };
+
+    // Override field delimiter via options — should take precedence
+    const results = await unified()
+      .use(hl7v2DecodeEscapes, { delimiters: { field: "*" } })
+      .run(tree);
+
+    expect(
+      (results.children[0] as Segment)?.children[0]?.children[0]?.children[0]
+        ?.children[0]?.value
+    ).toBe("Value*More");
+  });
+
   it("does nothing when there are no escapes", async () => {
     const tree = m(s("MSH", f("PlainValue")));
 


### PR DESCRIPTION
## Summary

- Fixed delimiter merge precedence in `hl7v2-decode-escapes` — explicit `options.delimiters` now correctly override `tree.data.delimiters`
- Previously used `||` which silently ignored options when tree data was present
- New precedence: `DEFAULT_DELIMITERS` < `tree.data.delimiters` < `options.delimiters`

**Note:** `hl7v2-encode-escapes` (#473) has the same pattern and should apply this fix when it lands.

## Test plan

- [x] Added test: options with `field: "*"` overrides tree data `field: "|"` — `\F\` decodes to `*`
- [x] All 11 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)