### PR TITLE
docs: update README with all packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,67 +63,103 @@ The `@rethinkhealth/hl7v2` ecosystem is organized as a set of modular packages, 
 
 - **[@rethinkhealth/hl7v2-to-hl7v2][github-hl7v2-to-hl7v2]**: converts HL7v2 AST nodes back to HL7v2 message text. Supports serializing any node type (Root, Segment, Field, etc.) and preserves delimiters. Useful for round-tripping, message editing, or custom serialization workflows.
 
-- **[@rethinkhealth/hl7v2-util-visit][github-hl7v2-visitor]**: lightweight visitor pattern for traversing HL7v2 AST trees with full path context. Provides immutable path tracking, metadata extraction (segment headers, group names), and control flow actions (skip, exit). Ideal for validation, transformation, and analysis workflows.
-
 - **[@rethinkhealth/hl7v2-cli][github-hl7v2-cli]**: a command-line tool for parsing, validating, and transforming HL7v2 messages. Useful for quick inspection, conversion, and automation in CI/CD pipelines.
 
 ### Plugins
 
 Plugins are composable functions that extend or modify the behavior of the HL7v2 processor. Plugins can add support for new syntaxes, transform the abstract syntax tree (AST), or integrate with external tools.
 
-- **[@rethinkhealth/hl7v2-decode-escapes][github-hl7v2-decode-escapes]**: decodes HL7v2 escape sequences (e.g., `\F\`, `\S\`, `\T\`, etc.) into their literal values, ensuring message content is interpreted correctly.
+- **[@rethinkhealth/hl7v2-decode-escapes][github-hl7v2-decode-escapes]**: decodes HL7v2 escape sequences (e.g., `\F\`, `\S\`, `\T\`, `\Xdd\`, `\.br\`) into their literal values, ensuring message content is interpreted correctly. Strips highlighting markers (`\H\`, `\N\`).
+
+- **[@rethinkhealth/hl7v2-encode-escapes][github-hl7v2-encode-escapes]**: encodes delimiter characters in subcomponent values as HL7v2 escape sequences (`|` → `\F\`, `^` → `\S\`, etc.) before serialization. The inverse of `hl7v2-decode-escapes`, ensuring round-trip fidelity and preventing malformed messages.
 
 - **[@rethinkhealth/hl7v2-annotate-message][github-hl7v2-annotate-message]**: annotates the AST with message metadata from `MSH` (version, message code, trigger event, structure) for downstream plugins to reuse without re-parsing.
 
-- **[@rethinkhealth/hl7v2-annotate-message-structure][github-hl7v2-annotate-message-structure]**: infers `MSH-9.3` (message structure) from `MSH-9.1` and `MSH-9.2` when missing, populating `tree.data.messageInfo.messageStructure`.
+- **[@rethinkhealth/hl7v2-message-structure][github-hl7v2-message-structure]**: infers `MSH-9.3` (message structure) from `MSH-9.1` and `MSH-9.2` when missing, using built-in event maps or custom mappings.
+
+### Transport
+
+Packages for sending and receiving HL7v2 messages over network protocols.
+
+- **[@rethinkhealth/hl7v2-mllp][github-hl7v2-mllp]**: MLLP (Minimal Lower Layer Protocol) transport for HL7v2. Includes frame encoding/decoding, a streaming decoder for chunked TCP data, and an Express-style routing engine with pattern-based message routing (`"ADT^A01"`, `"ADT^*"`, wildcards) and middleware composition.
+
+- **[@rethinkhealth/hl7v2-ack][github-hl7v2-ack]**: generates HL7v2 acknowledgment (ACK) messages from inbound messages. Supports AA (Application Accept), AE (Application Error), and AR (Application Reject) codes with proper MSA/ERR segment construction.
+
+- **[@rethinkhealth/hl7v2-mllp-ack][github-hl7v2-mllp-ack]**: MLLP middleware that automatically generates ACK/NAK responses. Catches handler exceptions and maps them to appropriate acknowledgment codes.
 
 ### Linting
 
 The `@rethinkhealth/hl7v2` ecosystem includes custom linting rules to help ensure message quality, conformance, and best practices. These lint rules are designed to catch common mistakes and enforce consistency in HL7v2 messages. Each rule is implemented as a `unified` plugin and can be used independently or in combination.
 
-#### Lint Preset(s)
+#### Lint Presets
 
-The recommended way to enable HL7v2 linting is to use the official preset:
+- **[@rethinkhealth/hl7v2-preset-lint-recommended][github-hl7v2-preset-lint-recommended]**
+  Bundles all core HL7v2 lint rules, providing a comprehensive set of checks for message quality, conformance, and best practices.
 
-- **[@rethinkhealth/hl7v2-preset-lint-recommended][github-hl7v2-preset-lint-recommended]**  
-  This preset bundles all core HL7v2 lint rules, providing a comprehensive set of checks for message quality, conformance, and best practices.  
-  By using the preset, you ensure your messages are validated against all supported rules with sensible defaults, and you can customize or extend the configuration as needed.
+- **[@rethinkhealth/hl7v2-preset-lint-profile-recommended][github-hl7v2-preset-lint-profile-recommended]**
+  Bundles all profile-based lint rules that validate messages against HL7v2 version-specific profiles (field definitions, data types, table values, and segment ordering).
 
-#### Lint Rules
+#### Core Lint Rules
 
-The rules that are maintained in this repo:
+- **[@rethinkhealth/hl7v2-lint-required-message-header][github-hl7v2-lint-required-message-header]**
+  Ensures that every HL7v2 message includes a required message header segment (such as `MSH`).
 
-- **[@rethinkhealth/hl7v2-lint-required-message-header][github-hl7v2-lint-required-message-header]**  
-  Ensures that every HL7v2 message includes a required message header segment (such as `MSH`). This rule helps catch incomplete or malformed messages that are missing the standard header, which is essential for correct parsing and routing.
+- **[@rethinkhealth/hl7v2-lint-max-message-size][github-hl7v2-lint-max-message-size]**
+  Reports when an HL7v2 message exceeds a configurable maximum size (in bytes or number of segments).
 
-- **[@rethinkhealth/hl7v2-lint-max-message-size][github-hl7v2-lint-max-message-size]**  
-  Reports when an HL7v2 message exceeds a configurable maximum size (in bytes or number of segments). Helps prevent oversized messages that may be rejected by downstream systems.
+- **[@rethinkhealth/hl7v2-lint-no-trailing-empty-field][github-hl7v2-lint-no-trailing-empty-field]**
+  Detects and warns about empty fields at the end of a segment, which can cause ambiguity or interoperability issues.
 
-- **[@rethinkhealth/hl7v2-lint-no-trailing-empty-field][github-hl7v2-lint-no-trailing-empty-field]**  
-  Detects and warns about empty fields at the end of a segment, which can cause ambiguity or interoperability issues in HL7v2 messages. This helps ensure that segments do not contain unnecessary trailing separators or empty fields.
+- **[@rethinkhealth/hl7v2-lint-segment-header-length][github-hl7v2-lint-segment-header-length]**
+  Validates that all segment headers are exactly three characters long, as required by the HL7v2 specification.
 
-- **[@rethinkhealth/hl7v2-lint-segment-header-length][github-hl7v2-lint-segment-header-length]**  
-  Validates that all segment headers are exactly three characters long, as required by the HL7v2 specification. This rule helps catch typos and malformed segment identifiers.
+- **[@rethinkhealth/hl7v2-lint-message-version][github-hl7v2-lint-message-version]**
+  Warns when an HL7v2 message's version is not supported or does not match expected constraints.
 
-- **[@rethinkhealth/hl7v2-lint-message-version][github-hl7v2-lint-message-version]**  
-  Warns when an HL7v2 message's version is not supported or does not match expected constraints. The default constraint is >3.0 and <=2.3
+- **[@rethinkhealth/hl7v2-lint-message-structure-missing][github-hl7v2-lint-message-structure-missing]**
+  Warns when `MSH-9.3` (message structure) is missing.
 
-- **[@rethinkhealth/hl7v2-lint-message-structure-missing][github-hl7v2-lint-message-structure-missing]**  
-  Warns when `MSH-9.3` (message structure) is missing. Combine with the annotator to infer and normalize message structure for downstream processing.
+#### Profile-Based Lint Rules
+
+These rules validate messages against HL7v2 version-specific profile definitions, loaded automatically based on the version in `MSH-12`.
+
+- **[@rethinkhealth/hl7v2-lint-profile-required-fields][github-hl7v2-lint-profile-required-fields]**
+  Validates that required fields per the HL7v2 profile are present and non-empty.
+
+- **[@rethinkhealth/hl7v2-lint-profile-field-max-length][github-hl7v2-lint-profile-field-max-length]**
+  Enforces field value maximum lengths as defined in the HL7v2 profile.
+
+- **[@rethinkhealth/hl7v2-lint-profile-field-repetition][github-hl7v2-lint-profile-field-repetition]**
+  Flags non-repeatable fields that contain multiple repetitions.
+
+- **[@rethinkhealth/hl7v2-lint-profile-required-components][github-hl7v2-lint-profile-required-components]**
+  Validates that required components within composite data types are present.
+
+- **[@rethinkhealth/hl7v2-lint-profile-table-values][github-hl7v2-lint-profile-table-values]**
+  Validates coded values against HL7v2 table definitions (UTG).
+
+- **[@rethinkhealth/hl7v2-lint-profile-events-segments-order][github-hl7v2-lint-profile-events-segments-order]**
+  Validates segment ordering per the message structure definition.
 
 ### Utilities
 
-Utilities are supporting packages that provide common helper functions and low-level tools used throughout the HL7v2 ecosystem. Utilities help ensure consistency, reduce duplication, and simplify maintenance across all related packages.
+Utilities are supporting packages that provide common helper functions and low-level tools used throughout the HL7v2 ecosystem.
 
 - **[@rethinkhealth/hl7v2-utils](./packages/hl7v2-utils)**: shared utilities for delimiter detection, normalization, and other HL7v2-specific helpers.
 
-- **[@rethinkhealth/hl7v2-util-query][github-hl7v2-util-query]**: canonical path querying utilities for navigating HL7v2 ASTs and retrieving values with strong typing support.
+- **[@rethinkhealth/hl7v2-util-visit][github-hl7v2-visitor]**: lightweight visitor pattern for traversing HL7v2 AST trees with full path context, metadata extraction, and control flow actions (skip, exit).
+
+- **[@rethinkhealth/hl7v2-util-query][github-hl7v2-util-query]**: canonical path querying utilities for navigating HL7v2 ASTs. Supports `select()`, `selectAll()`, `value()`, `set()`, and `matches()` with path syntax like `MSH-9.3` or `ORDER-ORC-1`.
 
 - **[@rethinkhealth/hl7v2-util-semver][github-hl7v2-util-semver]**: tiny, fast HL7v2 version and range utilities (basic comparators only).
 
 - **[@rethinkhealth/hl7v2-util-message-info][github-hl7v2-util-message-info]**: extract HL7v2 message metadata (version, type, structure) from MSH segments.
 
-- **[@rethinkhealth/hl7v2-config][github-hl7v2-config]**: configuration schema and loader for HL7v2 processing.
+- **[@rethinkhealth/hl7v2-util-timestamp][github-hl7v2-util-timestamp]**: HL7v2 timestamp handling with configurable precision (second, millisecond, microsecond).
+
+- **[@rethinkhealth/hl7v2-profiles][github-hl7v2-profiles]**: HL7v2 version-specific profile definitions (fields, data types, tables, segments) with LRU-cached loading. Used by profile-based lint rules.
+
+- **[@rethinkhealth/hl7v2-config][github-hl7v2-config]**: configuration schema and loader for HL7v2 processing (`.hl7v2rc.json`).
 
 ## Contributing
 
@@ -153,19 +189,32 @@ This program is licensed to you under the terms of the [MIT License](https://ope
 [github-hl7v2-parser]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-parser#readme
 [github-hl7v2-jsonify]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-jsonify#readme
 [github-hl7v2-decode-escapes]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-decode-escapes#readme
+[github-hl7v2-encode-escapes]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-encode-escapes#readme
 [github-hl7v2-annotate-message]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-annotate-message#readme
-[github-hl7v2-annotate-message-structure]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-annotate-message-structure#readme
+[github-hl7v2-message-structure]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-message-structure#readme
+[github-hl7v2-mllp]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-mllp#readme
+[github-hl7v2-ack]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-ack#readme
+[github-hl7v2-mllp-ack]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-mllp-ack#readme
 [github-hl7v2-lint-required-message-header]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-required-message-header#readme
 [github-hl7v2-lint-max-message-size]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-max-message-size#readme
 [github-hl7v2-lint-no-trailing-empty-field]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-no-trailing-empty-field#readme
 [github-hl7v2-lint-segment-header-length]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-segment-header-length#readme
+[github-hl7v2-lint-message-version]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-message-version#readme
+[github-hl7v2-lint-message-structure-missing]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-message-structure-missing#readme
+[github-hl7v2-lint-profile-required-fields]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-profile-required-fields#readme
+[github-hl7v2-lint-profile-field-max-length]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-profile-field-max-length#readme
+[github-hl7v2-lint-profile-field-repetition]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-profile-field-repetition#readme
+[github-hl7v2-lint-profile-required-components]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-profile-required-components#readme
+[github-hl7v2-lint-profile-table-values]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-profile-table-values#readme
+[github-hl7v2-lint-profile-events-segments-order]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-profile-events-segments-order#readme
 [github-hl7v2-preset-lint-recommended]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-preset-lint-recommended#readme
+[github-hl7v2-preset-lint-profile-recommended]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-preset-lint-profile-recommended#readme
+[github-hl7v2-profiles]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-profiles#readme
 [github-hl7v2-utils]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-utils#readme
 [github-hl7v2-util-query]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-util-query#readme
 [github-hl7v2-to-hl7v2]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-to-hl7v2#readme
 [github-hl7v2-visitor]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-util-visit#readme
-[github-hl7v2-lint-message-version]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-message-version#readme
 [github-hl7v2-util-semver]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-util-semver#readme
-[github-hl7v2-lint-message-structure-missing]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-lint-message-structure-missing#readme
 [github-hl7v2-util-message-info]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-util-message-info#readme
+[github-hl7v2-util-timestamp]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-util-timestamp#readme
 [github-hl7v2-config]: https://github.com/rethinkhealth/hl7v2/tree/main/packages/hl7v2-config#readme


### PR DESCRIPTION
## Summary

- Added 13 missing packages to the README that were not previously documented
- Added new **Transport** section for MLLP, ACK, and MLLP-ACK packages
- Added **Profile-Based Lint Rules** subsection with all 6 profile lint rules
- Added profile lint preset (`hl7v2-preset-lint-profile-recommended`)
- Added `hl7v2-encode-escapes`, `hl7v2-message-structure`, `hl7v2-profiles`, `hl7v2-util-timestamp`
- Updated descriptions for existing packages (decode-escapes, query, visitor)
- Moved `hl7v2-util-visit` from Core to Utilities where it belongs
- Removed `hl7v2-annotate-message-structure` (replaced by `hl7v2-message-structure`)

## Test plan

- [x] All package links verified against actual directory names
- [x] No broken reference links

🤖 Generated with [Claude Code](https://claude.com/claude-code)