### PR TITLE
feat(docs): write 16 missing per-package READMEs (Phase 2)

### DIFF
--- a/packages/annotate-delimiters/README.md
+++ b/packages/annotate-delimiters/README.md
@@ -1,23 +1,16 @@
 # @glion/annotate-delimiters
 
-> Unified plugin to annotate file.data with HL7v2 delimiters derived from MSH-1/MSH-2.
+Unified plugin to annotate file.data with HL7v2 delimiters derived from MSH-1/MSH-2.
 
 ## What it does
 
-HL7v2 messages encode their own delimiters in the first two fields of the MSH
-segment: MSH-1 carries the field separator and MSH-2 carries the component,
-repetition, escape, and subcomponent characters. This plugin reads those
-characters from the parsed tree once and stores the resolved `Delimiters`
-record on `file.data.delimiters` so downstream plugins (serializers, escape
-encoders, profile lints) can consult a single source of truth.
+HL7v2 messages encode their own delimiters in the first two fields of the MSH segment: MSH-1 carries the field separator and MSH-2 carries the component, repetition, escape, and subcomponent characters. This plugin reads those characters from the parsed tree once and stores the resolved `Delimiters` record on `file.data.delimiters` so downstream plugins (serializers, escape encoders, profile lints) can consult a single source of truth.
 
 ## Install
 
 ```bash
-pnpm add @glion/annotate-delimiters
+npm install @glion/annotate-delimiters
 ```
-
-> Using npm? `npm install @glion/annotate-delimiters`
 
 ## Use
 
