### PR TITLE
fix(hl7v2-mllp, glion): capture ACK code in telemetry by prepending middleware

### DIFF
--- a/.changeset/fix-telemetry-ack-ordering.md
+++ b/.changeset/fix-telemetry-ack-ordering.md
@@ -1,0 +1,11 @@
+---
+"@rethinkhealth/hl7v2-mllp": patch
+"glion": patch
+---
+
+Fix telemetry middleware not capturing ACK codes when `ackMiddleware()` is used.
+
+The TUI displayed `?` instead of `AA`/`AE`/`AR` because the telemetry middleware was installed as the innermost middleware, causing it to read `ctx.res` before the outer `ackMiddleware` had set it. Telemetry is now prepended (outermost) so its `await next()` completes after all user middleware have run.
+
+- Add `{ prepend: true }` option to `Mllp.use()` for inserting middleware at the front of the chain
+- Prepend the glion telemetry middleware so it wraps ackMiddleware correctly

--- a/.changeset/fix-telemetry-ack-ordering.md
+++ b/.changeset/fix-telemetry-ack-ordering.md
@@ -1,5 +1,5 @@
 ---
-"@rethinkhealth/hl7v2-mllp": patch
+"@rethinkhealth/hl7v2-mllp": minor
 "glion": patch
 ---
 

--- a/packages/glion/src/child/middlewares.ts
+++ b/packages/glion/src/child/middlewares.ts
@@ -8,10 +8,12 @@
  *
  * ## Middleware positioning
  *
- * This middleware must be installed LAST via `app.use()` so it sits
- * at the innermost position in the middleware chain. `performance.now()`
- * then measures only the user's handler time, not other middleware
- * (parsing, validation, etc.) that runs before `next()`.
+ * This middleware must be PREPENDED via `app.use(mw, { prepend: true })`
+ * so it sits at the outermost position in the middleware chain. Its
+ * `await next()` then completes after all user middleware (including
+ * `ackMiddleware`) have run, ensuring `ctx.res` is populated with the
+ * ACK response before telemetry reads it. `performance.now()` measures
+ * the full middleware + handler time.
  *
  * ## ACK parsing
  *

--- a/packages/glion/src/child/runner.ts
+++ b/packages/glion/src/child/runner.ts
@@ -107,9 +107,11 @@ async function main(): Promise<void> {
 
   // Step 3: Install the telemetry middleware.
   // This wraps every MLLP message handler to emit a "msg" event
-  // with timing, trigger, control ID, and ACK code. Installed last
-  // (innermost) so it measures only the user's handler time.
-  app.use(createMsgTelemetry(emit));
+  // with timing, trigger, control ID, and ACK code. Prepended so it
+  // sits outermost — its `await next()` completes after all user
+  // middleware (including ackMiddleware) have run, ensuring ctx.res
+  // and the ACK code are captured correctly.
+  app.use(createMsgTelemetry(emit), { prepend: true });
 
   // Step 4: Read TLS certificates (if configured).
   // Paths are absolute (resolved by the parent's config loader).
@@ -340,8 +342,6 @@ async function readFileOrThrow(path: string, field: string): Promise<Buffer> {
     );
   }
 }
-
-// ── Telemetry middleware ──────────────────────────────────────────
 
 // ── Top-level execution ──────────────────────────────────────────
 // This file is executed as a script (not imported). The top-level

