### PR TITLE
fix(hl7v2): update test snapshot for message structure lint output

### DIFF
--- a/packages/hl7v2/tests/__snapshots__/index.test.ts.snap
+++ b/packages/hl7v2/tests/__snapshots__/index.test.ts.snap
@@ -9,7 +9,9 @@ exports[`apply > parses MSH + PID and decodes escapes, then stringifies to JSON 
   "cwd": Any<String>,
   "data": {},
   "history": [],
-  "messages": [],
+  "messages": [
+    [2:1-2:50: Unexpected segment 'PID'. Expected: EVN, SFT],
+  ],
   "result": [
     {
       "fields": [


### PR DESCRIPTION
## Summary
- Updated stale test snapshot in `packages/hl7v2` that was failing after the extra-fields/extra-components lint rules were added in #522
- The lint preset now correctly flags `PID` as unexpected after `MSH` in an `ADT^A01` message (expects `EVN` or `SFT` first)

## Test plan
- [x] `pnpm vitest run` passes in `packages/hl7v2` (9/9 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)