@@ -40,8 +33,7 @@ const file = await processor.process(
 
 ## API
 
-This package exports the named constant `hl7v2AnnotateDelimiters`. It is a
-`unified` plugin with no options:
+This package exports the named constant `hl7v2AnnotateDelimiters`. It is a `unified` plugin with no options:
 
 ```ts
 import type { Root } from "@glion/ast";
@@ -50,14 +42,11 @@ import type { Plugin } from "unified";
 export const hl7v2AnnotateDelimiters: Plugin<[], Root, Root>;
 ```
 
-The plugin expects a parsed `Root` tree and a `VFile`. It never mutates the
-tree; it only writes to `file.data.delimiters`.
+The plugin expects a parsed `Root` tree and a `VFile`. It never mutates the tree; it only writes to `file.data.delimiters`.
 
 ## What it annotates
 
-This plugin writes to `file.data`, not to AST nodes. It derives the six
-HL7v2 delimiter characters from the first MSH segment and falls back to the
-default delimiter set when MSH-1 or MSH-2 is absent.
+This plugin writes to `file.data`, not to AST nodes. It derives the six HL7v2 delimiter characters from the first MSH segment and falls back to the default delimiter set when MSH-1 or MSH-2 is absent.
 
 ### `file.data.delimiters`
 
@@ -81,15 +70,11 @@ interface Delimiters {
 // }
 ```
 
-Resolution is delegated to the `delimiters()` helper in `@glion/util-query`,
-which walks the tree to find MSH, reads its first two fields, and merges any
-missing characters with `DEFAULT_DELIMITERS` from `@glion/utils`. Messages
-with no MSH segment receive the full default set.
+Resolution is delegated to the `delimiters()` helper in `@glion/util-query`, which walks the tree to find MSH, reads its first two fields, and merges any missing characters with `DEFAULT_DELIMITERS` from `@glion/utils`. Messages with no MSH segment receive the full default set.
 
 ## Part of Glion
 
-`@glion/annotate-delimiters` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/annotate-delimiters` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-delimiters/README.md
+++ b/packages/annotate-delimiters/README.md
@@ -1,0 +1,95 @@
+# @glion/annotate-delimiters
+
+> Unified plugin to annotate file.data with HL7v2 delimiters derived from MSH-1/MSH-2.
+
+## What it does
+
+HL7v2 messages encode their own delimiters in the first two fields of the MSH
+segment: MSH-1 carries the field separator and MSH-2 carries the component,
+repetition, escape, and subcomponent characters. This plugin reads those
+characters from the parsed tree once and stores the resolved `Delimiters`
+record on `file.data.delimiters` so downstream plugins (serializers, escape
+encoders, profile lints) can consult a single source of truth.
+
+## Install
+
+```bash
+pnpm add @glion/annotate-delimiters
+```
+
+> Using npm? `npm install @glion/annotate-delimiters`
+
+## Use
+
+```ts
+import { hl7v2AnnotateDelimiters } from "@glion/annotate-delimiters";
+import { hl7v2Parser } from "@glion/parser";
+import { unified } from "unified";
+
+const processor = unified().use(hl7v2Parser).use(hl7v2AnnotateDelimiters);
+
+const file = await processor.process(
+  "MSH|^~\\&|SENDER||RECEIVER||20241201||ADT^A01|MSG123|P|2.5\rPID|1||12345"
+);
+
+// file.data.delimiters === {
+//   field: "|", component: "^", repetition: "~",
+//   escape: "\\", subcomponent: "&", segment: "\r"
+// }
+```
+
+## API
+
+This package exports the named constant `hl7v2AnnotateDelimiters`. It is a
+`unified` plugin with no options:
+
+```ts
+import type { Root } from "@glion/ast";
+import type { Plugin } from "unified";
+
+export const hl7v2AnnotateDelimiters: Plugin<[], Root, Root>;
+```
+
+The plugin expects a parsed `Root` tree and a `VFile`. It never mutates the
+tree; it only writes to `file.data.delimiters`.
+
+## What it annotates
+
+This plugin writes to `file.data`, not to AST nodes. It derives the six
+HL7v2 delimiter characters from the first MSH segment and falls back to the
+default delimiter set when MSH-1 or MSH-2 is absent.
+
+### `file.data.delimiters`
+
+After this plugin runs, the vfile carries:
+
+```ts
+interface Delimiters {
+  field: string; // MSH-1, e.g. "|"
+  component: string; // MSH-2[0], e.g. "^"
+  repetition: string; // MSH-2[1], e.g. "~"
+  escape: string; // MSH-2[2], e.g. "\\"
+  subcomponent: string; // MSH-2[3], e.g. "&"
+  segment: string; // segment terminator, e.g. "\r"
+}
+
+// Augmented on VFile's DataMap:
+// declare module "vfile" {
+//   interface DataMap {
+//     delimiters: Delimiters;
+//   }
+// }
+```
+
+Resolution is delegated to the `delimiters()` helper in `@glion/util-query`,
+which walks the tree to find MSH, reads its first two fields, and merges any
+missing characters with `DEFAULT_DELIMITERS` from `@glion/utils`. Messages
+with no MSH segment receive the full default set.
+
+## Part of Glion
+
+`@glion/annotate-delimiters` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-profile-context/README.md
+++ b/packages/annotate-profile-context/README.md
@@ -1,0 +1,120 @@
+# @glion/annotate-profile-context
+
+> Unified plugin to centralize HL7v2 profile loading onto file.data.
+
+## What it does
+
+Downstream profile-aware plugins (segment annotators, field annotators,
+datatype annotators, code-system annotators, profile lints) all need the same
+slice of HL7v2 profile data for the version declared in MSH-12.1. This plugin
+loads that data once — field definitions, segment titles, datatype
+definitions (with component and subcomponent cascade), and table definitions
+— and stores it as a single `ProfileContext` on `file.data.profile`. The
+load is idempotent and silently skips unknown profiles.
+
+## Install
+
+```bash
+pnpm add @glion/annotate-profile-context
+```
+
+> Using npm? `npm install @glion/annotate-profile-context`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2Parser } from "@glion/parser";
+import { unified } from "unified";
+
+const processor = unified().use(hl7v2Parser).use(hl7v2AnnotateProfileContext);
+
+const file = await processor.process(
+  "MSH|^~\\&|SENDER||RECEIVER||20241201||ADT^A01|MSG123|P|2.5\rPID|1||12345"
+);
+
+// file.data.profile.version       === "2.5"
+// file.data.profile.fields        === Map<"MSH" | "PID", FieldDefinition>
+// file.data.profile.datatypes     === Map<"ST" | "CX" | "XPN" | ..., DatatypeDefinition>
+// file.data.profile.tables        === Map<"0001" | "0003" | ..., TableDefinition>
+// file.data.profile.segments.byId === Map<"MSH" | "PID" | ..., { title: string }>
+```
+
+## API
+
+This package exports the named constant `hl7v2AnnotateProfileContext` and
+the `ProfileContext` type. The default export is the plugin itself.
+
+```ts
+import type { Root } from "@glion/ast";
+import type {
+  DatatypeDefinition,
+  FieldDefinition,
+  SegmentDefinition,
+  TableDefinition,
+} from "@glion/profiles";
+import type { Plugin } from "unified";
+
+export const hl7v2AnnotateProfileContext: Plugin<[], Root, Root>;
+
+export interface ProfileContext {
+  version: string;
+  fields: ReadonlyMap<string, FieldDefinition>;
+  datatypes: ReadonlyMap<string, DatatypeDefinition>;
+  tables: ReadonlyMap<string, TableDefinition>;
+  segments: SegmentDefinition;
+}
+```
+
+The plugin is async: it awaits all profile loads in parallel.
+
+## What it annotates
+
+This plugin writes to `file.data`, not to AST nodes. It populates one entry,
+`file.data.profile`, with the resolved `ProfileContext` for the HL7v2 version
+declared in MSH-12.1.
+
+### `file.data.profile`
+
+After this plugin runs, the vfile carries:
+
+```ts
+// Augmented on VFile's DataMap:
+declare module "vfile" {
+  interface DataMap {
+    profile?: ProfileContext | undefined;
+  }
+}
+
+interface ProfileContext {
+  // HL7v2 version from MSH-12.1 (e.g. "2.5", "2.5.1", "2.8")
+  version: string;
+
+  // Field definitions indexed by segment name
+  fields: ReadonlyMap<string, FieldDefinition>;
+
+  // Datatype definitions indexed by datatype id (e.g. "ST", "CWE", "XPN")
+  datatypes: ReadonlyMap<string, DatatypeDefinition>;
+
+  // Table definitions indexed by normalized table id (e.g. "0001")
+  // Note: field profiles reference "HL70001"; this map uses "0001"
+  tables: ReadonlyMap<string, TableDefinition>;
+
+  // Segment titles indexed by segment id (e.g. "MSH", "PID", "OBX")
+  segments: SegmentDefinition;
+}
+```
+
+Loading is idempotent: if `file.data.profile` is already populated, the
+plugin returns immediately. If MSH-12.1 is missing, it returns without
+setting the key. Datatype loading cascades through composite datatypes up to
+three levels deep so every component and subcomponent datatype referenced
+anywhere in the field definitions is resolved in advance.
+
+## Part of Glion
+
+`@glion/annotate-profile-context` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-profile-context/README.md
+++ b/packages/annotate-profile-context/README.md
@@ -1,24 +1,16 @@
 # @glion/annotate-profile-context
 
-> Unified plugin to centralize HL7v2 profile loading onto file.data.
+Unified plugin to centralize HL7v2 profile loading onto file.data.
 
 ## What it does
 
-Downstream profile-aware plugins (segment annotators, field annotators,
-datatype annotators, code-system annotators, profile lints) all need the same
-slice of HL7v2 profile data for the version declared in MSH-12.1. This plugin
-loads that data once — field definitions, segment titles, datatype
-definitions (with component and subcomponent cascade), and table definitions
-— and stores it as a single `ProfileContext` on `file.data.profile`. The
-load is idempotent and silently skips unknown profiles.
+Downstream profile-aware plugins (segment annotators, field annotators, datatype annotators, code-system annotators, profile lints) all need the same slice of HL7v2 profile data for the version declared in MSH-12.1. This plugin loads that data once — field definitions, segment titles, datatype definitions (with component and subcomponent cascade), and table definitions — and stores it as a single `ProfileContext` on `file.data.profile`. The load is idempotent and silently skips unknown profiles.
 
 ## Install
 
 ```bash
-pnpm add @glion/annotate-profile-context
+npm install @glion/annotate-profile-context
 ```
-
-> Using npm? `npm install @glion/annotate-profile-context`
 
 ## Use
 
@@ -42,8 +34,7 @@ const file = await processor.process(
 
 ## API
 
-This package exports the named constant `hl7v2AnnotateProfileContext` and
-the `ProfileContext` type. The default export is the plugin itself.
+This package exports the named constant `hl7v2AnnotateProfileContext` and the `ProfileContext` type. The default export is the plugin itself.
 
 ```ts
 import type { Root } from "@glion/ast";
@@ -70,9 +61,7 @@ The plugin is async: it awaits all profile loads in parallel.
 
 ## What it annotates
 
-This plugin writes to `file.data`, not to AST nodes. It populates one entry,
-`file.data.profile`, with the resolved `ProfileContext` for the HL7v2 version
-declared in MSH-12.1.
+This plugin writes to `file.data`, not to AST nodes. It populates one entry, `file.data.profile`, with the resolved `ProfileContext` for the HL7v2 version declared in MSH-12.1.
 
 ### `file.data.profile`
 
@@ -105,16 +94,11 @@ interface ProfileContext {
 }
 ```
 
-Loading is idempotent: if `file.data.profile` is already populated, the
-plugin returns immediately. If MSH-12.1 is missing, it returns without
-setting the key. Datatype loading cascades through composite datatypes up to
-three levels deep so every component and subcomponent datatype referenced
-anywhere in the field definitions is resolved in advance.
+Loading is idempotent: if `file.data.profile` is already populated, the plugin returns immediately. If MSH-12.1 is missing, it returns without setting the key. Datatype loading cascades through composite datatypes up to three levels deep so every component and subcomponent datatype referenced anywhere in the field definitions is resolved in advance.
 
 ## Part of Glion
 
-`@glion/annotate-profile-context` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/annotate-profile-context` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-profile-datatypes/README.md
+++ b/packages/annotate-profile-datatypes/README.md
@@ -1,25 +1,16 @@
 # @glion/annotate-profile-datatypes
 
-> Unified plugin to annotate HL7v2 field repetition, component, and subcomponent nodes with datatype profile metadata.
+Unified plugin to annotate HL7v2 field repetition, component, and subcomponent nodes with datatype profile metadata.
 
 ## What it does
 
-HL7v2 fields hold either a primitive value (like `ST` or `DT`) or a composite
-structure built from a datatype like `XPN` or `CWE` whose components and
-subcomponents each have their own datatype. This plugin walks each field
-repetition, component, and subcomponent, resolves the corresponding datatype
-from the profile context, and writes that metadata onto `node.data` using a
-stop-at-primitive cascade — annotation stops at the node where the primitive
-value actually lives. It requires `@glion/annotate-profile-context` and
-`@glion/annotate-profile-fields` to run first.
+HL7v2 fields hold either a primitive value (like `ST` or `DT`) or a composite structure built from a datatype like `XPN` or `CWE` whose components and subcomponents each have their own datatype. This plugin walks each field repetition, component, and subcomponent, resolves the corresponding datatype from the profile context, and writes that metadata onto `node.data` using a stop-at-primitive cascade — annotation stops at the node where the primitive value actually lives. It requires `@glion/annotate-profile-context` and `@glion/annotate-profile-fields` to run first.
 
 ## Install
 
 ```bash
-pnpm add @glion/annotate-profile-datatypes
+npm install @glion/annotate-profile-datatypes
 ```
-
-> Using npm? `npm install @glion/annotate-profile-datatypes`
 
 ## Use
 
@@ -47,8 +38,7 @@ const file = await processor.process(
 
 ## API
 
-This package exports the named constant `hl7v2AnnotateProfileDatatypes`. The
-default export is the plugin itself.
+This package exports the named constant `hl7v2AnnotateProfileDatatypes`. The default export is the plugin itself.
 
 ```ts
 import type { Root } from "@glion/ast";
@@ -57,21 +47,13 @@ import type { Plugin } from "unified";
 export const hl7v2AnnotateProfileDatatypes: Plugin<[], Root, Root>;
 ```
 
-The plugin reads `file.data.profile` and `field.data.datatype` from
-upstream annotators. It writes to `FieldRepetitionData`, `ComponentData`, and
-`SubcomponentData` (all declared on the `@glion/ast` module augmentation).
+The plugin reads `file.data.profile` and `field.data.datatype` from upstream annotators. It writes to `FieldRepetitionData`, `ComponentData`, and `SubcomponentData` (all declared on the `@glion/ast` module augmentation).
 
 ## What it annotates
 
-This plugin visits three node types in order — `field-repetition`,
-`component`, and `subcomponent` — and writes datatype metadata to
-`node.data`. The cascade follows the composite structure: primitive fields
-stop at the repetition; composite fields with primitive components stop at
-the component; fully nested composites continue to the subcomponent.
+This plugin visits three node types in order — `field-repetition`, `component`, and `subcomponent` — and writes datatype metadata to `node.data`. The cascade follows the composite structure: primitive fields stop at the repetition; composite fields with primitive components stop at the component; fully nested composites continue to the subcomponent.
 
-`kind: "primitive"` means the value lives on that node. `kind: "composite"`
-means inspect the children. Nodes on ancestor paths of the primitive carry
-no annotation from this plugin.
+`kind: "primitive"` means the value lives on that node. `kind: "composite"` means inspect the children. Nodes on ancestor paths of the primitive carry no annotation from this plugin.
 
 ### `node.data` (FieldRepetition, Component, Subcomponent)
 
@@ -106,15 +88,11 @@ declare module "@glion/ast" {
 }
 ```
 
-Annotation is skipped for nodes whose datatype is not known to the profile
-(for example Z-segments or custom fields). The field-level `datatype`
-property is read from `field.data.datatype`, which is populated by
-`@glion/annotate-profile-fields`.
+Annotation is skipped for nodes whose datatype is not known to the profile (for example Z-segments or custom fields). The field-level `datatype` property is read from `field.data.datatype`, which is populated by `@glion/annotate-profile-fields`.
 
 ## Part of Glion
 
-`@glion/annotate-profile-datatypes` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/annotate-profile-datatypes` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-profile-datatypes/README.md
+++ b/packages/annotate-profile-datatypes/README.md
@@ -1,0 +1,120 @@
+# @glion/annotate-profile-datatypes
+
+> Unified plugin to annotate HL7v2 field repetition, component, and subcomponent nodes with datatype profile metadata.
+
+## What it does
+
+HL7v2 fields hold either a primitive value (like `ST` or `DT`) or a composite
+structure built from a datatype like `XPN` or `CWE` whose components and
+subcomponents each have their own datatype. This plugin walks each field
+repetition, component, and subcomponent, resolves the corresponding datatype
+from the profile context, and writes that metadata onto `node.data` using a
+stop-at-primitive cascade — annotation stops at the node where the primitive
+value actually lives. It requires `@glion/annotate-profile-context` and
+`@glion/annotate-profile-fields` to run first.
+
+## Install
+
+```bash
+pnpm add @glion/annotate-profile-datatypes
+```
+
+> Using npm? `npm install @glion/annotate-profile-datatypes`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2AnnotateProfileDatatypes } from "@glion/annotate-profile-datatypes";
+import { hl7v2AnnotateProfileFields } from "@glion/annotate-profile-fields";
+import { hl7v2Parser } from "@glion/parser";
+import { unified } from "unified";
+
+const processor = unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2AnnotateProfileFields)
+  .use(hl7v2AnnotateProfileDatatypes);
+
+const file = await processor.process(
+  "MSH|^~\\&|SENDER||RECEIVER||20241201||ADT^A01|MSG123|P|2.5\rPID|1||12345||Doe^John"
+);
+
+// PID-5 field-repetition.data === { datatypeId: "XPN", kind: "composite", title: "Extended Person Name" }
+// PID-5.1 component.data        === { id: "XPN.1", name: "Family Name", required: false, datatypeId: "FN", kind: "composite", title: "Family Name" }
+// PID-5.1.1 subcomponent.data   === { id: "FN.1", name: "Surname", required: true, datatypeId: "ST", kind: "primitive", title: "String Data" }
+```
+
+## API
+
+This package exports the named constant `hl7v2AnnotateProfileDatatypes`. The
+default export is the plugin itself.
+
+```ts
+import type { Root } from "@glion/ast";
+import type { Plugin } from "unified";
+
+export const hl7v2AnnotateProfileDatatypes: Plugin<[], Root, Root>;
+```
+
+The plugin reads `file.data.profile` and `field.data.datatype` from
+upstream annotators. It writes to `FieldRepetitionData`, `ComponentData`, and
+`SubcomponentData` (all declared on the `@glion/ast` module augmentation).
+
+## What it annotates
+
+This plugin visits three node types in order — `field-repetition`,
+`component`, and `subcomponent` — and writes datatype metadata to
+`node.data`. The cascade follows the composite structure: primitive fields
+stop at the repetition; composite fields with primitive components stop at
+the component; fully nested composites continue to the subcomponent.
+
+`kind: "primitive"` means the value lives on that node. `kind: "composite"`
+means inspect the children. Nodes on ancestor paths of the primitive carry
+no annotation from this plugin.
+
+### `node.data` (FieldRepetition, Component, Subcomponent)
+
+After this plugin runs, the augmented interfaces are:
+
+```ts
+declare module "@glion/ast" {
+  interface FieldRepetitionData {
+    datatypeId?: string; // e.g. "ST", "CWE", "XPN"
+    kind?: "primitive" | "composite";
+    title?: string; // e.g. "String Data", "Coded with Exceptions"
+  }
+
+  interface ComponentData {
+    id?: string; // "<datatypeId>.<sequence>", e.g. "CWE.1", "XPN.2"
+    name?: string; // e.g. "Family Name"
+    required?: boolean;
+    datatypeId?: string; // e.g. "ST", "ID", "FN"
+    maxLength?: number;
+    kind?: "primitive" | "composite";
+    title?: string;
+  }
+
+  interface SubcomponentData {
+    id?: string; // "<datatypeId>.<sequence>", e.g. "FN.1", "HD.2"
+    name?: string;
+    required?: boolean;
+    datatypeId?: string;
+    kind?: "primitive" | "composite";
+    title?: string;
+  }
+}
+```
+
+Annotation is skipped for nodes whose datatype is not known to the profile
+(for example Z-segments or custom fields). The field-level `datatype`
+property is read from `field.data.datatype`, which is populated by
+`@glion/annotate-profile-fields`.
+
+## Part of Glion
+
+`@glion/annotate-profile-datatypes` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-profile-fields-code-systems/README.md
+++ b/packages/annotate-profile-fields-code-systems/README.md
@@ -1,0 +1,113 @@
+# @glion/annotate-profile-fields-code-systems
+
+> Unified plugin to annotate HL7v2 field-level coded values with UTG code system metadata.
+
+## What it does
+
+Fields bound to HL7v2 tables (such as PID-8 `Administrative Sex` bound to
+table `0001`, or MSH-11.1 `Processing ID` bound to table `0103`) carry coded
+values that expand into human-readable displays and lifecycle statuses. This
+plugin resolves each field's table reference against the UTG code system
+registry in `@glion/profiles`, then writes the code system identity onto the
+field and the resolved value entry onto each repetition. It requires
+`@glion/annotate-profile-fields` to run first so that `field.data.table` is
+populated.
+
+## Install
+
+```bash
+pnpm add @glion/annotate-profile-fields-code-systems
+```
+
+> Using npm? `npm install @glion/annotate-profile-fields-code-systems`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2AnnotateProfileFields } from "@glion/annotate-profile-fields";
+import { hl7v2AnnotateProfileFieldsCodeSystems } from "@glion/annotate-profile-fields-code-systems";
+import { hl7v2Parser } from "@glion/parser";
+import { unified } from "unified";
+
+const processor = unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2AnnotateProfileFields)
+  .use(hl7v2AnnotateProfileFieldsCodeSystems);
+
+const file = await processor.process(
+  "MSH|^~\\&|SENDER||RECEIVER||20241201||ADT^A01|MSG123|P|2.5\rPID|1||12345||Doe^John||19800101|M"
+);
+
+// PID-8 field.data.codeSystem === { id: "v2-0001", name: "AdministrativeSex", title: "Administrative Sex" }
+// PID-8 repetition.data.code   === { value: "M", display: "Male", status: "A" }
+```
+
+## API
+
+This package exports the named constant
+`hl7v2AnnotateProfileFieldsCodeSystems`. The default export is the plugin
+itself.
+
+```ts
+import type { Root } from "@glion/ast";
+import type { Plugin } from "unified";
+
+export const hl7v2AnnotateProfileFieldsCodeSystems: Plugin<[], Root, Root>;
+```
+
+The plugin is async. Code system loads run in parallel; failures for unknown
+code systems are silent, while other errors attach a `VFile` message with
+source `hl7v2-annotate-profile-fields-code-systems`.
+
+## What it annotates
+
+This plugin visits coded `field` nodes (fields with a table reference on
+`field.data.table`) and writes two pieces of metadata: a code system
+identity on the field itself (shared across all repetitions) and a resolved
+code entry on each repetition. Per the HL7v2 spec, when a coded field uses
+a composite datatype (CWE or CNE) the table binding constrains CWE.1 — the
+first subcomponent of the first component — which is the value this plugin
+reads.
+
+### `node.data` (Field, FieldRepetition)
+
+After this plugin runs, the augmented interfaces are:
+
+```ts
+declare module "@glion/ast" {
+  interface FieldData {
+    // Code system identity for the field's table reference.
+    // Present only when the table resolves in the UTG registry.
+    codeSystem?: {
+      id: string; // e.g. "v2-0001" (derived from "HL70001")
+      name: string; // e.g. "AdministrativeSex"
+      title: string; // e.g. "Administrative Sex"
+    };
+  }
+
+  interface FieldRepetitionData {
+    // Resolved code entry for this repetition's primary value.
+    // Present only when the repetition's CWE.1 value matches a code.
+    code?: {
+      value: string; // as written in the message, e.g. "M"
+      display: string; // e.g. "Male"
+      status: string; // UTG lifecycle status, e.g. "A" (active)
+    };
+  }
+}
+```
+
+Table references are converted from the HL7v2 form (`HL70001`) to the UTG
+form (`v2-0001`) before lookup. Fields whose table does not resolve in the
+UTG registry are left untouched, and repetitions whose primary value does
+not match any code in the registry are left without a `code` entry.
+
+## Part of Glion
+
+`@glion/annotate-profile-fields-code-systems` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-profile-fields-code-systems/README.md
+++ b/packages/annotate-profile-fields-code-systems/README.md
@@ -1,25 +1,16 @@
 # @glion/annotate-profile-fields-code-systems
 