--- a/packages/glion/src/child/runner.ts
+++ b/packages/glion/src/child/runner.ts
@@ -109,8 +109,8 @@ async function main(): Promise<void> {
   // This wraps every MLLP message handler to emit a "msg" event
   // with timing, trigger, control ID, and ACK code. Prepended so it
   // sits outermost — its `await next()` completes after all user
-  // middleware (including ackMiddleware) have run, ensuring ctx.res
-  // and the ACK code are captured correctly.
+  // middleware (including ackMiddleware) have run, ensuring any
+  // other middleware is injected before.
   app.use(createMsgTelemetry(emit), { prepend: true });
 
   // Step 4: Read TLS certificates (if configured).

--- a/packages/glion/test/child/middlewares.test.ts
+++ b/packages/glion/test/child/middlewares.test.ts
@@ -1,0 +1,230 @@
+// oxlint-disable require-await, no-empty-function
+import type { Context, Middleware } from "@rethinkhealth/hl7v2-mllp";
+import { describe, expect, it } from "vitest";
+
+import { createMsgTelemetry } from "../../src/child/middlewares.js";
+import type { PartialEvent } from "../../src/events.js";
+
+/**
+ * Minimal context stub for middleware tests.
+ * Only the fields read by createMsgTelemetry are needed.
+ */
+function makeCtx(overrides: Partial<Context> = {}): Context {
+  return {
+    connection: {
+      id: 1,
+      localPort: 2575,
+      remoteAddress: "127.0.0.1",
+      remotePort: 41_376,
+      secure: false,
+      state: new Map(),
+    },
+    messageType: "ADT",
+    triggerEvent: "A01",
+    controlId: "MSG001",
+    res: undefined,
+    ...overrides,
+  } as Context;
+}
+
+describe("createMsgTelemetry", () => {
+  it("emits a msg event with timing and routing info", async () => {
+    const events: PartialEvent[] = [];
+    const mw = createMsgTelemetry((e) => events.push(e));
+
+    const ctx = makeCtx();
+    await mw(ctx, async () => {});
+
+    expect(events).toHaveLength(1);
+    const event = events[0] as Record<string, unknown>;
+    expect(event.t).toBe("msg");
+    expect(event.trigger).toBe("ADT^A01");
+    expect(event.control).toBe("MSG001");
+    expect(event.remote).toBe("127.0.0.1:41376");
+    expectTypeOf(event.ms).toBeNumber();
+  });
+
+  it("reports ack=null when ctx.res is undefined", async () => {
+    const events: PartialEvent[] = [];
+    const mw = createMsgTelemetry((e) => events.push(e));
+
+    const ctx = makeCtx();
+    await mw(ctx, async () => {});
+
+    const event = events[0] as Record<string, unknown>;
+    expect(event.ack).toBeNull();
+  });
+
+  it("extracts AA ack code from ctx.res.raw", async () => {
+    const events: PartialEvent[] = [];
+    const mw = createMsgTelemetry((e) => events.push(e));
+
+    const ctx = makeCtx();
+    await mw(ctx, async () => {
+      ctx.res = {
+        raw: "MSH|^~\\&||||||||||2.5.1\rMSA|AA|MSG001",
+      };
+    });
+
+    const event = events[0] as Record<string, unknown>;
+    expect(event.ack).toBe("AA");
+  });
+
+  it("extracts AE ack code from ctx.res.raw", async () => {
+    const events: PartialEvent[] = [];
+    const mw = createMsgTelemetry((e) => events.push(e));
+
+    const ctx = makeCtx();
+    await mw(ctx, async () => {
+      ctx.res = {
+        raw: "MSH|^~\\&||||||||||2.5.1\rMSA|AE|MSG001|Error",
+      };
+    });
+
+    const event = events[0] as Record<string, unknown>;
+    expect(event.ack).toBe("AE");
+  });
+
+  it("extracts AR ack code from ctx.res.raw", async () => {
+    const events: PartialEvent[] = [];
+    const mw = createMsgTelemetry((e) => events.push(e));
+
+    const ctx = makeCtx();
+    await mw(ctx, async () => {
+      ctx.res = {
+        raw: "MSH|^~\\&||||||||||2.5.1\rMSA|AR|MSG001|Rejected",
+      };
+    });
+
+    const event = events[0] as Record<string, unknown>;
+    expect(event.ack).toBe("AR");
+  });
+
+  it("reports ack=null when res.raw has no MSA segment", async () => {
+    const events: PartialEvent[] = [];
+    const mw = createMsgTelemetry((e) => events.push(e));
+
+    const ctx = makeCtx();
+    await mw(ctx, async () => {
+      ctx.res = { raw: "MSH|^~\\&||||||||||2.5.1\rPID|1||12345" };
+    });
+
+    const event = events[0] as Record<string, unknown>;
+    expect(event.ack).toBeNull();
+  });
+
+  it("uses ? for missing messageType/triggerEvent", async () => {
+    const events: PartialEvent[] = [];
+    const mw = createMsgTelemetry((e) => events.push(e));
+
+    const ctx = makeCtx({
+      messageType: undefined as unknown as string,
+      triggerEvent: undefined as unknown as string,
+    });
+    await mw(ctx, async () => {});
+
+    const event = events[0] as Record<string, unknown>;
+    expect(event.trigger).toBe("?^?");
+  });
+
+  describe("middleware ordering interaction", () => {
+    /**
+     * This test reproduces the bug where telemetry middleware installed
+     * AFTER (inner to) ack middleware cannot see ctx.res because ack
+     * middleware sets it in its post-next() phase, which runs after
+     * the inner telemetry has already captured the response.
+     *
+     * Onion model:
+     * ackMiddleware (outer)
+     * → telemetry (inner)
+     * → handler
+     * ← telemetry reads ctx.res → undefined → ack=null → "?"
+     * ← ackMiddleware sets ctx.res (too late)
+     */
+    it("inner telemetry misses ctx.res set by outer ack middleware (the bug)", async () => {
+      const events: PartialEvent[] = [];
+      const telemetry = createMsgTelemetry((e) => events.push(e));
+
+      // Simulate ack middleware: sets ctx.res AFTER next()
+      const ackMw: Middleware = async (ctx, next) => {
+        await next();
+        ctx.res = {
+          raw: "MSH|^~\\&||||||||||2.5.1\rMSA|AA|MSG001",
+        };
+      };
+
+      const ctx = makeCtx();
+      // Chain: ackMw (outer) → telemetry (inner) → handler
+      const handler = async () => {};
+      const chain = async () => {
+        await ackMw(ctx, async () => {
+          await telemetry(ctx, handler);
+        });
+      };
+      await chain();
+
+      const event = events[0] as Record<string, unknown>;
+      // Bug: telemetry reads ctx.res before ackMw sets it
+      expect(event.ack).toBeNull();
+    });
+
+    /**
+     * This test shows the fix: when telemetry is outermost (prepended),
+     * it wraps ack middleware. Its await next() completes only after
+     * ack middleware has set ctx.res, so the ACK code is captured.
+     *
+     * Onion model:
+     * telemetry (outer)
+     * → ackMiddleware (inner)
+     * → handler
+     * ← ackMiddleware sets ctx.res
+     * ← telemetry reads ctx.res → "MSA|AA|..." → ack="AA"
+     */
+    it("outer telemetry captures ctx.res set by inner ack middleware (the fix)", async () => {
+      const events: PartialEvent[] = [];
+      const telemetry = createMsgTelemetry((e) => events.push(e));
+
+      // Simulate ack middleware: sets ctx.res AFTER next()
+      const ackMw: Middleware = async (ctx, next) => {
+        await next();
+        ctx.res = {
+          raw: "MSH|^~\\&||||||||||2.5.1\rMSA|AA|MSG001",
+        };
+      };
+
+      const ctx = makeCtx();
+      // Chain: telemetry (outer) → ackMw (inner) → handler
+      const handler = async () => {};
+      const chain = async () => {
+        await telemetry(ctx, async () => {
+          await ackMw(ctx, handler);
+        });
+      };
+      await chain();
+
+      const event = events[0] as Record<string, unknown>;
+      // Fix: telemetry reads ctx.res after ackMw sets it
+      expect(event.ack).toBe("AA");
+    });
+
+    it("outer telemetry captures error ACK codes too", async () => {
+      const events: PartialEvent[] = [];
+      const telemetry = createMsgTelemetry((e) => events.push(e));
+
+      const ackMw: Middleware = async (ctx, next) => {
+        await next();
+        ctx.res = {
+          raw: "MSH|^~\\&||||||||||2.5.1\rMSA|AE|MSG001|ApplicationError",
+        };
+      };
+
+      const ctx = makeCtx();
+      await telemetry(ctx, async () => {
+        await ackMw(ctx, async () => {});
+      });
+
+      const event = events[0] as Record<string, unknown>;
+      expect(event.ack).toBe("AE");
+    });
+  });
+});

--- a/packages/glion/test/child/middlewares.test.ts
+++ b/packages/glion/test/child/middlewares.test.ts
@@ -41,7 +41,7 @@ describe("createMsgTelemetry", () => {
     expect(event.trigger).toBe("ADT^A01");
     expect(event.control).toBe("MSG001");
     expect(event.remote).toBe("127.0.0.1:41376");
-    expectTypeOf(event.ms).toBeNumber();
+    expect(event.ms).toBeGreaterThanOrEqual(0);
   });
 
   it("reports ack=null when ctx.res is undefined", async () => {

--- a/packages/hl7v2-mllp/src/server/mllp.ts
+++ b/packages/hl7v2-mllp/src/server/mllp.ts
@@ -87,9 +87,12 @@ export class Mllp {
    * - A scoped middleware: `app.use('ADT^*', middleware)` or `app.use(filter,
    *   middleware)`
    */
-  use(middleware: Middleware): this;
+  use(middleware: Middleware, options?: { prepend?: boolean }): this;
   use(patternOrFilter: string | RouteFilter, middleware: Middleware): this;
-  use(first: string | RouteFilter | Middleware, second?: Middleware): this {
+  use(
+    first: string | RouteFilter | Middleware,
+    second?: Middleware | { prepend?: boolean }
+  ): this {
     // Scoped middleware: use('ADT^*', middleware) or use(filter, middleware)
     if (
       (typeof first === "string" || typeof first === "function") &&
@@ -101,7 +104,9 @@ export class Mllp {
 
     // Standard middleware: use((ctx, next) => { ... })
     if (typeof first === "function") {
-      this.#router.addMiddleware(first as Middleware);
+      const prepend =
+        second && typeof second === "object" ? second.prepend : false;
+      this.#router.addMiddleware(first as Middleware, prepend);
       return this;
     }
 

--- a/packages/hl7v2-mllp/src/server/router.ts
+++ b/packages/hl7v2-mllp/src/server/router.ts
@@ -70,8 +70,10 @@ export class Router {
 
   /**
    * Register global middleware (runs for all messages).
+   * When `prepend` is true, the middleware is inserted at the front
+   * of the chain so it executes outermost (first in, last out).
    */
-  addMiddleware(middleware: Middleware): void;
+  addMiddleware(middleware: Middleware, prepend?: boolean): void;
   /**
    * Register scoped middleware with a string pattern or filter function.
    */
@@ -81,16 +83,25 @@ export class Router {
   ): void;
   addMiddleware(
     patternOrFilterOrMiddleware: string | RouteFilter | Middleware,
-    middleware?: Middleware
+    middlewareOrPrepend?: Middleware | boolean
   ): void {
-    // Global middleware: addMiddleware(fn)
+    // Global middleware: addMiddleware(fn) or addMiddleware(fn, true)
     if (
       typeof patternOrFilterOrMiddleware === "function" &&
-      middleware === undefined
+      (middlewareOrPrepend === undefined ||
+        typeof middlewareOrPrepend === "boolean")
     ) {
-      this.#globalMiddleware.push(patternOrFilterOrMiddleware as Middleware);
+      if (middlewareOrPrepend) {
+        this.#globalMiddleware.unshift(
+          patternOrFilterOrMiddleware as Middleware
+        );
+      } else {
+        this.#globalMiddleware.push(patternOrFilterOrMiddleware as Middleware);
+      }
       return;
     }
+
+    const middleware = middlewareOrPrepend as Middleware | undefined;
 
     // Scoped middleware: addMiddleware(pattern/filter, fn)
     if (middleware) {

--- a/packages/hl7v2-mllp/src/server/router.ts
+++ b/packages/hl7v2-mllp/src/server/router.ts
@@ -91,7 +91,7 @@ export class Router {
       (middlewareOrPrepend === undefined ||
         typeof middlewareOrPrepend === "boolean")
     ) {
-      if (middlewareOrPrepend) {
+      if (middlewareOrPrepend === true) {
         this.#globalMiddleware.unshift(
           patternOrFilterOrMiddleware as Middleware
         );
@@ -101,10 +101,9 @@ export class Router {
       return;
     }
 
-    const middleware = middlewareOrPrepend as Middleware | undefined;
-
     // Scoped middleware: addMiddleware(pattern/filter, fn)
-    if (middleware) {
+    if (typeof middlewareOrPrepend === "function") {
+      const middleware = middlewareOrPrepend;
       const filter =
         typeof patternOrFilterOrMiddleware === "string"
           ? patternMatcher(patternOrFilterOrMiddleware)

--- a/packages/hl7v2-mllp/test/server/mllp-prepend.test.ts
+++ b/packages/hl7v2-mllp/test/server/mllp-prepend.test.ts
@@ -1,0 +1,159 @@
+// oxlint-disable require-await
+import { parseHL7v2 } from "@rethinkhealth/hl7v2";
+
+import { Mllp } from "../../src/server/mllp.js";
+import type { ConnectionInfo } from "../../src/server/types.js";
+
+const SAMPLE_ADT = [
+  "MSH|^~\\&|SendApp|SendFac|RecvApp|RecvFac|20240101120000||ADT^A01^ADT_A01|MSG001|P|2.5.1",
+  "EVN|A01|20240101120000",
+  "PID|1||12345^^^MRN||Doe^John",
+].join("\r");
+
+const MOCK_CONNECTION: ConnectionInfo = {
+  id: 1,
+  localPort: 2575,
+  remoteAddress: "127.0.0.1",
+  remotePort: 12_345,
+  secure: false,
+  state: new Map(),
+};
+
+function toBytes(msg: string): Uint8Array {
+  return new TextEncoder().encode(msg);
+}
+
+function createApp() {
+  return new Mllp().parser(parseHL7v2);
+}
+
+describe("Mllp.use({ prepend })", () => {
+  it("appends middleware by default", async () => {
+    const order: string[] = [];
+    const app = createApp();
+
+    app.use(async (_ctx, next) => {
+      order.push("first");
+      await next();
+    });
+    app.use(async (_ctx, next) => {
+      order.push("second");
+      await next();
+    });
+    app.on("*", async () => {
+      order.push("handler");
+    });
+
+    await app.handle(SAMPLE_ADT, toBytes(SAMPLE_ADT), MOCK_CONNECTION);
+    expect(order).toEqual(["first", "second", "handler"]);
+  });
+
+  it("prepends middleware with { prepend: true }", async () => {
+    const order: string[] = [];
+    const app = createApp();
+
+    app.use(async (_ctx, next) => {
+      order.push("first");
+      await next();
+    });
+    app.use(
+      async (_ctx, next) => {
+        order.push("prepended");
+        await next();
+      },
+      { prepend: true }
+    );
+    app.on("*", async () => {
+      order.push("handler");
+    });
+
+    await app.handle(SAMPLE_ADT, toBytes(SAMPLE_ADT), MOCK_CONNECTION);
+    expect(order).toEqual(["prepended", "first", "handler"]);
+  });
+
+  it("prepended middleware sees ctx.res set by later (inner) middleware", async () => {
+    const app = createApp();
+    let capturedRes: string | undefined;
+
+    // Register an inner middleware that sets ctx.res (simulates ackMiddleware)
+    app.use(async (ctx, next) => {
+      await next();
+      ctx.res = { raw: "MSH|^~\\&||||||||||2.5.1\rMSA|AA|MSG001" };
+    });
+
+    // Prepend an outer middleware that reads ctx.res after next() (simulates telemetry)
+    app.use(
+      async (ctx, next) => {
+        await next();
+        capturedRes = ctx.res?.raw;
+      },
+      { prepend: true }
+    );
+
+    app.on("*", async () => {
+      // handler does nothing
+    });
+
+    await app.handle(SAMPLE_ADT, toBytes(SAMPLE_ADT), MOCK_CONNECTION);
+    expect(capturedRes).toContain("MSA|AA");
+  });
+
+  it("non-prepended middleware does NOT see ctx.res set by outer middleware", async () => {
+    const app = createApp();
+    let capturedRes: string | undefined;
+
+    // Register outer middleware that sets ctx.res after next()
+    app.use(async (ctx, next) => {
+      await next();
+      ctx.res = { raw: "MSH|^~\\&||||||||||2.5.1\rMSA|AA|MSG001" };
+    });
+
+    // Append inner middleware (default) that reads ctx.res after next()
+    // This runs INSIDE the outer middleware, so it finishes BEFORE outer sets ctx.res
+    app.use(async (ctx, next) => {
+      await next();
+      capturedRes = ctx.res?.raw;
+    });
+
+    app.on("*", async () => {
+      // handler does nothing
+    });
+
+    await app.handle(SAMPLE_ADT, toBytes(SAMPLE_ADT), MOCK_CONNECTION);
+    // Inner middleware finishes before outer sets ctx.res → undefined
+    expect(capturedRes).toBeUndefined();
+  });
+
+  it("scoped middleware still works alongside prepend", async () => {
+    const order: string[] = [];
+    const app = createApp();
+
+    app.use(async (_ctx, next) => {
+      order.push("global");
+      await next();
+    });
+    app.use("ADT^*", async (_ctx, next) => {
+      order.push("scoped");
+      await next();
+    });
+    app.use(
+      async (_ctx, next) => {
+        order.push("prepended");
+        await next();
+      },
+      { prepend: true }
+    );
+    app.on("*", async () => {
+      order.push("handler");
+    });
+
+    await app.handle(SAMPLE_ADT, toBytes(SAMPLE_ADT), MOCK_CONNECTION);
+    expect(order).toEqual(["prepended", "global", "scoped", "handler"]);
+  });
+
+  it("returns this for fluent chaining", () => {
+    const app = new Mllp();
+    const result = app.use(async (_ctx, next) => next(), { prepend: true });
+    expect(result).toBe(app);
+  });
+});

--- a/packages/hl7v2-mllp/test/server/router-prepend.test.ts
+++ b/packages/hl7v2-mllp/test/server/router-prepend.test.ts
@@ -1,0 +1,93 @@
+// oxlint-disable require-await
+import { parseHL7v2 } from "@rethinkhealth/hl7v2";
+
+import { createContext } from "../../src/server/context.js";
+import { Router } from "../../src/server/router.js";
+import type { Context, Middleware } from "../../src/server/types.js";
+
+const CONNECTION = {
+  id: 1,
+  localPort: 2575,
+  remoteAddress: "127.0.0.1",
+  remotePort: 12_345,
+  secure: false,
+  state: new Map(),
+};
+
+function makeCtx(raw: string): Context {
+  return createContext({
+    bytes: new TextEncoder().encode(raw),
+    connection: CONNECTION,
+    processor: parseHL7v2,
+    raw,
+  });
+}
+
+const ADT_A01 = [
+  "MSH|^~\\&|SendApp|SendFac|RecvApp|RecvFac|20240101120000||ADT^A01^ADT_A01|MSG001|P|2.5.1",
+  "PID|1||12345",
+].join("\r");
+
+describe("Router addMiddleware prepend", () => {
+  it("appends by default (prepend=false)", () => {
+    const router = new Router();
+    const mw1: Middleware = async (_ctx, next) => next();
+    const mw2: Middleware = async (_ctx, next) => next();
+    router.addMiddleware(mw1);
+    router.addMiddleware(mw2);
+
+    const result = router.match(makeCtx(ADT_A01));
+    expect(result.middlewares).toEqual([mw1, mw2]);
+  });
+
+  it("prepends when prepend=true", () => {
+    const router = new Router();
+    const mw1: Middleware = async (_ctx, next) => next();
+    const mw2: Middleware = async (_ctx, next) => next();
+    router.addMiddleware(mw1);
+    router.addMiddleware(mw2, true);
+
+    const result = router.match(makeCtx(ADT_A01));
+    expect(result.middlewares).toEqual([mw2, mw1]);
+  });
+
+  it("prepend=false behaves like default append", () => {
+    const router = new Router();
+    const mw1: Middleware = async (_ctx, next) => next();
+    const mw2: Middleware = async (_ctx, next) => next();
+    router.addMiddleware(mw1);
+    router.addMiddleware(mw2, false);
+
+    const result = router.match(makeCtx(ADT_A01));
+    expect(result.middlewares).toEqual([mw1, mw2]);
+  });
+
+  it("multiple prepends stack in LIFO order", () => {
+    const router = new Router();
+    const mw1: Middleware = async (_ctx, next) => next();
+    const mw2: Middleware = async (_ctx, next) => next();
+    const mw3: Middleware = async (_ctx, next) => next();
+    router.addMiddleware(mw1);
+    router.addMiddleware(mw2, true);
+    router.addMiddleware(mw3, true);
+
+    const result = router.match(makeCtx(ADT_A01));
+    // mw3 prepended last → front, mw2 prepended first → second, mw1 appended → last
+    expect(result.middlewares).toEqual([mw3, mw2, mw1]);
+  });
+
+  it("prepend does not affect scoped middleware", () => {
+    const router = new Router();
+    const globalMw: Middleware = async (_ctx, next) => next();
+    const scopedMw: Middleware = async (_ctx, next) => next();
+    const prependedMw: Middleware = async (_ctx, next) => next();
+
+    router.addMiddleware(globalMw);
+    router.addMiddleware("ADT^*", scopedMw);
+    router.addMiddleware(prependedMw, true);
+
+    const result = router.match(makeCtx(ADT_A01));
+    // Global middleware: [prependedMw, globalMw], then scoped: [scopedMw]
+    expect(result.middlewares).toEqual([prependedMw, globalMw, scopedMw]);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes the glion TUI showing `?` instead of `AA`/`AE`/`AR` for ACK status when `ackMiddleware()` is used
- **Root cause:** The telemetry middleware was installed as the innermost middleware (after `ackMiddleware`). In the onion model, telemetry's `await next()` returned before `ackMiddleware` had set `ctx.res` in its post-`next()` phase, so the ACK code was always `null`
- **Fix:** Add `{ prepend: true }` option to `Mllp.use()` / `Router.addMiddleware()` to insert middleware at the front of the chain. The glion runner now prepends the telemetry middleware so it wraps outermost and captures `ctx.res` after all user middleware have completed

### Before (bug)
```
ackMiddleware (outer)  →  enters
  telemetry (inner)    →  enters
    handler            →  runs
  telemetry            →  reads ctx.res → undefined → ack=null → "?"
ackMiddleware          →  sets ctx.res (too late)
```

### After (fix)
```
telemetry (outer)      →  enters
  ackMiddleware (inner)→  enters
    handler            →  runs
  ackMiddleware        →  sets ctx.res with ACK
telemetry              →  reads ctx.res → "MSA|AA|..." → ack="AA"
```

## Changes

| Package | File | Change |
|---------|------|--------|
| `hl7v2-mllp` | `src/server/router.ts` | `addMiddleware()` accepts optional `prepend` boolean to `unshift` instead of `push` |
| `hl7v2-mllp` | `src/server/mllp.ts` | `use()` accepts `{ prepend: true }` options and passes through to router |
| `glion` | `src/child/runner.ts` | Telemetry middleware installed with `{ prepend: true }` |

## Test plan

- [x] `packages/hl7v2-mllp/test/server/router-prepend.test.ts` — 5 tests covering `addMiddleware` prepend/append ordering, LIFO stacking, and interaction with scoped middleware
- [x] `packages/hl7v2-mllp/test/server/mllp-prepend.test.ts` — 6 tests covering `Mllp.use({ prepend })` end-to-end execution order, ctx.res visibility across middleware positions, and fluent chaining
- [x] `packages/glion/test/child/middlewares.test.ts` — 10 tests covering telemetry event emission, ACK code extraction (AA/AE/AR/null), and the specific bug/fix scenario with middleware ordering interaction
- [x] All existing tests pass (190 mllp, 97 glion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)