-> Unified plugin to annotate HL7v2 field-level coded values with UTG code system metadata.
+Unified plugin to annotate HL7v2 field-level coded values with UTG code system metadata.
 
 ## What it does
 
-Fields bound to HL7v2 tables (such as PID-8 `Administrative Sex` bound to
-table `0001`, or MSH-11.1 `Processing ID` bound to table `0103`) carry coded
-values that expand into human-readable displays and lifecycle statuses. This
-plugin resolves each field's table reference against the UTG code system
-registry in `@glion/profiles`, then writes the code system identity onto the
-field and the resolved value entry onto each repetition. It requires
-`@glion/annotate-profile-fields` to run first so that `field.data.table` is
-populated.
+Fields bound to HL7v2 tables (such as PID-8 `Administrative Sex` bound to table `0001`, or MSH-11.1 `Processing ID` bound to table `0103`) carry coded values that expand into human-readable displays and lifecycle statuses. This plugin resolves each field's table reference against the UTG code system registry in `@glion/profiles`, then writes the code system identity onto the field and the resolved value entry onto each repetition. It requires `@glion/annotate-profile-fields` to run first so that `field.data.table` is populated.
 
 ## Install
 
 ```bash
-pnpm add @glion/annotate-profile-fields-code-systems
+npm install @glion/annotate-profile-fields-code-systems
 ```
-
-> Using npm? `npm install @glion/annotate-profile-fields-code-systems`
 
 ## Use
 
@@ -46,9 +37,7 @@ const file = await processor.process(
 
 ## API
 
-This package exports the named constant
-`hl7v2AnnotateProfileFieldsCodeSystems`. The default export is the plugin
-itself.
+This package exports the named constant `hl7v2AnnotateProfileFieldsCodeSystems`. The default export is the plugin itself.
 
 ```ts
 import type { Root } from "@glion/ast";
@@ -57,19 +46,11 @@ import type { Plugin } from "unified";
 export const hl7v2AnnotateProfileFieldsCodeSystems: Plugin<[], Root, Root>;
 ```
 
-The plugin is async. Code system loads run in parallel; failures for unknown
-code systems are silent, while other errors attach a `VFile` message with
-source `hl7v2-annotate-profile-fields-code-systems`.
+The plugin is async. Code system loads run in parallel; failures for unknown code systems are silent, while other errors attach a `VFile` message with source `hl7v2-annotate-profile-fields-code-systems`.
 
 ## What it annotates
 
-This plugin visits coded `field` nodes (fields with a table reference on
-`field.data.table`) and writes two pieces of metadata: a code system
-identity on the field itself (shared across all repetitions) and a resolved
-code entry on each repetition. Per the HL7v2 spec, when a coded field uses
-a composite datatype (CWE or CNE) the table binding constrains CWE.1 — the
-first subcomponent of the first component — which is the value this plugin
-reads.
+This plugin visits coded `field` nodes (fields with a table reference on `field.data.table`) and writes two pieces of metadata: a code system identity on the field itself (shared across all repetitions) and a resolved code entry on each repetition. Per the HL7v2 spec, when a coded field uses a composite datatype (CWE or CNE) the table binding constrains CWE.1 — the first subcomponent of the first component — which is the value this plugin reads.
 
 ### `node.data` (Field, FieldRepetition)
 
@@ -99,15 +80,11 @@ declare module "@glion/ast" {
 }
 ```
 
-Table references are converted from the HL7v2 form (`HL70001`) to the UTG
-form (`v2-0001`) before lookup. Fields whose table does not resolve in the
-UTG registry are left untouched, and repetitions whose primary value does
-not match any code in the registry are left without a `code` entry.
+Table references are converted from the HL7v2 form (`HL70001`) to the UTG form (`v2-0001`) before lookup. Fields whose table does not resolve in the UTG registry are left untouched, and repetitions whose primary value does not match any code in the registry are left without a `code` entry.
 
 ## Part of Glion
 
-`@glion/annotate-profile-fields-code-systems` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/annotate-profile-fields-code-systems` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-profile-segments/README.md
+++ b/packages/annotate-profile-segments/README.md
@@ -1,24 +1,16 @@
 # @glion/annotate-profile-segments
 
-> Unified plugin to annotate HL7v2 segment nodes with profile metadata.
+Unified plugin to annotate HL7v2 segment nodes with profile metadata.
 
 ## What it does
 
-Segments in a parsed HL7v2 tree carry only their three-character name (`MSH`,
-`PID`, `OBX`, `OBR`). This plugin looks each segment up in the HL7v2
-specification profile for the message's version and writes the official
-segment title — for example `Message Header` for MSH or `Patient
-Identification` for PID — onto `segment.data.title`. It reads the preloaded
-profile from `file.data.profile`, so it requires
-`@glion/annotate-profile-context` to run first.
+Segments in a parsed HL7v2 tree carry only their three-character name (`MSH`, `PID`, `OBX`, `OBR`). This plugin looks each segment up in the HL7v2 specification profile for the message's version and writes the official segment title — for example `Message Header` for MSH or `Patient Identification` for PID — onto `segment.data.title`. It reads the preloaded profile from `file.data.profile`, so it requires `@glion/annotate-profile-context` to run first.
 
 ## Install
 
 ```bash
-pnpm add @glion/annotate-profile-segments
+npm install @glion/annotate-profile-segments
 ```
-
-> Using npm? `npm install @glion/annotate-profile-segments`
 
 ## Use
 
@@ -43,8 +35,7 @@ const file = await processor.process(
 
 ## API
 
-This package exports the named constant `hl7v2AnnotateProfileSegments`. The
-default export is the plugin itself.
+This package exports the named constant `hl7v2AnnotateProfileSegments`. The default export is the plugin itself.
 
 ```ts
 import type { Root } from "@glion/ast";
@@ -53,16 +44,11 @@ import type { Plugin } from "unified";
 export const hl7v2AnnotateProfileSegments: Plugin<[], Root, Root>;
 ```
 
-The plugin reads `file.data.profile.segments` (populated by
-`@glion/annotate-profile-context`) and writes to `SegmentData` on each
-matching segment.
+The plugin reads `file.data.profile.segments` (populated by `@glion/annotate-profile-context`) and writes to `SegmentData` on each matching segment.
 
 ## What it annotates
 
-This plugin visits every `segment` node, looks up the segment profile by
-three-character name, and writes the human-readable title onto
-`segment.data.title`. Segments with no matching profile — Z-segments or
-segments from unsupported versions — are left untouched.
+This plugin visits every `segment` node, looks up the segment profile by three-character name, and writes the human-readable title onto `segment.data.title`. Segments with no matching profile — Z-segments or segments from unsupported versions — are left untouched.
 
 ### `segment.data`
 
@@ -79,15 +65,11 @@ declare module "@glion/ast" {
 }
 ```
 
-Lookup uses `profile.segments.byId.get(node.name)` where `profile` is the
-`ProfileContext` attached by `@glion/annotate-profile-context`. If
-`file.data.profile` is missing entirely, the plugin returns without writing
-anything.
+Lookup uses `profile.segments.byId.get(node.name)` where `profile` is the `ProfileContext` attached by `@glion/annotate-profile-context`. If `file.data.profile` is missing entirely, the plugin returns without writing anything.
 
 ## Part of Glion
 
-`@glion/annotate-profile-segments` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/annotate-profile-segments` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-profile-segments/README.md
+++ b/packages/annotate-profile-segments/README.md
@@ -1,0 +1,93 @@
+# @glion/annotate-profile-segments
+
+> Unified plugin to annotate HL7v2 segment nodes with profile metadata.
+
+## What it does
+
+Segments in a parsed HL7v2 tree carry only their three-character name (`MSH`,
+`PID`, `OBX`, `OBR`). This plugin looks each segment up in the HL7v2
+specification profile for the message's version and writes the official
+segment title — for example `Message Header` for MSH or `Patient
+Identification` for PID — onto `segment.data.title`. It reads the preloaded
+profile from `file.data.profile`, so it requires
+`@glion/annotate-profile-context` to run first.
+
+## Install
+
+```bash
+pnpm add @glion/annotate-profile-segments
+```
+
+> Using npm? `npm install @glion/annotate-profile-segments`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2AnnotateProfileSegments } from "@glion/annotate-profile-segments";
+import { hl7v2Parser } from "@glion/parser";
+import { unified } from "unified";
+
+const processor = unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2AnnotateProfileSegments);
+
+const file = await processor.process(
+  "MSH|^~\\&|SENDER||RECEIVER||20241201||ADT^A01|MSG123|P|2.5\rPID|1||12345"
+);
+
+// MSH segment.data.title === "Message Header"
+// PID segment.data.title === "Patient Identification"
+```
+
+## API
+
+This package exports the named constant `hl7v2AnnotateProfileSegments`. The
+default export is the plugin itself.
+
+```ts
+import type { Root } from "@glion/ast";
+import type { Plugin } from "unified";
+
+export const hl7v2AnnotateProfileSegments: Plugin<[], Root, Root>;
+```
+
+The plugin reads `file.data.profile.segments` (populated by
+`@glion/annotate-profile-context`) and writes to `SegmentData` on each
+matching segment.
+
+## What it annotates
+
+This plugin visits every `segment` node, looks up the segment profile by
+three-character name, and writes the human-readable title onto
+`segment.data.title`. Segments with no matching profile — Z-segments or
+segments from unsupported versions — are left untouched.
+
+### `segment.data`
+
+After this plugin runs, the augmented interface is:
+
+```ts
+declare module "@glion/ast" {
+  interface SegmentData {
+    // Human-readable segment title from the HL7v2 specification.
+    // Examples: "Message Header" (MSH), "Patient Identification" (PID),
+    // "Observation/Result" (OBX), "Observation Request" (OBR).
+    title?: string;
+  }
+}
+```
+
+Lookup uses `profile.segments.byId.get(node.name)` where `profile` is the
+`ProfileContext` attached by `@glion/annotate-profile-context`. If
+`file.data.profile` is missing entirely, the plugin returns without writing
+anything.
+
+## Part of Glion
+
+`@glion/annotate-profile-segments` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/glion/README.md
+++ b/packages/glion/README.md
@@ -1,6 +1,6 @@
 # @glion/cli
 
-> The `glion` command — development and production runtime for Glion MLLP applications.
+The `glion` command — development and production runtime for Glion MLLP applications.
 
 ## What it does
 
@@ -9,10 +9,8 @@
 ## Install
 
 ```bash
-pnpm add @glion/cli
+npm install @glion/cli
 ```
-
-> Using npm? `npm install @glion/cli`
 
 ## Use
 
@@ -42,7 +40,7 @@ Add the two scripts to `package.json`:
 }
 ```
 
-Run `pnpm dev` during development. Run `pnpm start` in production.
+Run `npm run dev` during development. Run `npm start` in production.
 
 ## API
 
@@ -94,14 +92,13 @@ The `glion` binary ships with `#!/usr/bin/env node`. Bun and Deno require explic
 
 | Runtime | Invocation                                                          |
 | ------- | ------------------------------------------------------------------- |
-| Node    | `pnpm dev` / `pnpm start` / `npx glion dev`                         |
+| Node    | `npm run dev` / `npm start` / `npx glion dev`                       |
 | Bun     | `bun --bun run dev` (package.json script) or `bunx --bun glion dev` |
 | Deno    | `deno task dev` with a `deno.json` task that runs the bin           |
 
 ## Part of Glion
 
-`@glion/cli` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/cli` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/glion/README.md
+++ b/packages/glion/README.md
@@ -1,0 +1,107 @@
+# @glion/cli
+
+> The `glion` command — development and production runtime for Glion MLLP applications.
+
+## What it does
+
+`@glion/cli` provides the `glion` binary that runs Glion applications. A single-file MLLP app exported as `export default new Mllp()` becomes a running server with `glion dev` (for development with live reload and a terminal UI) or `glion start` (for production with graceful shutdown and structured logs). The CLI reads configuration from a `glion.config.ts` file when present or infers defaults when not.
+
+## Install
+
+```bash
+pnpm add @glion/cli
+```
+
+> Using npm? `npm install @glion/cli`
+
+## Use
+
+Define your app in a single file:
+
+```ts
+// glion.app.ts
+import { parseHL7v2 } from "@glion/hl7v2";
+import { Mllp } from "@glion/mllp";
+import { ackMiddleware } from "@glion/mllp-ack";
+
+export default new Mllp()
+  .parser(parseHL7v2)
+  .use(ackMiddleware())
+  .on("ADT^A01", handleAdmit)
+  .on("ORU^R01", handleResult);
+```
+
+Add the two scripts to `package.json`:
+
+```json
+{
+  "scripts": {
+    "dev": "glion dev",
+    "start": "glion start"
+  }
+}
+```
+
+Run `pnpm dev` during development. Run `pnpm start` in production.
+
+## API
+
+### `defineConfig(config)`
+
+Identity helper for `glion.config.ts` that gives TypeScript inference over the configuration schema:
+
+```ts
+// glion.config.ts
+import { defineConfig } from "@glion/cli/config";
+
+export default defineConfig({
+  entry: "./src/app.ts",
+  port: 2575,
+  hostname: "0.0.0.0",
+});
+```
+
+### `GlionConfig`
+
+Type exported from `@glion/cli/config`:
+
+| Field             | Type                            | Description                                                          |
+| ----------------- | ------------------------------- | -------------------------------------------------------------------- |
+| `entry`           | `string`                        | Path to the app file. Defaults to `./glion.app.ts` when unspecified. |
+| `port`            | `number`                        | Port to listen on. Defaults to `2575` (the MLLP standard).           |
+| `hostname`        | `string`                        | Interface to bind. Defaults to `0.0.0.0`.                            |
+| `tls`             | `{ cert: string; key: string }` | Enable MLLP over TLS.                                                |
+| `watch`           | `string[]`                      | Additional paths the dev watcher should reload on.                   |
+| `gracefulCloseMs` | `number`                        | Drain timeout for `glion start`. Defaults to `5000`.                 |
+
+## Commands
+
+### `glion dev`
+
+Runs the app with live reload. Watches the entry file and any paths listed in `watch`, cold-restarts on change, and renders a live terminal UI showing request/response counts, uptime, and error summaries. Falls back to log-only mode when stdout is not a TTY (CI, piped output).
+
+### `glion start`
+
+Runs the app in production. Emits JSON-line events to stdout for log aggregators, handles `SIGTERM` with a graceful drain (`gracefulCloseMs`, default 5000), and exits cleanly when the drain completes.
+
+### Zero-config mode
+
+Both commands work without a `glion.config.ts` when the app file is at `./glion.app.ts` at the project root. The TUI shows a `zero-config` badge to indicate no config was loaded. Create a `glion.config.ts` when you need custom ports, TLS, or additional watch paths.
+
+### Cross-runtime invocation
+
+The `glion` binary ships with `#!/usr/bin/env node`. Bun and Deno require explicit opt-in:
+
+| Runtime | Invocation                                                          |
+| ------- | ------------------------------------------------------------------- |
+| Node    | `pnpm dev` / `pnpm start` / `npx glion dev`                         |
+| Bun     | `bun --bun run dev` (package.json script) or `bunx --bun glion dev` |
+| Deno    | `deno task dev` with a `deno.json` task that runs the bin           |
+
+## Part of Glion
+
+`@glion/cli` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-extra-components/README.md
+++ b/packages/lint-profile-extra-components/README.md
@@ -1,0 +1,108 @@
+# @glion/lint-profile-extra-components
+
+> Lint rule to warn when a composite field contains more components than its datatype profile defines.
+
+## What it does
+
+Flags fields whose repetitions contain more components than the
+datatype's profile allows. For composite datatypes, the maximum is the
+highest sequence key in the datatype definition; for primitive datatypes
+the maximum is 1 (the value itself). The rule reads profile context
+attached by `@glion/annotate-profile-context`. Empty fields, fields on
+unknown segments, and fields whose datatype definition is missing are
+silently skipped.
+
+## Install
+
+```bash
+pnpm add @glion/lint-profile-extra-components
+```
+
+> Using npm? `npm install @glion/lint-profile-extra-components`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2Parser } from "@glion/parser";
+import hl7v2LintExtraComponents from "@glion/lint-profile-extra-components";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+
+const message = [
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
+].join("\r");
+
+const file = await unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2LintExtraComponents)
+  .process(message);
+
+console.error(reporter([file]));
+```
+
+## API
+
+### `unified().use(hl7v2LintExtraComponents)`
+
+A `unified` lint rule plugin. Takes no options.
+
+Reads `file.data.profile`. For each non-empty field it resolves the
+datatype definition. For primitives the allowed component count is 1; for
+composites it is the highest key in `dtDef.componentsBySequence`. Every
+component at a position greater than that max produces one message per
+offending repetition.
+
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
+
+declare const hl7v2LintExtraComponents: Plugin<[], Root>;
+export default hl7v2LintExtraComponents;
+```
+
+## What it checks
+
+This rule flags `^`-delimited components past the profile's defined range
+for a datatype. `PID-8` (Administrative Sex) is a primitive field in
+v2.5, so it allows exactly one component.
+
+### Valid
+
+`PID-8` has a single component (`F`), which matches the primitive limit:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+### Invalid
+
+`PID-8` has two components (`F^EXTRA`), which exceeds the v2.5 primitive
+limit of 1:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F^EXTRA
+```
+
+Reported message:
+
+```
+Component PID-8.2 is beyond the defined components for IS (max: 1 in v2.5)
+```
+
+The datatype code (for example `IS`, `CX`, `XPN`) comes from the field's
+profile. For composite datatypes the same rule applies — a `CX` field in
+v2.5 defines up to 10 components, so a value carrying an 11th is
+reported against that datatype.
+
+## Part of Glion
+
+`@glion/lint-profile-extra-components` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-extra-components/README.md
+++ b/packages/lint-profile-extra-components/README.md
@@ -1,24 +1,16 @@
 # @glion/lint-profile-extra-components
 
-> Lint rule to warn when a composite field contains more components than its datatype profile defines.
+Lint rule to warn when a composite field contains more components than its datatype profile defines.
 
 ## What it does
 
-Flags fields whose repetitions contain more components than the
-datatype's profile allows. For composite datatypes, the maximum is the
-highest sequence key in the datatype definition; for primitive datatypes
-the maximum is 1 (the value itself). The rule reads profile context
-attached by `@glion/annotate-profile-context`. Empty fields, fields on
-unknown segments, and fields whose datatype definition is missing are
-silently skipped.
+Flags fields whose repetitions contain more components than the datatype's profile allows. For composite datatypes, the maximum is the highest sequence key in the datatype definition; for primitive datatypes the maximum is 1 (the value itself). The rule reads profile context attached by `@glion/annotate-profile-context`. Empty fields, fields on unknown segments, and fields whose datatype definition is missing are silently skipped.
 
 ## Install
 
 ```bash
-pnpm add @glion/lint-profile-extra-components
+npm install @glion/lint-profile-extra-components
 ```
-
-> Using npm? `npm install @glion/lint-profile-extra-components`
 
 ## Use
 
@@ -49,11 +41,7 @@ console.error(reporter([file]));
 
 A `unified` lint rule plugin. Takes no options.
 
-Reads `file.data.profile`. For each non-empty field it resolves the
-datatype definition. For primitives the allowed component count is 1; for
-composites it is the highest key in `dtDef.componentsBySequence`. Every
-component at a position greater than that max produces one message per
-offending repetition.
+Reads `file.data.profile`. For each non-empty field it resolves the datatype definition. For primitives the allowed component count is 1; for composites it is the highest key in `dtDef.componentsBySequence`. Every component at a position greater than that max produces one message per offending repetition.
 
 ```ts
 import type { Plugin } from "unified";
@@ -65,9 +53,7 @@ export default hl7v2LintExtraComponents;
 
 ## What it checks
 
-This rule flags `^`-delimited components past the profile's defined range
-for a datatype. `PID-8` (Administrative Sex) is a primitive field in
-v2.5, so it allows exactly one component.
+This rule flags `^`-delimited components past the profile's defined range for a datatype. `PID-8` (Administrative Sex) is a primitive field in v2.5, so it allows exactly one component.
 
 ### Valid
 
@@ -80,8 +66,7 @@ PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
 
 ### Invalid
 
-`PID-8` has two components (`F^EXTRA`), which exceeds the v2.5 primitive
-limit of 1:
+`PID-8` has two components (`F^EXTRA`), which exceeds the v2.5 primitive limit of 1:
 
 ```hl7
 MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
@@ -94,15 +79,11 @@ Reported message:
 Component PID-8.2 is beyond the defined components for IS (max: 1 in v2.5)
 ```
 
-The datatype code (for example `IS`, `CX`, `XPN`) comes from the field's
-profile. For composite datatypes the same rule applies — a `CX` field in
-v2.5 defines up to 10 components, so a value carrying an 11th is
-reported against that datatype.
+The datatype code (for example `IS`, `CX`, `XPN`) comes from the field's profile. For composite datatypes the same rule applies — a `CX` field in v2.5 defines up to 10 components, so a value carrying an 11th is reported against that datatype.
 
 ## Part of Glion
 
-`@glion/lint-profile-extra-components` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-extra-components` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-extra-fields/README.md
+++ b/packages/lint-profile-extra-fields/README.md
@@ -1,0 +1,106 @@
+# @glion/lint-profile-extra-fields
+
+> Lint rule that warns when a segment contains fields beyond the maximum sequence defined in its profile.
+
+## What it does
+
+Flags fields whose sequence number exceeds the highest field position
+defined in the HL7v2 profile for that segment at the message's version.
+The rule reads profile context attached by
+`@glion/annotate-profile-context`, computes the maximum defined sequence
+per segment, and reports each field past that boundary. Segments without
+a known profile (for example Z-segments) are silently skipped.
+
+## Install
+
+```bash
+pnpm add @glion/lint-profile-extra-fields
+```
+
+> Using npm? `npm install @glion/lint-profile-extra-fields`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2Parser } from "@glion/parser";
+import hl7v2LintExtraFields from "@glion/lint-profile-extra-fields";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+
+const message = [
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
+].join("\r");
+
+const file = await unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2LintExtraFields)
+  .process(message);
+
+console.error(reporter([file]));
+```
+
+## API
+
+### `unified().use(hl7v2LintExtraFields)`
+
+A `unified` lint rule plugin. Takes no options.
+
+Reads `file.data.profile`. For each segment it looks up the field
+definition set and takes the largest key (a 1-based HL7 sequence number)
+as the maximum. It then walks the segment's fields and reports each
+field whose sequence is greater than that maximum.
+
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
+
+declare const hl7v2LintExtraFields: Plugin<[], Root>;
+export default hl7v2LintExtraFields;
+```
+
+## What it checks
+
+This rule flags fields past the defined range for a segment. `MSH` in
+v2.5 ends at `MSH-21`, so any field at sequence 22 or higher is
+unexpected for that segment and version.
+
+### Valid
+
+`MSH` stops at `MSH-12` (Version ID) and all fields are within the v2.5
+definition:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+### Invalid
+
+`MSH` carries a field at sequence 22, which is past the v2.5 maximum
+of `MSH-21`:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5||||||||||EXTRA
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+Reported message:
+
+```
+Field MSH-22 is beyond the defined fields for MSH (max: 21 in v2.5)
+```
+
+The reported max comes from the profile's highest sequence number and
+the version is taken from the annotated profile context. One message is
+reported per extra field.
+
+## Part of Glion
+
+`@glion/lint-profile-extra-fields` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-extra-fields/README.md
+++ b/packages/lint-profile-extra-fields/README.md
@@ -1,23 +1,16 @@
 # @glion/lint-profile-extra-fields
 
-> Lint rule that warns when a segment contains fields beyond the maximum sequence defined in its profile.
+Lint rule that warns when a segment contains fields beyond the maximum sequence defined in its profile.
 
 ## What it does
 
-Flags fields whose sequence number exceeds the highest field position
-defined in the HL7v2 profile for that segment at the message's version.
-The rule reads profile context attached by
-`@glion/annotate-profile-context`, computes the maximum defined sequence
-per segment, and reports each field past that boundary. Segments without
-a known profile (for example Z-segments) are silently skipped.
+Flags fields whose sequence number exceeds the highest field position defined in the HL7v2 profile for that segment at the message's version. The rule reads profile context attached by `@glion/annotate-profile-context`, computes the maximum defined sequence per segment, and reports each field past that boundary. Segments without a known profile (for example Z-segments) are silently skipped.
 
 ## Install
 
 ```bash
-pnpm add @glion/lint-profile-extra-fields
+npm install @glion/lint-profile-extra-fields
 ```
-
-> Using npm? `npm install @glion/lint-profile-extra-fields`
 
 ## Use
 
@@ -48,10 +41,7 @@ console.error(reporter([file]));
 
 A `unified` lint rule plugin. Takes no options.
 
-Reads `file.data.profile`. For each segment it looks up the field
-definition set and takes the largest key (a 1-based HL7 sequence number)
-as the maximum. It then walks the segment's fields and reports each
-field whose sequence is greater than that maximum.
+Reads `file.data.profile`. For each segment it looks up the field definition set and takes the largest key (a 1-based HL7 sequence number) as the maximum. It then walks the segment's fields and reports each field whose sequence is greater than that maximum.
 
 ```ts
 import type { Plugin } from "unified";
@@ -63,14 +53,11 @@ export default hl7v2LintExtraFields;
 
 ## What it checks
 
-This rule flags fields past the defined range for a segment. `MSH` in
-v2.5 ends at `MSH-21`, so any field at sequence 22 or higher is
-unexpected for that segment and version.
+This rule flags fields past the defined range for a segment. `MSH` in v2.5 ends at `MSH-21`, so any field at sequence 22 or higher is unexpected for that segment and version.
 
 ### Valid
 
-`MSH` stops at `MSH-12` (Version ID) and all fields are within the v2.5
-definition:
+`MSH` stops at `MSH-12` (Version ID) and all fields are within the v2.5 definition:
 
 ```hl7
 MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
@@ -79,8 +66,7 @@ PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
 
 ### Invalid
 
-`MSH` carries a field at sequence 22, which is past the v2.5 maximum
-of `MSH-21`:
+`MSH` carries a field at sequence 22, which is past the v2.5 maximum of `MSH-21`:
 
 ```hl7
 MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5||||||||||EXTRA
@@ -93,14 +79,11 @@ Reported message:
 Field MSH-22 is beyond the defined fields for MSH (max: 21 in v2.5)
 ```
 
-The reported max comes from the profile's highest sequence number and
-the version is taken from the annotated profile context. One message is
-reported per extra field.
+The reported max comes from the profile's highest sequence number and the version is taken from the annotated profile context. One message is reported per extra field.
 
 ## Part of Glion
 
-`@glion/lint-profile-extra-fields` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-extra-fields` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-field-max-length/README.md
+++ b/packages/lint-profile-field-max-length/README.md
@@ -1,0 +1,106 @@
+# @glion/lint-profile-field-max-length
+
+> Lint rule to validate field value lengths against HL7v2 profile maxLength.
+
+## What it does
+
+Flags field values that exceed the `maxLength` declared in the HL7v2
+profile for the message's version. Length is computed by recursively
+summing the string lengths of all subcomponent values in a repetition,
+so delimiters (`^`, `&`, `~`) are not counted. The rule reads profile
+context attached by `@glion/annotate-profile-context` and reports once
+per offending repetition. Fields without a declared `maxLength`, empty
+fields, and Z-segments are skipped.
+
+## Install
+
+```bash
+pnpm add @glion/lint-profile-field-max-length
+```
+
+> Using npm? `npm install @glion/lint-profile-field-max-length`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2Parser } from "@glion/parser";
+import hl7v2LintFieldMaxLength from "@glion/lint-profile-field-max-length";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+
+const message = [
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
+].join("\r");
+
+const file = await unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2LintFieldMaxLength)
+  .process(message);
+
+console.error(reporter([file]));
+```
+
+## API
+
+### `unified().use(hl7v2LintFieldMaxLength)`
+
+A `unified` lint rule plugin. Takes no options.
+
+Reads `file.data.profile`. For each segment in the tree it walks its
+fields, looks up the profile entry by sequence, and — if a `maxLength`
+is declared — compares it against `getLength()` from `@glion/utils` for
+every repetition. Each repetition over the limit produces one message.
+
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
+
+declare const hl7v2LintFieldMaxLength: Plugin<[], Root>;
+export default hl7v2LintFieldMaxLength;
+```
+
+## What it checks
+
+This rule flags fields whose measured content length is greater than the
+`maxLength` declared for that field in the HL7v2 profile. In v2.5,
+`MSH-10` (Message Control ID) has `maxLength: 20`.
+
+### Valid
+
+`MSH-10` carries a 9-character Message Control ID, well within the v2.5
+limit of 20:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+### Invalid
+
+`MSH-10` is 28 characters long, exceeding the v2.5 limit of 20:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG0000000000000000000000001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+Reported message:
+
+```
+Field MSH-10 exceeds max length of 20 (actual: 28)
+```
+
+One message is produced per offending repetition. Delimiters are not
+included in the measured length — a composite value like `DOE^JANE`
+counts as 7 characters, not 8.
+
+## Part of Glion
+
+`@glion/lint-profile-field-max-length` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-field-max-length/README.md
+++ b/packages/lint-profile-field-max-length/README.md
@@ -1,24 +1,16 @@
 # @glion/lint-profile-field-max-length
 
-> Lint rule to validate field value lengths against HL7v2 profile maxLength.
+Lint rule to validate field value lengths against HL7v2 profile maxLength.
 
 ## What it does
 
-Flags field values that exceed the `maxLength` declared in the HL7v2
-profile for the message's version. Length is computed by recursively
-summing the string lengths of all subcomponent values in a repetition,
-so delimiters (`^`, `&`, `~`) are not counted. The rule reads profile
-context attached by `@glion/annotate-profile-context` and reports once
-per offending repetition. Fields without a declared `maxLength`, empty
-fields, and Z-segments are skipped.
+Flags field values that exceed the `maxLength` declared in the HL7v2 profile for the message's version. Length is computed by recursively summing the string lengths of all subcomponent values in a repetition, so delimiters (`^`, `&`, `~`) are not counted. The rule reads profile context attached by `@glion/annotate-profile-context` and reports once per offending repetition. Fields without a declared `maxLength`, empty fields, and Z-segments are skipped.
 
 ## Install
 
 ```bash
-pnpm add @glion/lint-profile-field-max-length
+npm install @glion/lint-profile-field-max-length
 ```
-
-> Using npm? `npm install @glion/lint-profile-field-max-length`
 
 ## Use
 
@@ -49,10 +41,7 @@ console.error(reporter([file]));
 
 A `unified` lint rule plugin. Takes no options.
 
-Reads `file.data.profile`. For each segment in the tree it walks its
-fields, looks up the profile entry by sequence, and — if a `maxLength`
-is declared — compares it against `getLength()` from `@glion/utils` for
-every repetition. Each repetition over the limit produces one message.
+Reads `file.data.profile`. For each segment in the tree it walks its fields, looks up the profile entry by sequence, and — if a `maxLength` is declared — compares it against `getLength()` from `@glion/utils` for every repetition. Each repetition over the limit produces one message.
 
 ```ts
 import type { Plugin } from "unified";
@@ -64,14 +53,11 @@ export default hl7v2LintFieldMaxLength;
 
 ## What it checks
 
-This rule flags fields whose measured content length is greater than the
-`maxLength` declared for that field in the HL7v2 profile. In v2.5,
-`MSH-10` (Message Control ID) has `maxLength: 20`.
+This rule flags fields whose measured content length is greater than the `maxLength` declared for that field in the HL7v2 profile. In v2.5, `MSH-10` (Message Control ID) has `maxLength: 20`.
 
 ### Valid
 
-`MSH-10` carries a 9-character Message Control ID, well within the v2.5
-limit of 20:
+`MSH-10` carries a 9-character Message Control ID, well within the v2.5 limit of 20:
 
 ```hl7
 MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
@@ -93,14 +79,11 @@ Reported message:
 Field MSH-10 exceeds max length of 20 (actual: 28)
 ```
 
-One message is produced per offending repetition. Delimiters are not
-included in the measured length — a composite value like `DOE^JANE`
-counts as 7 characters, not 8.
+One message is produced per offending repetition. Delimiters are not included in the measured length — a composite value like `DOE^JANE` counts as 7 characters, not 8.
 
 ## Part of Glion
 
-`@glion/lint-profile-field-max-length` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-field-max-length` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-field-repetition/README.md
+++ b/packages/lint-profile-field-repetition/README.md
@@ -1,24 +1,16 @@
 # @glion/lint-profile-field-repetition
 
-> Lint rule that flags non-repeatable fields with multiple repetitions.
+Lint rule that flags non-repeatable fields with multiple repetitions.
 
 ## What it does
 
-Flags fields that contain more than one repetition (delimited by `~`) when
-the HL7v2 profile for the message's version declares `repeatable: false`
-for that field. The rule reads profile context attached by
-`@glion/annotate-profile-context`. A single repetition is always valid
-regardless of the `repeatable` flag; only 2+ repetitions on a
-non-repeatable field are reported. Segments without a known profile are
-silently skipped.
+Flags fields that contain more than one repetition (delimited by `~`) when the HL7v2 profile for the message's version declares `repeatable: false` for that field. The rule reads profile context attached by `@glion/annotate-profile-context`. A single repetition is always valid regardless of the `repeatable` flag; only 2+ repetitions on a non-repeatable field are reported. Segments without a known profile are silently skipped.
 
 ## Install
 
 ```bash
-pnpm add @glion/lint-profile-field-repetition
+npm install @glion/lint-profile-field-repetition
 ```
-
-> Using npm? `npm install @glion/lint-profile-field-repetition`
 
 ## Use
 
@@ -49,10 +41,7 @@ console.error(reporter([file]));
 
 A `unified` lint rule plugin. Takes no options.
 
-Reads `file.data.profile`. For each field under a segment with a known
-profile it looks up the field entry by sequence. If the field's profile
-sets `repeatable: false` and the AST has more than one repetition, the
-rule emits one message for that field.
+Reads `file.data.profile`. For each field under a segment with a known profile it looks up the field entry by sequence. If the field's profile sets `repeatable: false` and the AST has more than one repetition, the rule emits one message for that field.
 
 ```ts
 import type { Plugin } from "unified";
@@ -64,9 +53,7 @@ export default hl7v2LintFieldRepetition;
 
 ## What it checks
 
-This rule flags fields with multiple `~`-delimited repetitions when the
-profile marks the field as non-repeatable. For example, `PID-7` (Date of
-Birth) is not repeatable in v2.5.
+This rule flags fields with multiple `~`-delimited repetitions when the profile marks the field as non-repeatable. For example, `PID-7` (Date of Birth) is not repeatable in v2.5.
 
 ### Valid
 
@@ -79,8 +66,7 @@ PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
 
 ### Invalid
 
-`PID-7` carries two `~`-separated values, which violates the v2.5 profile
-for the `PID-7` field:
+`PID-7` carries two `~`-separated values, which violates the v2.5 profile for the `PID-7` field:
 
 ```hl7
 MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
@@ -93,14 +79,11 @@ Reported message:
 Field PID-7 (Date/Time of Birth) is not repeatable but has 2 repetitions
 ```
 
-When the field name is available in the profile it appears in parentheses
-after the position. The reported count equals the number of repetitions
-present in the field.
+When the field name is available in the profile it appears in parentheses after the position. The reported count equals the number of repetitions present in the field.
 
 ## Part of Glion
 
-`@glion/lint-profile-field-repetition` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-field-repetition` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-field-repetition/README.md
+++ b/packages/lint-profile-field-repetition/README.md
@@ -1,0 +1,106 @@
+# @glion/lint-profile-field-repetition
+
+> Lint rule that flags non-repeatable fields with multiple repetitions.
+
+## What it does
+
+Flags fields that contain more than one repetition (delimited by `~`) when
+the HL7v2 profile for the message's version declares `repeatable: false`
+for that field. The rule reads profile context attached by
+`@glion/annotate-profile-context`. A single repetition is always valid
+regardless of the `repeatable` flag; only 2+ repetitions on a
+non-repeatable field are reported. Segments without a known profile are
+silently skipped.
+
+## Install
+
+```bash
+pnpm add @glion/lint-profile-field-repetition
+```
+
+> Using npm? `npm install @glion/lint-profile-field-repetition`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2Parser } from "@glion/parser";
+import hl7v2LintFieldRepetition from "@glion/lint-profile-field-repetition";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+
+const message = [
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
+].join("\r");
+
+const file = await unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2LintFieldRepetition)
+  .process(message);
+
+console.error(reporter([file]));
+```
+
+## API
+
+### `unified().use(hl7v2LintFieldRepetition)`
+
+A `unified` lint rule plugin. Takes no options.
+
+Reads `file.data.profile`. For each field under a segment with a known
+profile it looks up the field entry by sequence. If the field's profile
+sets `repeatable: false` and the AST has more than one repetition, the
+rule emits one message for that field.
+
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
+
+declare const hl7v2LintFieldRepetition: Plugin<[], Root>;
+export default hl7v2LintFieldRepetition;
+```
+
+## What it checks
+
+This rule flags fields with multiple `~`-delimited repetitions when the
+profile marks the field as non-repeatable. For example, `PID-7` (Date of
+Birth) is not repeatable in v2.5.
+
+### Valid
+
+`PID-7` carries a single Date of Birth:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+### Invalid
+
+`PID-7` carries two `~`-separated values, which violates the v2.5 profile
+for the `PID-7` field:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101~19800102|F
+```
+
+Reported message:
+
+```
+Field PID-7 (Date/Time of Birth) is not repeatable but has 2 repetitions
+```
+
+When the field name is available in the profile it appears in parentheses
+after the position. The reported count equals the number of repetitions
+present in the field.
+
+## Part of Glion
+
+`@glion/lint-profile-field-repetition` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-required-components/README.md
+++ b/packages/lint-profile-required-components/README.md
@@ -1,23 +1,16 @@
 # @glion/lint-profile-required-components
 
-> Lint rule to validate required components in composite datatype fields.
+Lint rule to validate required components in composite datatype fields.
 
 ## What it does
 
-Flags composite fields whose required components (as declared by the
-datatype profile for the message's version) are missing or empty in any
-repetition. The rule reads profile context attached by
-`@glion/annotate-profile-context`, resolves each field's datatype, and
-checks the required components on every repetition. Empty fields,
-primitive datatypes, and segments without a known profile are skipped.
+Flags composite fields whose required components (as declared by the datatype profile for the message's version) are missing or empty in any repetition. The rule reads profile context attached by `@glion/annotate-profile-context`, resolves each field's datatype, and checks the required components on every repetition. Empty fields, primitive datatypes, and segments without a known profile are skipped.
 
 ## Install
 
 ```bash
-pnpm add @glion/lint-profile-required-components
+npm install @glion/lint-profile-required-components
 ```
-
-> Using npm? `npm install @glion/lint-profile-required-components`
 
 ## Use
 
@@ -48,10 +41,7 @@ console.error(reporter([file]));
 
 A `unified` lint rule plugin. Takes no options.
 
-Reads `file.data.profile`. For each non-empty field, resolves the datatype
-definition from the field profile and iterates
-`dtDef.requiredSequences`. For every field repetition, checks that each
-required component is present with a non-empty first subcomponent value.
+Reads `file.data.profile`. For each non-empty field, resolves the datatype definition from the field profile and iterates `dtDef.requiredSequences`. For every field repetition, checks that each required component is present with a non-empty first subcomponent value.
 
 ```ts
 import type { Plugin } from "unified";
@@ -63,9 +53,7 @@ export default hl7v2LintRequiredComponents;
 
 ## What it checks
 
-This rule flags missing required components on composite fields. The
-classic case is `MSH-9` (Message Type), where the `MSG` datatype requires
-the message code (`.1`) and trigger event (`.2`) components.
+This rule flags missing required components on composite fields. The classic case is `MSH-9` (Message Type), where the `MSG` datatype requires the message code (`.1`) and trigger event (`.2`) components.
 
 ### Valid
 
@@ -78,8 +66,7 @@ PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
 
 ### Invalid
 
-`MSH-9.2` (Trigger Event) is empty, which violates the `MSG` datatype
-profile in v2.5:
+`MSH-9.2` (Trigger Event) is empty, which violates the `MSG` datatype profile in v2.5:
 
 ```hl7
 MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^|MSG00001|P|2.5
@@ -92,14 +79,11 @@ Reported message:
 Required component MSH-9.2 (Trigger Event) is missing or empty
 ```
 
-When the component name is available in the datatype profile it appears
-in parentheses. One message is reported per missing required component
-per repetition.
+When the component name is available in the datatype profile it appears in parentheses. One message is reported per missing required component per repetition.
 
 ## Part of Glion
 
-`@glion/lint-profile-required-components` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-required-components` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-required-components/README.md
+++ b/packages/lint-profile-required-components/README.md
@@ -1,0 +1,105 @@
+# @glion/lint-profile-required-components
+
+> Lint rule to validate required components in composite datatype fields.
+
+## What it does
+
+Flags composite fields whose required components (as declared by the
+datatype profile for the message's version) are missing or empty in any
+repetition. The rule reads profile context attached by
+`@glion/annotate-profile-context`, resolves each field's datatype, and
+checks the required components on every repetition. Empty fields,
+primitive datatypes, and segments without a known profile are skipped.
+
+## Install
+
+```bash
+pnpm add @glion/lint-profile-required-components
+```
+
+> Using npm? `npm install @glion/lint-profile-required-components`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2Parser } from "@glion/parser";
+import hl7v2LintRequiredComponents from "@glion/lint-profile-required-components";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+
+const message = [
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
+].join("\r");
+
+const file = await unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2LintRequiredComponents)
+  .process(message);
+
+console.error(reporter([file]));
+```
+
+## API
+
+### `unified().use(hl7v2LintRequiredComponents)`
+
+A `unified` lint rule plugin. Takes no options.
+
+Reads `file.data.profile`. For each non-empty field, resolves the datatype
+definition from the field profile and iterates
+`dtDef.requiredSequences`. For every field repetition, checks that each
+required component is present with a non-empty first subcomponent value.
+
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
+
+declare const hl7v2LintRequiredComponents: Plugin<[], Root>;
+export default hl7v2LintRequiredComponents;
+```
+
+## What it checks
+
+This rule flags missing required components on composite fields. The
+classic case is `MSH-9` (Message Type), where the `MSG` datatype requires
+the message code (`.1`) and trigger event (`.2`) components.
+
+### Valid
+
+`MSH-9` carries message code, trigger event, and message structure:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+### Invalid
+
+`MSH-9.2` (Trigger Event) is empty, which violates the `MSG` datatype
+profile in v2.5:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+Reported message:
+
+```
+Required component MSH-9.2 (Trigger Event) is missing or empty
+```
+
+When the component name is available in the datatype profile it appears
+in parentheses. One message is reported per missing required component
+per repetition.
+
+## Part of Glion
+
+`@glion/lint-profile-required-components` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-required-fields/README.md
+++ b/packages/lint-profile-required-fields/README.md
@@ -1,0 +1,105 @@
+# @glion/lint-profile-required-fields
+
+> Lint rule to validate required fields per HL7v2 profile.
+
+## What it does
+
+Flags segments whose required fields (as declared by the HL7v2 profile for
+the message's version) are missing or empty. The rule reads profile context
+attached to the file by `@glion/annotate-profile-context` and reports one
+message per missing required field. Segments without a known profile (for
+example Z-segments like `ZPD`) are silently skipped.
+
+## Install
+
+```bash
+pnpm add @glion/lint-profile-required-fields
+```
+
+> Using npm? `npm install @glion/lint-profile-required-fields`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2Parser } from "@glion/parser";
+import hl7v2LintRequiredFields from "@glion/lint-profile-required-fields";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+
+const message = [
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
+].join("\r");
+
+const file = await unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2LintRequiredFields)
+  .process(message);
+
+console.error(reporter([file]));
+```
+
+## API
+
+### `unified().use(hl7v2LintRequiredFields)`
+
+A `unified` lint rule plugin. Takes no options.
+
+The plugin reads `file.data.profile` (populated by
+`@glion/annotate-profile-context`). If no profile context is present the
+rule exits silently. For each segment, it iterates
+`fieldDef.requiredSequences` and checks that the corresponding field at
+that 1-based position is present and non-empty.
+
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
+
+declare const hl7v2LintRequiredFields: Plugin<[], Root>;
+export default hl7v2LintRequiredFields;
+```
+
+## What it checks
+
+This rule flags fields declared `required: true` in the HL7v2 profile for
+the message's version when those fields are missing or empty on the
+corresponding segment.
+
+### Valid
+
+`PID-3` (Patient Identifier List) and `PID-5` (Patient Name) are required
+in v2.5 and both are populated:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+### Invalid
+
+`PID-3` is empty, which violates the v2.5 profile for the `PID` segment:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||||DOE^JANE||19800101|F
+```
+
+Reported message:
+
+```
+Required field PID-3 (Patient Identifier List) is missing or empty
+```
+
+When the profile attaches a field name, it appears in parentheses after
+the position. Segments shorter than the highest required sequence produce
+one message per missing required field.
+
+## Part of Glion
+
+`@glion/lint-profile-required-fields` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-required-fields/README.md
+++ b/packages/lint-profile-required-fields/README.md
@@ -1,22 +1,16 @@
 # @glion/lint-profile-required-fields
 
-> Lint rule to validate required fields per HL7v2 profile.
+Lint rule to validate required fields per HL7v2 profile.
 
 ## What it does
 
-Flags segments whose required fields (as declared by the HL7v2 profile for
-the message's version) are missing or empty. The rule reads profile context
-attached to the file by `@glion/annotate-profile-context` and reports one
-message per missing required field. Segments without a known profile (for
-example Z-segments like `ZPD`) are silently skipped.
+Flags segments whose required fields (as declared by the HL7v2 profile for the message's version) are missing or empty. The rule reads profile context attached to the file by `@glion/annotate-profile-context` and reports one message per missing required field. Segments without a known profile (for example Z-segments like `ZPD`) are silently skipped.
 
 ## Install
 
 ```bash
-pnpm add @glion/lint-profile-required-fields
+npm install @glion/lint-profile-required-fields
 ```
-
-> Using npm? `npm install @glion/lint-profile-required-fields`
 
 ## Use
 
@@ -47,11 +41,7 @@ console.error(reporter([file]));
 
 A `unified` lint rule plugin. Takes no options.
 
-The plugin reads `file.data.profile` (populated by
-`@glion/annotate-profile-context`). If no profile context is present the
-rule exits silently. For each segment, it iterates
-`fieldDef.requiredSequences` and checks that the corresponding field at
-that 1-based position is present and non-empty.
+The plugin reads `file.data.profile` (populated by `@glion/annotate-profile-context`). If no profile context is present the rule exits silently. For each segment, it iterates `fieldDef.requiredSequences` and checks that the corresponding field at that 1-based position is present and non-empty.
 
 ```ts
 import type { Plugin } from "unified";
@@ -63,14 +53,11 @@ export default hl7v2LintRequiredFields;
 
 ## What it checks
 
-This rule flags fields declared `required: true` in the HL7v2 profile for
-the message's version when those fields are missing or empty on the
-corresponding segment.
+This rule flags fields declared `required: true` in the HL7v2 profile for the message's version when those fields are missing or empty on the corresponding segment.
 
 ### Valid
 
-`PID-3` (Patient Identifier List) and `PID-5` (Patient Name) are required
-in v2.5 and both are populated:
+`PID-3` (Patient Identifier List) and `PID-5` (Patient Name) are required in v2.5 and both are populated:
 
 ```hl7
 MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
@@ -92,14 +79,11 @@ Reported message:
 Required field PID-3 (Patient Identifier List) is missing or empty
 ```
 
-When the profile attaches a field name, it appears in parentheses after
-the position. Segments shorter than the highest required sequence produce
-one message per missing required field.
+When the profile attaches a field name, it appears in parentheses after the position. Segments shorter than the highest required sequence produce one message per missing required field.
 
 ## Part of Glion
 
-`@glion/lint-profile-required-fields` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-required-fields` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-table-values/README.md
+++ b/packages/lint-profile-table-values/README.md
@@ -1,24 +1,16 @@
 # @glion/lint-profile-table-values
 
-> Lint rule to validate coded field values against HL7v2 tables.
+Lint rule to validate coded field values against HL7v2 tables.
 
 ## What it does
 
-Flags coded field values that are not present in the HL7-defined table
-referenced by the field's profile. The rule reads profile context
-attached by `@glion/annotate-profile-context`, resolves the table by id
-(stripping the `HL7` prefix, so `HL70001` looks up table `0001`), and
-checks the first component value of each repetition against the table's
-code set. Only `hl7`-type tables are validated; user-defined tables,
-empty fields, and Z-segments are skipped.
+Flags coded field values that are not present in the HL7-defined table referenced by the field's profile. The rule reads profile context attached by `@glion/annotate-profile-context`, resolves the table by id (stripping the `HL7` prefix, so `HL70001` looks up table `0001`), and checks the first component value of each repetition against the table's code set. Only `hl7`-type tables are validated; user-defined tables, empty fields, and Z-segments are skipped.
 
 ## Install
 
 ```bash
-pnpm add @glion/lint-profile-table-values
+npm install @glion/lint-profile-table-values
 ```
-
-> Using npm? `npm install @glion/lint-profile-table-values`
 
 ## Use
 
@@ -49,10 +41,7 @@ console.error(reporter([file]));
 
 A `unified` lint rule plugin. Takes no options.
 
-Reads `file.data.profile`. For each non-empty field with a declared
-`table` reference in its profile, loads the table definition from
-`ctx.tables`. If the table is HL7-defined it checks each repetition's
-first subcomponent value against the table's code set.
+Reads `file.data.profile`. For each non-empty field with a declared `table` reference in its profile, loads the table definition from `ctx.tables`. If the table is HL7-defined it checks each repetition's first subcomponent value against the table's code set.
 
 ```ts
 import type { Plugin } from "unified";
@@ -64,10 +53,7 @@ export default hl7v2LintTableValues;
 
 ## What it checks
 
-This rule flags coded values that are not members of the HL7 table
-referenced by the field's profile. For example, `PID-8` (Administrative
-Sex) references table `HL70001`, whose v2.5 codes include `F`, `M`, `O`,
-`U`, `A`, `N`.
+This rule flags coded values that are not members of the HL7 table referenced by the field's profile. For example, `PID-8` (Administrative Sex) references table `HL70001`, whose v2.5 codes include `F`, `M`, `O`, `U`, `A`, `N`.
 
 ### Valid
 
@@ -93,14 +79,11 @@ Reported message:
 Field PID-8 (Administrative Sex) value 'Z' is not in table 0001 (Administrative Sex)
 ```
 
-When the field has a profile name it appears in parentheses. The table
-id is reported without the `HL7` prefix, matching the way the tables
-store keys its entries. One message is reported per offending repetition.
+When the field has a profile name it appears in parentheses. The table id is reported without the `HL7` prefix, matching the way the tables store keys its entries. One message is reported per offending repetition.
 
 ## Part of Glion
 
-`@glion/lint-profile-table-values` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-table-values` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-table-values/README.md
+++ b/packages/lint-profile-table-values/README.md
@@ -1,0 +1,106 @@
+# @glion/lint-profile-table-values
+
+> Lint rule to validate coded field values against HL7v2 tables.
+
+## What it does
+
+Flags coded field values that are not present in the HL7-defined table
+referenced by the field's profile. The rule reads profile context
+attached by `@glion/annotate-profile-context`, resolves the table by id
+(stripping the `HL7` prefix, so `HL70001` looks up table `0001`), and
+checks the first component value of each repetition against the table's
+code set. Only `hl7`-type tables are validated; user-defined tables,
+empty fields, and Z-segments are skipped.
+
+## Install
+
+```bash
+pnpm add @glion/lint-profile-table-values
+```
+
+> Using npm? `npm install @glion/lint-profile-table-values`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2Parser } from "@glion/parser";
+import hl7v2LintTableValues from "@glion/lint-profile-table-values";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+
+const message = [
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
+].join("\r");
+
+const file = await unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2LintTableValues)
+  .process(message);
+
+console.error(reporter([file]));
+```
+
+## API
+
+### `unified().use(hl7v2LintTableValues)`
+
+A `unified` lint rule plugin. Takes no options.
+
+Reads `file.data.profile`. For each non-empty field with a declared
+`table` reference in its profile, loads the table definition from
+`ctx.tables`. If the table is HL7-defined it checks each repetition's
+first subcomponent value against the table's code set.
+
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
+
+declare const hl7v2LintTableValues: Plugin<[], Root>;
+export default hl7v2LintTableValues;
+```
+
+## What it checks
+
+This rule flags coded values that are not members of the HL7 table
+referenced by the field's profile. For example, `PID-8` (Administrative
+Sex) references table `HL70001`, whose v2.5 codes include `F`, `M`, `O`,
+`U`, `A`, `N`.
+
+### Valid
+
+`PID-8` is `F`, which is a valid code in table `0001`:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+### Invalid
+
+`PID-8` is `Z`, which is not in table `0001`:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|Z
+```
+
+Reported message:
+
+```
+Field PID-8 (Administrative Sex) value 'Z' is not in table 0001 (Administrative Sex)
+```
+
+When the field has a profile name it appears in parentheses. The table
+id is reported without the `HL7` prefix, matching the way the tables
+store keys its entries. One message is reported per offending repetition.
+
+## Part of Glion
+
+`@glion/lint-profile-table-values` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/preset-annotate-profile-recommended/README.md
+++ b/packages/preset-annotate-profile-recommended/README.md
@@ -1,6 +1,6 @@
 # @glion/preset-annotate-profile-recommended
 
-> Preset bundling every profile-based annotation plugin so the AST carries full profile metadata after a single `.use(...)` call.
+Preset bundling every profile-based annotation plugin so the AST carries full profile metadata after a single `.use(...)` call.
 
 ## What it does
 
@@ -9,10 +9,8 @@ This preset wires the five profile annotation plugins plus the `annotate-profile
 ## Install
 
 ```bash
-pnpm add @glion/preset-annotate-profile-recommended
+npm install @glion/preset-annotate-profile-recommended
 ```
-
-> Using npm? `npm install @glion/preset-annotate-profile-recommended`
 
 ## Use
 
@@ -59,8 +57,7 @@ All five plugins read the HL7v2 version from `MSH-12` and load profiles via `@gl
 
 ## Part of Glion
 
-`@glion/preset-annotate-profile-recommended` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/preset-annotate-profile-recommended` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/preset-annotate-profile-recommended/README.md
+++ b/packages/preset-annotate-profile-recommended/README.md
@@ -1,0 +1,66 @@
+# @glion/preset-annotate-profile-recommended
+
+> Preset bundling every profile-based annotation plugin so the AST carries full profile metadata after a single `.use(...)` call.
+
+## What it does
+
+This preset wires the five profile annotation plugins plus the `annotate-profile-context` loader into a single `unified` plugin. One `.use(...)` call enriches every segment, field, field-repetition, component, sub-component, and coded value in the AST with its HL7v2 profile metadata — names, datatypes, required flags, repeatability, max lengths, table references, and code-system displays. The annotated tree is self-describing and can be walked without loading any profiles yourself.
+
+## Install
+
+```bash
+pnpm add @glion/preset-annotate-profile-recommended
+```
+
+> Using npm? `npm install @glion/preset-annotate-profile-recommended`
+
+## Use
+
+```ts
+import hl7v2PresetAnnotateProfileRecommended from "@glion/preset-annotate-profile-recommended";
+import { hl7v2Parser } from "@glion/parser";
+import { visit } from "@glion/util-visit";
+import { unified } from "unified";
+
+const processor = unified()
+  .use(hl7v2Parser)
+  .use(hl7v2PresetAnnotateProfileRecommended);
+
+const file = await processor.process(
+  "MSH|^~\\&|SENDER||RECEIVER||20250601120000||ADT^A01|MSG00001|P|2.5\rPID|1||12345||Doe^John"
+);
+
+visit(file.result, "field", (node) => {
+  if (node.data?.required && node.data.name) {
+    console.log(`Required: ${node.data.id} (${node.data.name})`);
+  }
+});
+```
+
+## API
+
+### `unified().use(hl7v2PresetAnnotateProfileRecommended)`
+
+Default export is a `Preset` (unified's `{ plugins: [...] }` shape). No options — to annotate selectively, compose individual plugins from their own packages instead.
+
+## What's bundled
+
+The preset applies these plugins in order. `annotate-profile-context` runs first so each subsequent plugin reads the pre-resolved profile from `file.data.profile`.
+
+| Plugin                                                                                   | Annotates                                                                                      |
+| ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [`@glion/annotate-profile-context`](../annotate-profile-context)                         | Loads the HL7v2 profile for the message version onto `file.data`.                              |
+| [`@glion/annotate-profile-segments`](../annotate-profile-segments)                       | Annotates Segment nodes with their human-readable title (e.g. `MSH` → `"Message Header"`).     |
+| [`@glion/annotate-profile-fields`](../annotate-profile-fields)                           | Annotates Field nodes with `name`, `required`, `repeatable`, `datatype`, `maxLength`, `table`. |
+| [`@glion/annotate-profile-datatypes`](../annotate-profile-datatypes)                     | Annotates FieldRepetition, Component, and Subcomponent nodes with datatype metadata.           |
+| [`@glion/annotate-profile-fields-code-systems`](../annotate-profile-fields-code-systems) | Annotates coded fields with UTG code-system identity and resolved display values.              |
+
+All five plugins read the HL7v2 version from `MSH-12` and load profiles via `@glion/profiles`. Unknown segments (Z-segments) are silently skipped so non-standard content passes through unchanged.
+
+## Part of Glion
+
+`@glion/preset-annotate-profile-recommended` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/preset-lint-profile-recommended/README.md
+++ b/packages/preset-lint-profile-recommended/README.md
@@ -1,6 +1,6 @@
 # @glion/preset-lint-profile-recommended
 
-> Preset bundling every profile-based HL7v2 lint rule for validating messages against their version-specific profiles.
+Preset bundling every profile-based HL7v2 lint rule for validating messages against their version-specific profiles.
 
 ## What it does
 
@@ -9,10 +9,8 @@ This preset wires the eight profile lint rules plus the `annotate-profile-contex
 ## Install
 
 ```bash
-pnpm add @glion/preset-lint-profile-recommended
+npm install @glion/preset-lint-profile-recommended
 ```
-
-> Using npm? `npm install @glion/preset-lint-profile-recommended`
 
 ## Use
 
@@ -60,8 +58,7 @@ The companion `@glion/preset-lint-recommended` covers the core (version-independ
 
 ## Part of Glion
 
-`@glion/preset-lint-profile-recommended` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/preset-lint-profile-recommended` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/preset-lint-profile-recommended/README.md
+++ b/packages/preset-lint-profile-recommended/README.md
@@ -1,0 +1,67 @@
+# @glion/preset-lint-profile-recommended
+
+> Preset bundling every profile-based HL7v2 lint rule for validating messages against their version-specific profiles.
+
+## What it does
+
+This preset wires the eight profile lint rules plus the `annotate-profile-context` loader into a single `unified` plugin. One `.use(...)` call enables required-field, field-length, field-repetition, required-component, table-value, extra-field, extra-component, and segment-order validation — all driven by the HL7v2 profile loaded for the message's MSH-12 version.
+
+## Install
+
+```bash
+pnpm add @glion/preset-lint-profile-recommended
+```
+
+> Using npm? `npm install @glion/preset-lint-profile-recommended`
+
+## Use
+
+```ts
+import hl7v2PresetLintProfileRecommended from "@glion/preset-lint-profile-recommended";
+import { hl7v2Parser } from "@glion/parser";
+import { unified } from "unified";
+
+const processor = unified()
+  .use(hl7v2Parser)
+  .use(hl7v2PresetLintProfileRecommended);
+
+const file = await processor.process(
+  "MSH|^~\\&|SENDER||RECEIVER||20250601120000||ADT^A01|MSG00001|P|2.5\rPID|1||PATID1234^^^HOSP^MR"
+);
+
+for (const message of file.messages) {
+  console.log(`${message.ruleId}: ${message.reason}`);
+}
+```
+
+## API
+
+### `unified().use(hl7v2PresetLintProfileRecommended)`
+
+Default export is a `Preset` (unified's `{ plugins: [...] }` shape). No options — to configure individual rules, compose them directly from their own packages instead of using the preset.
+
+## What's bundled
+
+The preset applies these plugins in order. `annotate-profile-context` runs first so every subsequent rule sees the resolved profile on `file.data.profile`.
+
+| Plugin                                                                               | Purpose                                                                  |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| [`@glion/annotate-profile-context`](../annotate-profile-context)                     | Loads the HL7v2 profile for the message version onto `file.data`.        |
+| [`@glion/lint-profile-required-fields`](../lint-profile-required-fields)             | Flags missing or empty required fields.                                  |
+| [`@glion/lint-profile-field-max-length`](../lint-profile-field-max-length)           | Enforces field-value `maxLength` from the profile.                       |
+| [`@glion/lint-profile-field-repetition`](../lint-profile-field-repetition)           | Flags non-repeatable fields that contain multiple repetitions.           |
+| [`@glion/lint-profile-required-components`](../lint-profile-required-components)     | Validates required components inside composite datatypes.                |
+| [`@glion/lint-profile-table-values`](../lint-profile-table-values)                   | Validates coded values against HL7 tables.                               |
+| [`@glion/lint-profile-events-segments-order`](../lint-profile-events-segments-order) | Validates segment order per the message structure definition.            |
+| [`@glion/lint-profile-extra-fields`](../lint-profile-extra-fields)                   | Warns when a segment contains more fields than the profile defines.      |
+| [`@glion/lint-profile-extra-components`](../lint-profile-extra-components)           | Warns when a composite field contains more components than its datatype. |
+
+The companion `@glion/preset-lint-recommended` covers the core (version-independent) lint rules; use both together for comprehensive validation.
+
+## Part of Glion
+
+`@glion/preset-lint-profile-recommended` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/profiles/README.md
+++ b/packages/profiles/README.md
@@ -1,6 +1,6 @@
 # @glion/profiles
 
-> HL7v2 version-specific profile data — segments, fields, datatypes, and tables — with LRU-cached loaders.
+HL7v2 version-specific profile data — segments, fields, datatypes, and tables — with LRU-cached loaders.
 
 ## What it does
 
@@ -9,10 +9,8 @@
 ## Install
 
 ```bash
-pnpm add @glion/profiles
+npm install @glion/profiles
 ```
-
-> Using npm? `npm install @glion/profiles`
 
 ## Use
 
@@ -132,8 +130,7 @@ Same shape convention: each exposes its id, version, and the typed payload (valu
 
 ## Part of Glion
 
-`@glion/profiles` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/profiles` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/profiles/README.md
+++ b/packages/profiles/README.md
@@ -1,0 +1,139 @@
+# @glion/profiles
+
+> HL7v2 version-specific profile data — segments, fields, datatypes, and tables — with LRU-cached loaders.
+
+## What it does
+
+`@glion/profiles` is the data source for Glion's profile-aware plugins. It provides structured HL7v2 profile definitions for every supported version (2.3 through 2.8), loaded on demand and cached in memory. The annotation plugins (`@glion/annotate-profile-*`) and the profile lint rules (`@glion/lint-profile-*`) read from this package to enrich and validate HL7v2 messages against the HL7-published specifications.
+
+## Install
+
+```bash
+pnpm add @glion/profiles
+```
+
+> Using npm? `npm install @glion/profiles`
+
+## Use
+
+```ts
+import { profiles } from "@glion/profiles";
+
+const msh = await profiles.segments.load("2.5", "MSH");
+console.log(msh.fields.length); // => 21
+
+const field = await profiles.fields.load("2.5", "MSH", "9");
+console.log(field.name); // => "Message Type"
+console.log(field.required); // => true
+console.log(field.datatype); // => "MSG"
+
+const cx = await profiles.datatypes.load("2.5", "CX");
+console.log(cx.kind); // => "composite"
+console.log(cx.components.length); // => 10
+```
+
+Event structure validation uses the same API:
+
+```ts
+const structure = await profiles.events.load("2.5", "ADT_A01");
+// structure.dfa — deterministic finite automaton for segment-order validation
+```
+
+## API
+
+### `profiles`
+
+Shared singleton store (eager LRU cache, 100 entries per kind). Use this unless you need a bespoke cache configuration.
+
+### `createProfiles(options)`
+
+Construct a dedicated store with a custom cache size or eviction strategy.
+
+```ts
+import { createLruCache, createProfiles } from "@glion/profiles";
+
+const store = createProfiles({
+  cache: createLruCache({ maxEntries: 500 }),
+});
+```
+
+### Loaders on each store
+
+| Method                                      | Returns                |
+| ------------------------------------------- | ---------------------- |
+| `segments.load(version, segmentId)`         | `SegmentDefinition`    |
+| `fields.load(version, segmentId, position)` | `FieldProfile`         |
+| `datatypes.load(version, datatypeId)`       | `DatatypeDefinition`   |
+| `tables.load(version, tableId)`             | `Table`                |
+| `events.load(version, structureId)`         | `EventStructure`       |
+| `codeSystems.load(version, codeSystemId)`   | `CodeSystemDefinition` |
+
+### `loadSegments(version)`
+
+Standalone helper that loads every segment definition for a given version in one call. Used by batch-processing plugins.
+
+### Automaton runner
+
+For segment-order validation, `@glion/profiles` exposes the underlying DFA engine:
+
+```ts
+import { runner, type Definition } from "@glion/profiles";
+
+const engine = runner(definition);
+engine.step("MSH");
+engine.step("EVN");
+// engine.state === RunnerState.Running
+```
+
+## Profile data format
+
+Each kind of profile is loaded on demand from pre-built chunks. The compiled output is sharded into ~170 chunks (merged from ~10,800 source files via Rolldown code-splitting) to keep install size and cold-start cost low.
+
+### Segments
+
+```ts
+interface SegmentDefinition {
+  id: string; // "MSH", "PID", ...
+  name: string; // "Message Header"
+  fields: FieldProfile[]; // in positional order
+}
+```
+
+### Fields
+
+```ts
+interface FieldProfile {
+  id: string; // "MSH-9"
+  name: string; // "Message Type"
+  position: number; // 9
+  datatype: string; // "MSG"
+  required: boolean;
+  repeatable: boolean;
+  maxLength?: number;
+  table?: string; // "HL70001" when the field is coded
+  item?: string;
+}
+```
+
+### Datatypes
+
+```ts
+interface DatatypeDefinition {
+  id: string; // "CX"
+  kind: "primitive" | "composite";
+  title: string;
+  components?: ComponentProfile[]; // only for composite kind
+}
+```
+
+### Tables, event structures, code systems
+
+Same shape convention: each exposes its id, version, and the typed payload (value lists for tables, DFA definitions for event structures, concept lists with displayNames for code systems).
+
+## Part of Glion
+
+`@glion/profiles` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/turbo/generators/templates/README.md.hbs
+++ b/turbo/generators/templates/README.md.hbs
@@ -30,7 +30,7 @@
 
 # @glion/{{name}}
 
-> {{description}}
+{{description}}
 
 ## What it does
 
@@ -40,10 +40,8 @@
 ## Install
 
 ```bash
-pnpm add @glion/{{name}}
+npm install @glion/{{name}}
 ```
-
-> Using npm? `npm install @glion/{{name}}`
 
 ## Use
 


### PR DESCRIPTION
Phase 2 of 4 for the per-package README standardization plan. Fills every remaining blank `@glion/*` npm page from 16 to 0 — the ecosystem now has full README coverage for the first time.

Plan: [`docs/plans/2026-04-21-002-feat-per-package-readme-standardization-plan.md`](./docs/plans/2026-04-21-002-feat-per-package-readme-standardization-plan.md) (merged as part of Phase 1 / #592).

## Summary

All 16 READMEs follow the Phase 1 template strictly — title matching `package.json` "name", `## Install` / `## Use` / `## Part of Glion` headings — and pass the workspace's `check:readme` turbo task.

**Unit 3 — 7 profile lint rules** (`## What it checks` + valid/invalid HL7v2 examples):
- `@glion/lint-profile-required-fields`
- `@glion/lint-profile-required-components`
- `@glion/lint-profile-field-max-length`
- `@glion/lint-profile-field-repetition`
- `@glion/lint-profile-table-values`
- `@glion/lint-profile-extra-fields`
- `@glion/lint-profile-extra-components`

**Unit 4 — 5 annotation plugins** (`## What it annotates` + `data.*` shape):
- `@glion/annotate-delimiters`
- `@glion/annotate-profile-context`
- `@glion/annotate-profile-datatypes`
- `@glion/annotate-profile-fields-code-systems`
- `@glion/annotate-profile-segments`

**Unit 5 — CLI + data + 2 presets** (heterogeneous category sections):
- `@glion/cli` — `## Commands` with `glion dev`/`glion start` reference, `defineConfig` API, Node/Bun/Deno invocation table.
- `@glion/profiles` — `## Profile data format` describing segment / field / datatype / table / event-structure / code-system shapes and the LRU-cached store surface.
- `@glion/preset-lint-profile-recommended` — `## What's bundled` listing the 8 profile lint rules + `annotate-profile-context`.
- `@glion/preset-annotate-profile-recommended` — `## What's bundled` listing the 5 profile annotators + context loader.

## Voice

Positive, factual, practical throughout. No framework analogies (no "Hono-style", "remark-style", "like ESLint"). No manifesto or competitor-positioning language. Real HL7v2 specifics (MSH, PID, OBX, OBR, MSH-9, MSH-12, version 2.5, tables `0001`/`0103`) do the persuasion.

## Content provenance

Each README was written by reading the package's own source (`src/index.ts` + supporting files) and its tests, so the API signatures, option interfaces, and reported message text are drawn verbatim from the implementation — not paraphrased.

## Testing

- `pnpm check:readmes` → `16 successful, 41 total`. Every new README passes. The 25 remaining failures are the existing READMEs still on pre-Phase-3 structure — Phase 3 rewrites them to the template.
- `pnpm check` → 0 errors, 0 warnings.
- Each of the 16 READMEs was verified individually via `pnpm turbo run check:readme --filter=@glion/<name>` during authoring.

## Follow-ups

- **Phase 3** — rewrite the 25 existing READMEs to match the template (separate PR, including the voice fixes in `packages/mllp` Hono references and `packages/builder` / `packages/util-query` "Philosophy" headings).
- **Phase 4** — flip `continue-on-error: true` off the CI advisory step (tracked in #595; preconditioned on Phase 3 landing).
- #589 — separately correct the `@glion/profiles` `package.json` description (this PR writes the README description correctly; the `package.json` field is a parallel work stream).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this PR adds documentation (16 README.md files) with no runtime or deployment impact. After merge, spot-check 2-3 of the previously blank npm package pages (e.g. `@glion/profiles`, `@glion/cli`, `@glion/lint-profile-required-fields`) to confirm the new READMEs render.

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>