### PR TITLE
feat(docs): rewrite 25 existing READMEs to the Phase 1 template (Phase 3)

### DIFF
--- a/packages/ack/README.md
+++ b/packages/ack/README.md
@@ -1,32 +1,22 @@
 # @glion/ack
 
-HL7v2 acknowledgment message builder and typed error classes — builds spec-compliant ACK/NAK response ASTs from parsed HL7v2 messages.
+HL7v2 acknowledgment message builder and typed exception classes.
 
-## Overview
+## What it does
 
-This package provides:
+`@glion/ack` builds spec-compliant ACK/NAK response ASTs from a parsed HL7v2 message. The `acknowledge()` function accepts an original message `Root` and returns a new `Root` containing an MSH, MSA, and (when an error is supplied) an ERR segment. Typed exception classes (`AckApplicationError`, `AckApplicationReject`, `AckCommitError`, `AckCommitReject`) carry the HL7v2 error code and severity that the response needs, so callers throw semantic errors and the builder renders them as the correct MSA-1 code.
 
-1. **`acknowledge()`** — Builds a complete ACK/NAK `Root` AST from an original message's AST
-2. **Error classes** — `AckError` (AE) and `AckReject` (AR) with HL7v2 error codes and severity
-3. **`uid()`** — Generates unique MSH-10 control IDs via `nanoid`
-
-**Key characteristics:**
-
-- **AST in, AST out** — works with `@glion/ast` trees, not raw strings
-- **Spec-compliant** — produces MSH, MSA, and optional ERR segments per HL7v2 standard
-- **Composable** — use standalone or with `@glion/mllp-ack` middleware
-
-## Installation
+## Install
 
 ```bash
-pnpm add @glion/ack
+npm install @glion/ack
 ```
 
-## Usage
+## Use
 
-### Success (AA)
+Build a successful acknowledgment (AA):
 
-```typescript
+```ts
 import { acknowledge } from "@glion/ack";
 import { toHl7v2 } from "@glion/to-hl7v2";
 
@@ -36,14 +26,16 @@ const raw = toHl7v2(ack);
 // MSA|AA|MSG001
 ```
 
-The ACK sender (MSH-3/MSH-4) is derived from the original message's MSH-5/MSH-6 by default.
+Build an application error (AE) or reject (AR):
 
-### Error (AE)
+```ts
+import {
+  acknowledge,
+  AckApplicationError,
+  AckApplicationReject,
+} from "@glion/ack";
 
-```typescript
-import { acknowledge, AckError } from "@glion/ack";
-
-const error = new AckError("Validation failed", {
+const error = new AckApplicationError("Validation failed", {
   errorCode: "207",
   severity: "E",
 });
@@ -53,20 +45,7 @@ const ack = acknowledge(originalTree, { error });
 // ERR|||207|E
 ```
 
-### Reject (AR)
-
-```typescript
-import { acknowledge, AckReject } from "@glion/ack";
-
-const error = new AckReject("Unsupported message type", {
-  errorCode: "200",
-  severity: "E",
-});
-
-const ack = acknowledge(originalTree, { error });
-// MSA|AR|MSG001|Unsupported message type
-// ERR|||200|E
-```
+The ACK sender (MSH-3/MSH-4) is derived from the original message's MSH-5/MSH-6 by default.
 
 ## API
 
@@ -80,58 +59,52 @@ Builds an ACK/NAK `Root` AST from the original message tree.
 | `options.id`                | `string`       | Custom MSH-10 control ID. Auto-generated via `uid()` when omitted  |
 | `options.sending`           | `SendingInfo`  | MSH-3/MSH-4 of the ACK. Defaults to original message's MSH-5/MSH-6 |
 | `options.processingId`      | `string`       | MSH-11 processing ID. Defaults to original message's MSH-11        |
-| `options.error`             | `AckException` | Sets AE/AR code and populates MSA-3 with the error message         |
-| `options.includeErrSegment` | `boolean`      | Include ERR segment when error is provided. Defaults to `true`     |
+| `options.error`             | `AckException` | Sets the MSA-1 code and populates MSA-3 with the error message     |
+| `options.includeErrSegment` | `boolean`      | Include ERR segment when an error is provided. Defaults to `true`  |
 
 Returns a `Root` node containing MSH, MSA, and optionally ERR segments.
 
-### `AckError`
+### Exception classes
 
-Error class for application errors (ACK code `AE`).
-
-```typescript
-new AckError(message, { errorCode, severity?, cause? })
+```ts
+new AckApplicationError(message, { errorCode, severity?, cause? })
+new AckApplicationReject(message, { errorCode, severity?, cause? })
+new AckCommitError(message, { errorCode, severity?, cause? })
+new AckCommitReject(message, { errorCode, severity?, cause? })
 ```
 
-### `AckReject`
-
-Error class for application rejects (ACK code `AR`).
-
-```typescript
-new AckReject(message, { errorCode, severity?, cause? })
-```
-
-Both extend `AckException`, which extends `Error`. The `cause` option supports error chain debugging via standard `ErrorOptions`.
+All four extend `AckException`, which extends `Error`. Pre-configured convenience subclasses are exported for common cases: `ApplicationInternalError` (AE, code 207), `UnsupportedMessageTypeReject` (AR, code 200), `CommitInternalError` (CE, code 207). The standard `cause` option supports error chains.
 
 ### `uid(options?)`
 
-Generates a unique ID suitable for MSH-10 control IDs.
+Generates a unique identifier suitable for MSH-10 control IDs.
 
 | Parameter        | Type     | Default | Description                      |
 | ---------------- | -------- | ------- | -------------------------------- |
 | `options.prefix` | `string` | —       | Optional prefix for the ID       |
 | `options.size`   | `number` | `20`    | Total length of the generated ID |
 
-## Contributing
+### Constants
 
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
+`AckCode`, `Hl7ErrorCode`, and `Severity` are exported as const objects with the standard HL7v2 enumeration values.
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+## Acknowledgment codes
 
-## Code of Conduct
+HL7v2 distinguishes two levels of acknowledgment — **application** and **commit** — and each has accept, error, and reject variants. The exception class you throw determines MSA-1 directly.
 
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
+| Class                  | MSA-1 | Meaning                                                                |
+| ---------------------- | ----- | ---------------------------------------------------------------------- |
+| _(no error)_           | AA    | Application accept. The receiver processed the message.                |
+| `AckApplicationError`  | AE    | Application error. Syntactically valid but rejected by business logic. |
+| `AckApplicationReject` | AR    | Application reject. The receiver cannot accept the message at all.     |
+| `AckCommitError`       | CE    | Commit error (enhanced mode). Persistence or downstream failure.       |
+| `AckCommitReject`      | CR    | Commit reject (enhanced mode). Refused at the commit layer.            |
 
-## License
+When an exception is passed via `options.error`, its `errorCode` and `severity` populate the ERR segment. The error's `message` populates MSA-3 (text message).
 
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
+## Part of Glion
 
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
+`@glion/ack` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-delimiters/README.md
+++ b/packages/annotate-delimiters/README.md
@@ -1,23 +1,16 @@
 # @glion/annotate-delimiters
 
-> Unified plugin to annotate file.data with HL7v2 delimiters derived from MSH-1/MSH-2.
+Unified plugin to annotate file.data with HL7v2 delimiters derived from MSH-1/MSH-2.
 
 ## What it does
 
-HL7v2 messages encode their own delimiters in the first two fields of the MSH
-segment: MSH-1 carries the field separator and MSH-2 carries the component,
-repetition, escape, and subcomponent characters. This plugin reads those
-characters from the parsed tree once and stores the resolved `Delimiters`
-record on `file.data.delimiters` so downstream plugins (serializers, escape
-encoders, profile lints) can consult a single source of truth.
+HL7v2 messages encode their own delimiters in the first two fields of the MSH segment: MSH-1 carries the field separator and MSH-2 carries the component, repetition, escape, and subcomponent characters. This plugin reads those characters from the parsed tree once and stores the resolved `Delimiters` record on `file.data.delimiters` so downstream plugins (serializers, escape encoders, profile lints) can consult a single source of truth.
 
 ## Install
 
 ```bash
-pnpm add @glion/annotate-delimiters
+npm install @glion/annotate-delimiters
 ```
-
-> Using npm? `npm install @glion/annotate-delimiters`
 
 ## Use
 
@@ -40,8 +33,7 @@ const file = await processor.process(
 
 ## API
 
-This package exports the named constant `hl7v2AnnotateDelimiters`. It is a
-`unified` plugin with no options:
+This package exports the named constant `hl7v2AnnotateDelimiters`. It is a `unified` plugin with no options:
 
 ```ts
 import type { Root } from "@glion/ast";
@@ -50,14 +42,11 @@ import type { Plugin } from "unified";
 export const hl7v2AnnotateDelimiters: Plugin<[], Root, Root>;
 ```
 
-The plugin expects a parsed `Root` tree and a `VFile`. It never mutates the
-tree; it only writes to `file.data.delimiters`.
+The plugin expects a parsed `Root` tree and a `VFile`. It never mutates the tree; it only writes to `file.data.delimiters`.
 
 ## What it annotates
 
-This plugin writes to `file.data`, not to AST nodes. It derives the six
-HL7v2 delimiter characters from the first MSH segment and falls back to the
-default delimiter set when MSH-1 or MSH-2 is absent.
+This plugin writes to `file.data`, not to AST nodes. It derives the six HL7v2 delimiter characters from the first MSH segment and falls back to the default delimiter set when MSH-1 or MSH-2 is absent.
 
 ### `file.data.delimiters`
 
@@ -81,15 +70,11 @@ interface Delimiters {
 // }
 ```
 
-Resolution is delegated to the `delimiters()` helper in `@glion/util-query`,
-which walks the tree to find MSH, reads its first two fields, and merges any
-missing characters with `DEFAULT_DELIMITERS` from `@glion/utils`. Messages
-with no MSH segment receive the full default set.
+Resolution is delegated to the `delimiters()` helper in `@glion/util-query`, which walks the tree to find MSH, reads its first two fields, and merges any missing characters with `DEFAULT_DELIMITERS` from `@glion/utils`. Messages with no MSH segment receive the full default set.
 
 ## Part of Glion
 
-`@glion/annotate-delimiters` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/annotate-delimiters` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-delimiters/README.md
+++ b/packages/annotate-delimiters/README.md
@@ -1,0 +1,95 @@
+# @glion/annotate-delimiters
+
+> Unified plugin to annotate file.data with HL7v2 delimiters derived from MSH-1/MSH-2.
+
+## What it does
+
+HL7v2 messages encode their own delimiters in the first two fields of the MSH
+segment: MSH-1 carries the field separator and MSH-2 carries the component,
+repetition, escape, and subcomponent characters. This plugin reads those
+characters from the parsed tree once and stores the resolved `Delimiters`
+record on `file.data.delimiters` so downstream plugins (serializers, escape
+encoders, profile lints) can consult a single source of truth.
+
+## Install
+
+```bash
+pnpm add @glion/annotate-delimiters
+```
+
+> Using npm? `npm install @glion/annotate-delimiters`
+
+## Use
+
+```ts
+import { hl7v2AnnotateDelimiters } from "@glion/annotate-delimiters";
+import { hl7v2Parser } from "@glion/parser";
+import { unified } from "unified";
+
+const processor = unified().use(hl7v2Parser).use(hl7v2AnnotateDelimiters);
+
+const file = await processor.process(
+  "MSH|^~\\&|SENDER||RECEIVER||20241201||ADT^A01|MSG123|P|2.5\rPID|1||12345"
+);
+
+// file.data.delimiters === {
+//   field: "|", component: "^", repetition: "~",
+//   escape: "\\", subcomponent: "&", segment: "\r"
+// }
+```
+
+## API
+
+This package exports the named constant `hl7v2AnnotateDelimiters`. It is a
+`unified` plugin with no options:
+
+```ts
+import type { Root } from "@glion/ast";
+import type { Plugin } from "unified";
+
+export const hl7v2AnnotateDelimiters: Plugin<[], Root, Root>;
+```
+
+The plugin expects a parsed `Root` tree and a `VFile`. It never mutates the
+tree; it only writes to `file.data.delimiters`.
+
+## What it annotates
+
+This plugin writes to `file.data`, not to AST nodes. It derives the six
+HL7v2 delimiter characters from the first MSH segment and falls back to the
+default delimiter set when MSH-1 or MSH-2 is absent.
+
+### `file.data.delimiters`
+
+After this plugin runs, the vfile carries:
+
+```ts
+interface Delimiters {
+  field: string; // MSH-1, e.g. "|"
+  component: string; // MSH-2[0], e.g. "^"
+  repetition: string; // MSH-2[1], e.g. "~"
+  escape: string; // MSH-2[2], e.g. "\\"
+  subcomponent: string; // MSH-2[3], e.g. "&"
+  segment: string; // segment terminator, e.g. "\r"
+}
+
+// Augmented on VFile's DataMap:
+// declare module "vfile" {
+//   interface DataMap {
+//     delimiters: Delimiters;
+//   }
+// }
+```
+
+Resolution is delegated to the `delimiters()` helper in `@glion/util-query`,
+which walks the tree to find MSH, reads its first two fields, and merges any
+missing characters with `DEFAULT_DELIMITERS` from `@glion/utils`. Messages
+with no MSH segment receive the full default set.
+
+## Part of Glion
+
+`@glion/annotate-delimiters` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-profile-context/README.md
+++ b/packages/annotate-profile-context/README.md
@@ -1,0 +1,120 @@
+# @glion/annotate-profile-context
+
+> Unified plugin to centralize HL7v2 profile loading onto file.data.
+
+## What it does
+
+Downstream profile-aware plugins (segment annotators, field annotators,
+datatype annotators, code-system annotators, profile lints) all need the same
+slice of HL7v2 profile data for the version declared in MSH-12.1. This plugin
+loads that data once — field definitions, segment titles, datatype
+definitions (with component and subcomponent cascade), and table definitions
+— and stores it as a single `ProfileContext` on `file.data.profile`. The
+load is idempotent and silently skips unknown profiles.
+
+## Install
+
+```bash
+pnpm add @glion/annotate-profile-context
+```
+
+> Using npm? `npm install @glion/annotate-profile-context`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2Parser } from "@glion/parser";
+import { unified } from "unified";
+
+const processor = unified().use(hl7v2Parser).use(hl7v2AnnotateProfileContext);
+
+const file = await processor.process(
+  "MSH|^~\\&|SENDER||RECEIVER||20241201||ADT^A01|MSG123|P|2.5\rPID|1||12345"
+);
+
+// file.data.profile.version       === "2.5"
+// file.data.profile.fields        === Map<"MSH" | "PID", FieldDefinition>
+// file.data.profile.datatypes     === Map<"ST" | "CX" | "XPN" | ..., DatatypeDefinition>
+// file.data.profile.tables        === Map<"0001" | "0003" | ..., TableDefinition>
+// file.data.profile.segments.byId === Map<"MSH" | "PID" | ..., { title: string }>
+```
+
+## API
+
+This package exports the named constant `hl7v2AnnotateProfileContext` and
+the `ProfileContext` type. The default export is the plugin itself.
+
+```ts
+import type { Root } from "@glion/ast";
+import type {
+  DatatypeDefinition,
+  FieldDefinition,
+  SegmentDefinition,
+  TableDefinition,
+} from "@glion/profiles";
+import type { Plugin } from "unified";
+
+export const hl7v2AnnotateProfileContext: Plugin<[], Root, Root>;
+
+export interface ProfileContext {
+  version: string;
+  fields: ReadonlyMap<string, FieldDefinition>;
+  datatypes: ReadonlyMap<string, DatatypeDefinition>;
+  tables: ReadonlyMap<string, TableDefinition>;
+  segments: SegmentDefinition;
+}
+```
+
+The plugin is async: it awaits all profile loads in parallel.
+
+## What it annotates
+
+This plugin writes to `file.data`, not to AST nodes. It populates one entry,
+`file.data.profile`, with the resolved `ProfileContext` for the HL7v2 version
+declared in MSH-12.1.
+
+### `file.data.profile`
+
+After this plugin runs, the vfile carries:
+
+```ts
+// Augmented on VFile's DataMap:
+declare module "vfile" {
+  interface DataMap {
+    profile?: ProfileContext | undefined;
+  }
+}
+
+interface ProfileContext {
+  // HL7v2 version from MSH-12.1 (e.g. "2.5", "2.5.1", "2.8")
+  version: string;
+
+  // Field definitions indexed by segment name
+  fields: ReadonlyMap<string, FieldDefinition>;
+
+  // Datatype definitions indexed by datatype id (e.g. "ST", "CWE", "XPN")
+  datatypes: ReadonlyMap<string, DatatypeDefinition>;
+
+  // Table definitions indexed by normalized table id (e.g. "0001")
+  // Note: field profiles reference "HL70001"; this map uses "0001"
+  tables: ReadonlyMap<string, TableDefinition>;
+
+  // Segment titles indexed by segment id (e.g. "MSH", "PID", "OBX")
+  segments: SegmentDefinition;
+}
+```
+
+Loading is idempotent: if `file.data.profile` is already populated, the
+plugin returns immediately. If MSH-12.1 is missing, it returns without
+setting the key. Datatype loading cascades through composite datatypes up to
+three levels deep so every component and subcomponent datatype referenced
+anywhere in the field definitions is resolved in advance.
+
+## Part of Glion
+
+`@glion/annotate-profile-context` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-profile-context/README.md
+++ b/packages/annotate-profile-context/README.md
@@ -1,24 +1,16 @@
 # @glion/annotate-profile-context
 
-> Unified plugin to centralize HL7v2 profile loading onto file.data.
+Unified plugin to centralize HL7v2 profile loading onto file.data.
 
 ## What it does
 
-Downstream profile-aware plugins (segment annotators, field annotators,
-datatype annotators, code-system annotators, profile lints) all need the same
-slice of HL7v2 profile data for the version declared in MSH-12.1. This plugin
-loads that data once — field definitions, segment titles, datatype
-definitions (with component and subcomponent cascade), and table definitions
-— and stores it as a single `ProfileContext` on `file.data.profile`. The
-load is idempotent and silently skips unknown profiles.
+Downstream profile-aware plugins (segment annotators, field annotators, datatype annotators, code-system annotators, profile lints) all need the same slice of HL7v2 profile data for the version declared in MSH-12.1. This plugin loads that data once — field definitions, segment titles, datatype definitions (with component and subcomponent cascade), and table definitions — and stores it as a single `ProfileContext` on `file.data.profile`. The load is idempotent and silently skips unknown profiles.
 
 ## Install
 
 ```bash
-pnpm add @glion/annotate-profile-context
+npm install @glion/annotate-profile-context
 ```
-
-> Using npm? `npm install @glion/annotate-profile-context`
 
 ## Use
 
@@ -42,8 +34,7 @@ const file = await processor.process(
 
 ## API
 
-This package exports the named constant `hl7v2AnnotateProfileContext` and
-the `ProfileContext` type. The default export is the plugin itself.
+This package exports the named constant `hl7v2AnnotateProfileContext` and the `ProfileContext` type. The default export is the plugin itself.
 
 ```ts
 import type { Root } from "@glion/ast";
@@ -70,9 +61,7 @@ The plugin is async: it awaits all profile loads in parallel.
 
 ## What it annotates
 
-This plugin writes to `file.data`, not to AST nodes. It populates one entry,
-`file.data.profile`, with the resolved `ProfileContext` for the HL7v2 version
-declared in MSH-12.1.
+This plugin writes to `file.data`, not to AST nodes. It populates one entry, `file.data.profile`, with the resolved `ProfileContext` for the HL7v2 version declared in MSH-12.1.
 
 ### `file.data.profile`
 
@@ -105,16 +94,11 @@ interface ProfileContext {
 }
 ```
 
-Loading is idempotent: if `file.data.profile` is already populated, the
-plugin returns immediately. If MSH-12.1 is missing, it returns without
-setting the key. Datatype loading cascades through composite datatypes up to
-three levels deep so every component and subcomponent datatype referenced
-anywhere in the field definitions is resolved in advance.
+Loading is idempotent: if `file.data.profile` is already populated, the plugin returns immediately. If MSH-12.1 is missing, it returns without setting the key. Datatype loading cascades through composite datatypes up to three levels deep so every component and subcomponent datatype referenced anywhere in the field definitions is resolved in advance.
 
 ## Part of Glion
 
-`@glion/annotate-profile-context` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/annotate-profile-context` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-profile-datatypes/README.md
+++ b/packages/annotate-profile-datatypes/README.md
@@ -1,25 +1,16 @@
 # @glion/annotate-profile-datatypes
 
-> Unified plugin to annotate HL7v2 field repetition, component, and subcomponent nodes with datatype profile metadata.
+Unified plugin to annotate HL7v2 field repetition, component, and subcomponent nodes with datatype profile metadata.
 
 ## What it does
 
-HL7v2 fields hold either a primitive value (like `ST` or `DT`) or a composite
-structure built from a datatype like `XPN` or `CWE` whose components and
-subcomponents each have their own datatype. This plugin walks each field
-repetition, component, and subcomponent, resolves the corresponding datatype
-from the profile context, and writes that metadata onto `node.data` using a
-stop-at-primitive cascade — annotation stops at the node where the primitive
-value actually lives. It requires `@glion/annotate-profile-context` and
-`@glion/annotate-profile-fields` to run first.
+HL7v2 fields hold either a primitive value (like `ST` or `DT`) or a composite structure built from a datatype like `XPN` or `CWE` whose components and subcomponents each have their own datatype. This plugin walks each field repetition, component, and subcomponent, resolves the corresponding datatype from the profile context, and writes that metadata onto `node.data` using a stop-at-primitive cascade — annotation stops at the node where the primitive value actually lives. It requires `@glion/annotate-profile-context` and `@glion/annotate-profile-fields` to run first.
 
 ## Install
 
 ```bash
-pnpm add @glion/annotate-profile-datatypes
+npm install @glion/annotate-profile-datatypes
 ```
-
-> Using npm? `npm install @glion/annotate-profile-datatypes`
 
 ## Use
 
@@ -47,8 +38,7 @@ const file = await processor.process(
 
 ## API
 
-This package exports the named constant `hl7v2AnnotateProfileDatatypes`. The
-default export is the plugin itself.
+This package exports the named constant `hl7v2AnnotateProfileDatatypes`. The default export is the plugin itself.
 
 ```ts
 import type { Root } from "@glion/ast";
@@ -57,21 +47,13 @@ import type { Plugin } from "unified";
 export const hl7v2AnnotateProfileDatatypes: Plugin<[], Root, Root>;
 ```
 
-The plugin reads `file.data.profile` and `field.data.datatype` from
-upstream annotators. It writes to `FieldRepetitionData`, `ComponentData`, and
-`SubcomponentData` (all declared on the `@glion/ast` module augmentation).
+The plugin reads `file.data.profile` and `field.data.datatype` from upstream annotators. It writes to `FieldRepetitionData`, `ComponentData`, and `SubcomponentData` (all declared on the `@glion/ast` module augmentation).
 
 ## What it annotates
 
-This plugin visits three node types in order — `field-repetition`,
-`component`, and `subcomponent` — and writes datatype metadata to
-`node.data`. The cascade follows the composite structure: primitive fields
-stop at the repetition; composite fields with primitive components stop at
-the component; fully nested composites continue to the subcomponent.
+This plugin visits three node types in order — `field-repetition`, `component`, and `subcomponent` — and writes datatype metadata to `node.data`. The cascade follows the composite structure: primitive fields stop at the repetition; composite fields with primitive components stop at the component; fully nested composites continue to the subcomponent.
 
-`kind: "primitive"` means the value lives on that node. `kind: "composite"`
-means inspect the children. Nodes on ancestor paths of the primitive carry
-no annotation from this plugin.
+`kind: "primitive"` means the value lives on that node. `kind: "composite"` means inspect the children. Nodes on ancestor paths of the primitive carry no annotation from this plugin.
 
 ### `node.data` (FieldRepetition, Component, Subcomponent)
 
@@ -106,15 +88,11 @@ declare module "@glion/ast" {
 }
 ```
 
-Annotation is skipped for nodes whose datatype is not known to the profile
-(for example Z-segments or custom fields). The field-level `datatype`
-property is read from `field.data.datatype`, which is populated by
-`@glion/annotate-profile-fields`.
+Annotation is skipped for nodes whose datatype is not known to the profile (for example Z-segments or custom fields). The field-level `datatype` property is read from `field.data.datatype`, which is populated by `@glion/annotate-profile-fields`.
 
 ## Part of Glion
 
-`@glion/annotate-profile-datatypes` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/annotate-profile-datatypes` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-profile-datatypes/README.md
+++ b/packages/annotate-profile-datatypes/README.md
@@ -1,0 +1,120 @@
+# @glion/annotate-profile-datatypes
+
+> Unified plugin to annotate HL7v2 field repetition, component, and subcomponent nodes with datatype profile metadata.
+
+## What it does
+
+HL7v2 fields hold either a primitive value (like `ST` or `DT`) or a composite
+structure built from a datatype like `XPN` or `CWE` whose components and
+subcomponents each have their own datatype. This plugin walks each field
+repetition, component, and subcomponent, resolves the corresponding datatype
+from the profile context, and writes that metadata onto `node.data` using a
+stop-at-primitive cascade — annotation stops at the node where the primitive
+value actually lives. It requires `@glion/annotate-profile-context` and
+`@glion/annotate-profile-fields` to run first.
+
+## Install
+
+```bash
+pnpm add @glion/annotate-profile-datatypes
+```
+
+> Using npm? `npm install @glion/annotate-profile-datatypes`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2AnnotateProfileDatatypes } from "@glion/annotate-profile-datatypes";
+import { hl7v2AnnotateProfileFields } from "@glion/annotate-profile-fields";
+import { hl7v2Parser } from "@glion/parser";
+import { unified } from "unified";
+
+const processor = unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2AnnotateProfileFields)
+  .use(hl7v2AnnotateProfileDatatypes);
+
+const file = await processor.process(
+  "MSH|^~\\&|SENDER||RECEIVER||20241201||ADT^A01|MSG123|P|2.5\rPID|1||12345||Doe^John"
+);
+
+// PID-5 field-repetition.data === { datatypeId: "XPN", kind: "composite", title: "Extended Person Name" }
+// PID-5.1 component.data        === { id: "XPN.1", name: "Family Name", required: false, datatypeId: "FN", kind: "composite", title: "Family Name" }
+// PID-5.1.1 subcomponent.data   === { id: "FN.1", name: "Surname", required: true, datatypeId: "ST", kind: "primitive", title: "String Data" }
+```
+
+## API
+
+This package exports the named constant `hl7v2AnnotateProfileDatatypes`. The
+default export is the plugin itself.
+
+```ts
+import type { Root } from "@glion/ast";
+import type { Plugin } from "unified";
+
+export const hl7v2AnnotateProfileDatatypes: Plugin<[], Root, Root>;
+```
+
+The plugin reads `file.data.profile` and `field.data.datatype` from
+upstream annotators. It writes to `FieldRepetitionData`, `ComponentData`, and
+`SubcomponentData` (all declared on the `@glion/ast` module augmentation).
+
+## What it annotates
+
+This plugin visits three node types in order — `field-repetition`,
+`component`, and `subcomponent` — and writes datatype metadata to
+`node.data`. The cascade follows the composite structure: primitive fields
+stop at the repetition; composite fields with primitive components stop at
+the component; fully nested composites continue to the subcomponent.
+
+`kind: "primitive"` means the value lives on that node. `kind: "composite"`
+means inspect the children. Nodes on ancestor paths of the primitive carry
+no annotation from this plugin.
+
+### `node.data` (FieldRepetition, Component, Subcomponent)
+
+After this plugin runs, the augmented interfaces are:
+
+```ts
+declare module "@glion/ast" {
+  interface FieldRepetitionData {
+    datatypeId?: string; // e.g. "ST", "CWE", "XPN"
+    kind?: "primitive" | "composite";
+    title?: string; // e.g. "String Data", "Coded with Exceptions"
+  }
+
+  interface ComponentData {
+    id?: string; // "<datatypeId>.<sequence>", e.g. "CWE.1", "XPN.2"
+    name?: string; // e.g. "Family Name"
+    required?: boolean;
+    datatypeId?: string; // e.g. "ST", "ID", "FN"
+    maxLength?: number;
+    kind?: "primitive" | "composite";
+    title?: string;
+  }
+
+  interface SubcomponentData {
+    id?: string; // "<datatypeId>.<sequence>", e.g. "FN.1", "HD.2"
+    name?: string;
+    required?: boolean;
+    datatypeId?: string;
+    kind?: "primitive" | "composite";
+    title?: string;
+  }
+}
+```
+
+Annotation is skipped for nodes whose datatype is not known to the profile
+(for example Z-segments or custom fields). The field-level `datatype`
+property is read from `field.data.datatype`, which is populated by
+`@glion/annotate-profile-fields`.
+
+## Part of Glion
+
+`@glion/annotate-profile-datatypes` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-profile-fields-code-systems/README.md
+++ b/packages/annotate-profile-fields-code-systems/README.md
@@ -1,0 +1,113 @@
+# @glion/annotate-profile-fields-code-systems
+
+> Unified plugin to annotate HL7v2 field-level coded values with UTG code system metadata.
+
+## What it does
+
+Fields bound to HL7v2 tables (such as PID-8 `Administrative Sex` bound to
+table `0001`, or MSH-11.1 `Processing ID` bound to table `0103`) carry coded
+values that expand into human-readable displays and lifecycle statuses. This
+plugin resolves each field's table reference against the UTG code system
+registry in `@glion/profiles`, then writes the code system identity onto the
+field and the resolved value entry onto each repetition. It requires
+`@glion/annotate-profile-fields` to run first so that `field.data.table` is
+populated.
+
+## Install
+
+```bash
+pnpm add @glion/annotate-profile-fields-code-systems
+```
+
+> Using npm? `npm install @glion/annotate-profile-fields-code-systems`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2AnnotateProfileFields } from "@glion/annotate-profile-fields";
+import { hl7v2AnnotateProfileFieldsCodeSystems } from "@glion/annotate-profile-fields-code-systems";
+import { hl7v2Parser } from "@glion/parser";
+import { unified } from "unified";
+
+const processor = unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2AnnotateProfileFields)
+  .use(hl7v2AnnotateProfileFieldsCodeSystems);
+
+const file = await processor.process(
+  "MSH|^~\\&|SENDER||RECEIVER||20241201||ADT^A01|MSG123|P|2.5\rPID|1||12345||Doe^John||19800101|M"
+);
+
+// PID-8 field.data.codeSystem === { id: "v2-0001", name: "AdministrativeSex", title: "Administrative Sex" }
+// PID-8 repetition.data.code   === { value: "M", display: "Male", status: "A" }
+```
+
+## API
+
+This package exports the named constant
+`hl7v2AnnotateProfileFieldsCodeSystems`. The default export is the plugin
+itself.
+
+```ts
+import type { Root } from "@glion/ast";
+import type { Plugin } from "unified";
+
+export const hl7v2AnnotateProfileFieldsCodeSystems: Plugin<[], Root, Root>;
+```
+
+The plugin is async. Code system loads run in parallel; failures for unknown
+code systems are silent, while other errors attach a `VFile` message with
+source `hl7v2-annotate-profile-fields-code-systems`.
+
+## What it annotates
+
+This plugin visits coded `field` nodes (fields with a table reference on
+`field.data.table`) and writes two pieces of metadata: a code system
+identity on the field itself (shared across all repetitions) and a resolved
+code entry on each repetition. Per the HL7v2 spec, when a coded field uses
+a composite datatype (CWE or CNE) the table binding constrains CWE.1 — the
+first subcomponent of the first component — which is the value this plugin
+reads.
+
+### `node.data` (Field, FieldRepetition)
+
+After this plugin runs, the augmented interfaces are:
+
+```ts
+declare module "@glion/ast" {
+  interface FieldData {
+    // Code system identity for the field's table reference.
+    // Present only when the table resolves in the UTG registry.
+    codeSystem?: {
+      id: string; // e.g. "v2-0001" (derived from "HL70001")
+      name: string; // e.g. "AdministrativeSex"
+      title: string; // e.g. "Administrative Sex"
+    };
+  }
+
+  interface FieldRepetitionData {
+    // Resolved code entry for this repetition's primary value.
+    // Present only when the repetition's CWE.1 value matches a code.
+    code?: {
+      value: string; // as written in the message, e.g. "M"
+      display: string; // e.g. "Male"
+      status: string; // UTG lifecycle status, e.g. "A" (active)
+    };
+  }
+}
+```
+
+Table references are converted from the HL7v2 form (`HL70001`) to the UTG
+form (`v2-0001`) before lookup. Fields whose table does not resolve in the
+UTG registry are left untouched, and repetitions whose primary value does
+not match any code in the registry are left without a `code` entry.
+
+## Part of Glion
+
+`@glion/annotate-profile-fields-code-systems` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-profile-fields-code-systems/README.md
+++ b/packages/annotate-profile-fields-code-systems/README.md
@@ -1,25 +1,16 @@
 # @glion/annotate-profile-fields-code-systems
 
-> Unified plugin to annotate HL7v2 field-level coded values with UTG code system metadata.
+Unified plugin to annotate HL7v2 field-level coded values with UTG code system metadata.
 
 ## What it does
 
-Fields bound to HL7v2 tables (such as PID-8 `Administrative Sex` bound to
-table `0001`, or MSH-11.1 `Processing ID` bound to table `0103`) carry coded
-values that expand into human-readable displays and lifecycle statuses. This
-plugin resolves each field's table reference against the UTG code system
-registry in `@glion/profiles`, then writes the code system identity onto the
-field and the resolved value entry onto each repetition. It requires
-`@glion/annotate-profile-fields` to run first so that `field.data.table` is
-populated.
+Fields bound to HL7v2 tables (such as PID-8 `Administrative Sex` bound to table `0001`, or MSH-11.1 `Processing ID` bound to table `0103`) carry coded values that expand into human-readable displays and lifecycle statuses. This plugin resolves each field's table reference against the UTG code system registry in `@glion/profiles`, then writes the code system identity onto the field and the resolved value entry onto each repetition. It requires `@glion/annotate-profile-fields` to run first so that `field.data.table` is populated.
 
 ## Install
 
 ```bash
-pnpm add @glion/annotate-profile-fields-code-systems
+npm install @glion/annotate-profile-fields-code-systems
 ```
-
-> Using npm? `npm install @glion/annotate-profile-fields-code-systems`
 
 ## Use
 
@@ -46,9 +37,7 @@ const file = await processor.process(
 
 ## API
 
-This package exports the named constant
-`hl7v2AnnotateProfileFieldsCodeSystems`. The default export is the plugin
-itself.
+This package exports the named constant `hl7v2AnnotateProfileFieldsCodeSystems`. The default export is the plugin itself.
 
 ```ts
 import type { Root } from "@glion/ast";
@@ -57,19 +46,11 @@ import type { Plugin } from "unified";
 export const hl7v2AnnotateProfileFieldsCodeSystems: Plugin<[], Root, Root>;
 ```
 
-The plugin is async. Code system loads run in parallel; failures for unknown
-code systems are silent, while other errors attach a `VFile` message with
-source `hl7v2-annotate-profile-fields-code-systems`.
+The plugin is async. Code system loads run in parallel; failures for unknown code systems are silent, while other errors attach a `VFile` message with source `hl7v2-annotate-profile-fields-code-systems`.
 
 ## What it annotates
 
-This plugin visits coded `field` nodes (fields with a table reference on
-`field.data.table`) and writes two pieces of metadata: a code system
-identity on the field itself (shared across all repetitions) and a resolved
-code entry on each repetition. Per the HL7v2 spec, when a coded field uses
-a composite datatype (CWE or CNE) the table binding constrains CWE.1 — the
-first subcomponent of the first component — which is the value this plugin
-reads.
+This plugin visits coded `field` nodes (fields with a table reference on `field.data.table`) and writes two pieces of metadata: a code system identity on the field itself (shared across all repetitions) and a resolved code entry on each repetition. Per the HL7v2 spec, when a coded field uses a composite datatype (CWE or CNE) the table binding constrains CWE.1 — the first subcomponent of the first component — which is the value this plugin reads.
 
 ### `node.data` (Field, FieldRepetition)
 
@@ -99,15 +80,11 @@ declare module "@glion/ast" {
 }
 ```
 
-Table references are converted from the HL7v2 form (`HL70001`) to the UTG
-form (`v2-0001`) before lookup. Fields whose table does not resolve in the
-UTG registry are left untouched, and repetitions whose primary value does
-not match any code in the registry are left without a `code` entry.
+Table references are converted from the HL7v2 form (`HL70001`) to the UTG form (`v2-0001`) before lookup. Fields whose table does not resolve in the UTG registry are left untouched, and repetitions whose primary value does not match any code in the registry are left without a `code` entry.
 
 ## Part of Glion
 
-`@glion/annotate-profile-fields-code-systems` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/annotate-profile-fields-code-systems` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-profile-fields/README.md
+++ b/packages/annotate-profile-fields/README.md
@@ -1,31 +1,10 @@
 # @glion/annotate-profile-fields
 
-**[unified](https://github.com/unifiedjs/unified)** plugin to annotate HL7v2 field nodes with profile metadata.
+Unified plugin to annotate HL7v2 field nodes with profile metadata.
 
-## Contents
+## What it does
 
-- [What is this?](#what-is-this)
-- [When should I use this?](#when-should-i-use-this)
-- [Install](#install)
-- [Use](#use)
-- [API](#api)
-- [Examples](#examples)
-- [Compatibility](#compatibility)
-- [Related](#related)
-
-## What is this?
-
-This package is a [unified](https://github.com/unifiedjs/unified) plugin that enriches Field AST nodes with metadata from HL7v2 profile definitions. After running this plugin, each field carries its profile information directly on `field.data` — making the AST self-describing.
-
-The plugin reads the message version from MSH-12, loads the corresponding field definitions from `@glion/profiles`, and spreads the profile properties onto each field node. Unknown segments (Z-segments) and unsupported versions are silently skipped.
-
-## When should I use this?
-
-Use this plugin when:
-
-- You want to inspect a parsed AST and see field names, datatypes, and constraints without loading profiles yourself
-- Building tools (serializers, debuggers, IDE integrations) that need field-level metadata
-- Creating custom processors that need to know which fields are required, repeatable, or coded
+Enriches every `field` node in a parsed HL7v2 tree with metadata drawn from the HL7v2 specification profile — field name, datatype, required/repeatable flags, maximum length, and table reference — so the AST becomes self-describing. The plugin reads the message version from MSH-12, loads the matching field definitions from `@glion/profiles`, and spreads the profile properties onto `field.data`. Unknown segments (Z-segments) and unsupported versions are silently skipped.
 
 ## Install
 
@@ -35,10 +14,10 @@ npm install @glion/annotate-profile-fields
 
 ## Use
 
-```typescript
-import { unified } from "unified";
-import { hl7v2Parser } from "@glion/parser";
+```ts
 import { hl7v2AnnotateProfileFields } from "@glion/annotate-profile-fields";
+import { hl7v2Parser } from "@glion/parser";
+import { unified } from "unified";
 
 const processor = unified().use(hl7v2Parser).use(hl7v2AnnotateProfileFields);
 
@@ -54,23 +33,21 @@ await processor.run(tree);
 
 ## API
 
-This package exports the identifier `hl7v2AnnotateProfileFields`. The default export is `hl7v2AnnotateProfileFields`.
+This package exports the named constant `hl7v2AnnotateProfileFields`. The default export is the plugin itself.
 
 ### `unified().use(hl7v2AnnotateProfileFields)`
 
-Annotate Field nodes with profile metadata.
+Annotate Field nodes with profile metadata. The plugin:
 
-This plugin:
-
-1. Reads the HL7v2 version from MSH-12
-2. Loads field definitions for all segments in the message
-3. Visits each Field node and spreads the matching profile properties onto `field.data`
+1. Reads the HL7v2 version from MSH-12.
+2. Loads field definitions for all segments in the message from `@glion/profiles`.
+3. Visits each Field node and spreads the matching profile properties onto `field.data`.
 
 ###### Returns
 
-Async transformer (`async function (Root) => Root`)
+Async transformer (`async function (Root) => Root`).
 
-### Augmented `FieldData`
+## What it annotates
 
 Importing this package augments the `FieldData` interface from `@glion/ast`:
 
@@ -87,15 +64,13 @@ Importing this package augments the `FieldData` interface from `@glion/ast`:
 
 All properties are optional (`undefined` when not available in the profile).
 
-## Examples
-
 ### Accessing field metadata
 
-```typescript
+```ts
 import { visit } from "@glion/util-visit";
 
 // After running the annotator...
-visit(tree, "field", (node, ancestors, info) => {
+visit(tree, "field", (node) => {
   if (node.data?.required && node.data?.name) {
     console.log(`Required field: ${node.data.id} (${node.data.name})`);
   }
@@ -104,7 +79,7 @@ visit(tree, "field", (node, ancestors, info) => {
 
 ### Finding coded fields
 
-```typescript
+```ts
 visit(tree, "field", (node) => {
   if (node.data?.table) {
     console.log(`${node.data.id} uses table ${node.data.table}`);
@@ -112,39 +87,9 @@ visit(tree, "field", (node) => {
 });
 ```
 
-## Compatibility
+## Part of Glion
 
-- **Node.js**: 18+
-- **TypeScript**: 5.0+
-- **unified**: 11.0+
+`@glion/annotate-profile-fields` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-## Related
-
-- [`@glion/annotate-profile-datatypes`](../hl7v2-annotate-profile-datatypes) — Annotate components with datatype metadata
-- [`@glion/annotate-profile-code-systems`](../hl7v2-annotate-profile-code-systems) — Annotate coded values with UTG display names
-- [`@glion/preset-annotate-profile-recommended`](../hl7v2-preset-annotate-profile-recommended) — Preset bundling all profile annotators
-- [`@glion/profiles`](../hl7v2-profiles) — Profile data source
-
-## Contributing
-
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## Code of Conduct
-
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
-
-## License
-
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
-
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
-
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-profile-segments/README.md
+++ b/packages/annotate-profile-segments/README.md
@@ -1,24 +1,16 @@
 # @glion/annotate-profile-segments
 
-> Unified plugin to annotate HL7v2 segment nodes with profile metadata.
+Unified plugin to annotate HL7v2 segment nodes with profile metadata.
 
 ## What it does
 
-Segments in a parsed HL7v2 tree carry only their three-character name (`MSH`,
-`PID`, `OBX`, `OBR`). This plugin looks each segment up in the HL7v2
-specification profile for the message's version and writes the official
-segment title — for example `Message Header` for MSH or `Patient
-Identification` for PID — onto `segment.data.title`. It reads the preloaded
-profile from `file.data.profile`, so it requires
-`@glion/annotate-profile-context` to run first.
+Segments in a parsed HL7v2 tree carry only their three-character name (`MSH`, `PID`, `OBX`, `OBR`). This plugin looks each segment up in the HL7v2 specification profile for the message's version and writes the official segment title — for example `Message Header` for MSH or `Patient Identification` for PID — onto `segment.data.title`. It reads the preloaded profile from `file.data.profile`, so it requires `@glion/annotate-profile-context` to run first.
 
 ## Install
 
 ```bash
-pnpm add @glion/annotate-profile-segments
+npm install @glion/annotate-profile-segments
 ```
-
-> Using npm? `npm install @glion/annotate-profile-segments`
 
 ## Use
 
@@ -43,8 +35,7 @@ const file = await processor.process(
 
 ## API
 
-This package exports the named constant `hl7v2AnnotateProfileSegments`. The
-default export is the plugin itself.
+This package exports the named constant `hl7v2AnnotateProfileSegments`. The default export is the plugin itself.
 
 ```ts
 import type { Root } from "@glion/ast";
@@ -53,16 +44,11 @@ import type { Plugin } from "unified";
 export const hl7v2AnnotateProfileSegments: Plugin<[], Root, Root>;
 ```
 
-The plugin reads `file.data.profile.segments` (populated by
-`@glion/annotate-profile-context`) and writes to `SegmentData` on each
-matching segment.
+The plugin reads `file.data.profile.segments` (populated by `@glion/annotate-profile-context`) and writes to `SegmentData` on each matching segment.
 
 ## What it annotates
 
-This plugin visits every `segment` node, looks up the segment profile by
-three-character name, and writes the human-readable title onto
-`segment.data.title`. Segments with no matching profile — Z-segments or
-segments from unsupported versions — are left untouched.
+This plugin visits every `segment` node, looks up the segment profile by three-character name, and writes the human-readable title onto `segment.data.title`. Segments with no matching profile — Z-segments or segments from unsupported versions — are left untouched.
 
 ### `segment.data`
 
@@ -79,15 +65,11 @@ declare module "@glion/ast" {
 }
 ```
 
-Lookup uses `profile.segments.byId.get(node.name)` where `profile` is the
-`ProfileContext` attached by `@glion/annotate-profile-context`. If
-`file.data.profile` is missing entirely, the plugin returns without writing
-anything.
+Lookup uses `profile.segments.byId.get(node.name)` where `profile` is the `ProfileContext` attached by `@glion/annotate-profile-context`. If `file.data.profile` is missing entirely, the plugin returns without writing anything.
 
 ## Part of Glion
 
-`@glion/annotate-profile-segments` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/annotate-profile-segments` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/annotate-profile-segments/README.md
+++ b/packages/annotate-profile-segments/README.md
@@ -1,0 +1,93 @@
+# @glion/annotate-profile-segments
+
+> Unified plugin to annotate HL7v2 segment nodes with profile metadata.
+
+## What it does
+
+Segments in a parsed HL7v2 tree carry only their three-character name (`MSH`,
+`PID`, `OBX`, `OBR`). This plugin looks each segment up in the HL7v2
+specification profile for the message's version and writes the official
+segment title — for example `Message Header` for MSH or `Patient
+Identification` for PID — onto `segment.data.title`. It reads the preloaded
+profile from `file.data.profile`, so it requires
+`@glion/annotate-profile-context` to run first.
+
+## Install
+
+```bash
+pnpm add @glion/annotate-profile-segments
+```
+
+> Using npm? `npm install @glion/annotate-profile-segments`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2AnnotateProfileSegments } from "@glion/annotate-profile-segments";
+import { hl7v2Parser } from "@glion/parser";
+import { unified } from "unified";
+
+const processor = unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2AnnotateProfileSegments);
+
+const file = await processor.process(
+  "MSH|^~\\&|SENDER||RECEIVER||20241201||ADT^A01|MSG123|P|2.5\rPID|1||12345"
+);
+
+// MSH segment.data.title === "Message Header"
+// PID segment.data.title === "Patient Identification"
+```
+
+## API
+
+This package exports the named constant `hl7v2AnnotateProfileSegments`. The
+default export is the plugin itself.
+
+```ts
+import type { Root } from "@glion/ast";
+import type { Plugin } from "unified";
+
+export const hl7v2AnnotateProfileSegments: Plugin<[], Root, Root>;
+```
+
+The plugin reads `file.data.profile.segments` (populated by
+`@glion/annotate-profile-context`) and writes to `SegmentData` on each
+matching segment.
+
+## What it annotates
+
+This plugin visits every `segment` node, looks up the segment profile by
+three-character name, and writes the human-readable title onto
+`segment.data.title`. Segments with no matching profile — Z-segments or
+segments from unsupported versions — are left untouched.
+
+### `segment.data`
+
+After this plugin runs, the augmented interface is:
+
+```ts
+declare module "@glion/ast" {
+  interface SegmentData {
+    // Human-readable segment title from the HL7v2 specification.
+    // Examples: "Message Header" (MSH), "Patient Identification" (PID),
+    // "Observation/Result" (OBX), "Observation Request" (OBR).
+    title?: string;
+  }
+}
+```
+
+Lookup uses `profile.segments.byId.get(node.name)` where `profile` is the
+`ProfileContext` attached by `@glion/annotate-profile-context`. If
+`file.data.profile` is missing entirely, the plugin returns without writing
+anything.
+
+## Part of Glion
+
+`@glion/annotate-profile-segments` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -1,37 +1,52 @@
-# HL7v2-AST
+# @glion/ast
 
-**H**ealth **L**evel **7** Version 2 **A**bstract **S**yntax **T**ree.
+TypeScript types and specification for the HL7v2 abstract syntax tree.
 
-**hl7v2-ast** is a specification for representing HL7v2 messages as an [abstract syntax tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree). It implements **[unist](https://github.com/syntax-tree/unist)** and provides a structured, lossless representation of HL7v2 segments, fields, field repetitions, components, and subcomponents.
+## What it does
 
-## Introduction
+`@glion/ast` defines the shape of HL7v2 messages as an abstract syntax tree. The tree implements the [`unist`](https://github.com/syntax-tree/unist) spec, so every Glion parser, transformer, linter, and serializer — and any third-party `unist` utility — can consume the same representation. This package ships only TypeScript types; runtime behavior (parsing, visiting, building) lives in the parser, builder, and util packages that consume these types.
 
-This document defines a format for representing HL7v2 messages as an abstract syntax tree.
+## Install
 
-**hl7v2-ast** was created to support parsing, validation, transformation, and linting of HL7v2 messages in a structured way.
-
-The specification follows the [Unist](https://github.com/syntax-tree/unist) model to benefit from the ecosystem of utilities and the [Unified](https://unifiedjs.com) processing pipeline.
-
-### Where this specification fits
-
-- **hl7v2-ast** extends [unist](https://github.com/syntax-tree/unist) with HL7-specific node types.
-- Integrates with editor tooling, validators, and transformers.
-
-## Types
-
-TypeScript types are published with the package:
-
-```sh
+```bash
 npm install @glion/ast
 ```
 
----
+## Use
 
-## Node Hierarchy
+```ts
+import type { Root, Segment, Field, Subcomponent } from "@glion/ast";
 
-The AST reflects the full HL7v2 delimiter hierarchy:
-
+function firstSegment(tree: Root): Segment | undefined {
+  return tree.children.find(
+    (child): child is Segment => child.type === "segment"
+  );
+}
 ```
+
+Use these types whenever you write a plugin, visitor, or helper that operates on the HL7v2 AST — they are the contract shared by every package in the ecosystem.
+
+## API
+
+The package exports interface declarations only. There is no runtime JavaScript.
+
+| Type              | Node kind                  | Role                                                       |
+| ----------------- | -------------------------- | ---------------------------------------------------------- |
+| `Root`            | `type: "root"`             | Top-level node representing a message or fragment          |
+| `Segment`         | `type: "segment"`          | A single HL7v2 segment (MSH, PID, OBX, …)                  |
+| `Group`           | `type: "group"`            | A repeating or optional group of related segments          |
+| `Field`           | `type: "field"`            | A field within a segment                                   |
+| `FieldRepetition` | `type: "field-repetition"` | A `~`-separated instance of a field                        |
+| `Component`       | `type: "component"`        | A `^`-separated component within a repetition              |
+| `Subcomponent`    | `type: "subcomponent"`     | An `&`-separated subcomponent — the only node with `value` |
+
+Every node may also carry a `position` property (`{ start, end }` with `line`, `column`, and `offset`) following the `unist` spec.
+
+## Node types
+
+The AST mirrors the full HL7v2 delimiter hierarchy:
+
+```text
 root
 └── segment
     └── field (|)
@@ -40,112 +55,62 @@ root
                 └── subcomponent (&)
 ```
 
-- Every **field** always contains one or more `field-repetition` nodes, even if there is no `~`.
-- Every **component** always contains one or more `subcomponent` nodes, even if there is no `&`.
-- Only `subcomponent` nodes carry `value`.
+- Every `field` always contains one or more `field-repetition` nodes, even when no `~` appears in the input.
+- Every `component` always contains one or more `subcomponent` nodes, even when no `&` appears.
+- Only `subcomponent` nodes carry a `value` string.
 
-## Nodes (abstract)
-
-### `Literal`
+### Abstract shapes
 
 ```idl
 interface Literal <: UnistLiteral {
   value: string
 }
-```
 
-Represents a leaf HL7v2 node containing a value. In this AST, the leaf is always a `subcomponent`.
-
-### `Parent`
-
-```idl
 interface Parent <: UnistParent {
   children: [HL7v2Node]
 }
 ```
 
-Represents a container node such as a `segment`, `field`, or `component`.
+`Literal` is the leaf (`Subcomponent`). `Parent` is anything that contains other nodes.
 
-## Nodes (concrete)
-
-### `Root`
+### Concrete nodes
 
 ```idl
 interface Root <: Parent {
   type: 'root'
   children: [Segment | Group]
 }
-```
 
-Root of an HL7v2 AST. Can represent a full message or a fragment.
-
----
-
-### `Segment`
-
-```idl
 interface Segment <: Parent {
   type: 'segment'
   name?: string
   children: [Field]
 }
-```
 
-Represents an HL7v2 segment such as `MSH`, `PID`, or `OBX`.
-
-The `name` property can be used to identify the segment without traversing the field hierarchy. When present, it contains the segment identifier (e.g., "MSH", "PID", "OBX").
-
-### `Group`
-
-```idl
 interface Group <: Parent {
   type: 'group'
   name: string
   children: [Segment]
 }
-```
 
-Represents a repeating or optional group of related segments (e.g., ORC+OBR+OBX).
-
-### `Field`
-
-```idl
 interface Field <: Parent {
   type: 'field'
   index: number
   children: [FieldRepetition]
 }
-```
 
-Represents a field inside a segment. **Always** contains one or more `field-repetition` nodes.
-
-### `FieldRepetition`
-
-```idl
 interface FieldRepetition <: Parent {
   type: 'field-repetition'
   index?: number
   children: [Component]
 }
-```
 
-Represents one `~`-separated instance of a field. **Always** contains one or more `component` nodes.
-
-### `Component`
-
-```idl
 interface Component <: Parent {
   type: 'component'
   index: number
   children: [Subcomponent]
 }
-```
 
-Represents a `^`-separated component. **Always** contains one or more `subcomponent` nodes.
-
-### `Subcomponent`
-
-```idl
 interface Subcomponent <: Literal {
   type: 'subcomponent'
   index: number
@@ -153,11 +118,9 @@ interface Subcomponent <: Literal {
 }
 ```
 
-Represents an `&`-separated subcomponent and holds the actual text value.
+`Segment.name` carries the segment identifier (for example `"MSH"`, `"PID"`, `"OBX"`) so visitors can filter without traversing the field hierarchy. `Group.name` names the logical group (for example `"ORDER_OBSERVATION"`).
 
-## Position
-
-All nodes may include a `position` property following [unist](https://github.com/syntax-tree/unist):
+### Position
 
 ```idl
 interface Position {
@@ -172,41 +135,20 @@ interface Point {
 }
 ```
 
-## Content model
+Position is optional per the `unist` spec but is always populated by `@glion/parser`.
+
+### Content model
 
 ```idl
 type HL7v2Content =
   Root | Segment | Group | Field | FieldRepetition | Component | Subcomponent
 ```
 
-## Extensions
+Delimiters themselves live on `file.data.delimiters` (populated by `@glion/annotate-delimiters`), not on individual nodes — a single source of truth for the six HL7v2 delimiter characters.
 
-The AST is designed for:
+## Part of Glion
 
-- **Validation plugins** (segment rules, field presence)
-- **Annotation plugins** (map to FHIR, metadata)
-- **Transformers** (to JSON, FHIR, XML)
+`@glion/ast` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-## Contributing
-
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## Code of Conduct
-
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
-
-## License
-
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
-
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
-
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -1,43 +1,20 @@
-# HL7v2 Builder
+# @glion/builder
 
-`@glion/builder` provides a tiny set of helpers for assembling HL7v2 abstract syntax trees that follow the [`@glion/ast`](../hl7v2-ast/) schema. The helpers wrap [`unist-builder`](https://github.com/syntax-tree/unist-builder) so you can build trees with a couple of function calls instead of manually nesting nodes.
+Tiny, typed helpers for assembling HL7v2 ASTs by hand.
 
-## Why it helps
+## What it does
 
-- Work directly with typed nodes while avoiding the repetitive `u('node-type', …)` boilerplate from `unist-builder`.
-- Describe complex segments declaratively without worrying about separator placement or empty components.
-
-## Philosophy
-
-- Stay explicit: you build the same AST shape you would by hand, so there is no hidden serialization logic or format guessing.
-- Compose freely: each helper is a thin wrapper over `unist-builder`, making it easy to mix raw nodes and other utilities when needed.
-- Keep things minimal: a small surface area means fewer abstractions to learn and less room for divergent interpretations of the HL7v2 model.
-
-## Functions at a glance
-
-- `m(...segments)` – build a `root` (i.e. message) node from any number of segments.
-- `s(...fields)` – build a `segment` node from one or more `Field` nodes.
-- `f(...values)` – build a `field` node from strings, components, repetitions, or arrays thereof.
-- `r(...components)` – build a `field-repetition` node from strings or components.
-- `c(...values)` – build a `component` node from strings or arrays of strings.
-
-Each helper returns objects typed from `@glion/ast`, so the resulting tree can be consumed by any package in the ecosystem (parsers, linters, etc.).
+`@glion/builder` provides five short functions (`m`, `s`, `f`, `r`, `c`) that wrap [`unist-builder`](https://github.com/syntax-tree/unist-builder) and return nodes typed from [`@glion/ast`](../ast/). You build trees with a few function calls instead of nesting `u('node-type', ...)` boilerplate by hand, and the output is the same shape a parser would produce — so any Glion consumer (serializers, linters, annotators) can read it back. The builder is intentionally small: no hidden serialization, no format guessing, no HL7v2 semantics. You decide what the tree looks like; the helpers just reduce the typing.
 
 ## Install
 
-This package is ESM-only. In Node.js 18+ run one of:
-
 ```bash
 npm install @glion/builder
-# or
-yarn add @glion/builder
-# or
-pnpm add @glion/builder
 ```
 
-## Usage
+## Use
 
-```typescript
+```ts
 import { c, f, m, s } from "@glion/builder";
 
 const tree = m(
@@ -49,57 +26,46 @@ const tree = m(
     f("PID"),
     f(), // empty field
     f([
-      c(["123456", "DOE", "JOHN"]), // accept arrays or individual args interchangeably
+      c(["123456", "DOE", "JOHN"]), // arrays and individual args are interchangeable
     ])
   )
 );
 ```
 
-`tree` is now a `Root` node with two segments (`MSH`, `PID`). You can serialise it, transform it, or feed it into other HL7v2 utilities.
-
-### Experimental: Empty Mode
-
-The builder respects the `emptyMode` experimental setting from `@glion/config`. When `emptyMode: "empty"` is configured in your `.hl7v2rc.json`, empty fields, repetitions, and components will have empty children arrays instead of the legacy full structure.
-
-**Legacy mode (default):**
-
-```typescript
-f(); // → Field → Rep → Comp → Sub("")
-```
-
-**Empty mode (via config):**
-
-```typescript
-// With .hl7v2rc.json: { "settings": { "experimental": { "emptyMode": "empty" } } }
-f(); // → Field with children: []
-```
-
-See [`@glion/config`](../hl7v2-config/) for configuration details.
+`tree` is a `Root` node containing two segments (`MSH`, `PID`). Pass it to `@glion/to-hl7v2` to serialize, to `@glion/jsonify` to jsonify, or to any `unist` visitor to inspect it.
 
 ## API
 
 ### `m(...children: RootContent[]): Root`
 
+Build a `Root` (message) node.
+
 - No arguments → empty root.
-- Pass any number of `RootContent` nodes (segments, fragments, etc.); they are appended in order.
-- Arguments are used as-is, so pass concrete AST nodes rather than nested arrays.
+- Pass any number of `RootContent` nodes (segments, fragments); they are appended in order.
+- Arguments are used as-is. Pass concrete AST nodes rather than nested arrays.
 
 ### `s(...fields: Field[]): Segment`
 
+Build a `Segment` node.
+
 - No arguments → empty segment.
-- Provide the header field yourself, typically with `f('PID')`, and include it as the first argument.
-- Fields are appended in the order provided; the helper does not do any automatic flattening.
+- Include the header field yourself, typically `f('PID')`, as the first argument.
+- Fields are appended in the order provided; the helper does not auto-flatten.
 
 ### `f(...values: Array<string | Component | FieldRepetition | Array<string | Component | FieldRepetition>>): Field`
+
+Build a `Field` node.
 
 - No arguments → empty field with a single empty repetition.
 - Strings become components with a single subcomponent containing the value.
 - `Component` instances are added directly.
-- `FieldRepetition` instances are preserved and allow you to control repetitions explicitly.
-- Arrays are flattened one level so you can pass a mixture of individual values and grouped lists.
-- Sequences of strings/components are grouped into a single repetition unless you introduce a `FieldRepetition` explicitly.
+- `FieldRepetition` instances are preserved so you can control repetitions explicitly.
+- Arrays are flattened one level, letting you mix individual values and grouped lists.
+- Sequences of strings/components are grouped into a single repetition unless a `FieldRepetition` is introduced explicitly.
 
 ### `r(...components: Array<string | Component | Array<string | Component>>): FieldRepetition`
+
+Build a `FieldRepetition` node.
 
 - No arguments → repetition with an empty component.
 - Strings become components with a single subcomponent containing the value.
@@ -108,33 +74,37 @@ See [`@glion/config`](../hl7v2-config/) for configuration details.
 
 ### `c(...values: Array<string | string[]>): Component`
 
+Build a `Component` node.
+
 - No arguments → component with an empty subcomponent.
 - Strings become subcomponents.
-- Arrays are flattened one level so you can pass `c('DOE', ['JOHN', 'Q'])`.
+- Arrays are flattened one level, so `c('DOE', ['JOHN', 'Q'])` works.
 
-> **Note**
-> These helpers are intentionally minimal. For advanced scenarios—multiple repetitions per field, custom metadata, or node reuse—you can still drop down to `unist-builder` (`u`) directly and mix those nodes with the helpers above.
+For advanced scenarios — multiple repetitions per field, custom metadata, node reuse — drop down to `unist-builder` (`u`) directly and mix those nodes with the helpers above.
 
-## Contributing
+## Design
 
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
+- **Explicit.** You build the same AST shape you would by hand. There is no hidden serialization logic or format guessing.
+- **Composable.** Each helper is a thin wrapper over `unist-builder`, so raw nodes from `u()` and other utilities can be mixed freely.
+- **Minimal.** A small surface means fewer abstractions to learn and less room for divergent interpretations of the HL7v2 model.
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+### Experimental: empty mode
 
-## Code of Conduct
+The builder respects the `emptyMode` experimental setting from `@glion/config`. When `emptyMode: "empty"` is configured in your `.hl7v2rc.json`, empty fields, repetitions, and components use empty `children` arrays instead of the legacy full structure:
 
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
+```ts
+// Legacy mode (default):
+f(); // → Field → Rep → Comp → Sub("")
 
-## License
+// Empty mode (via .hl7v2rc.json: { settings: { experimental: { emptyMode: "empty" } } }):
+f(); // → Field with children: []
+```
 
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
+See [`@glion/config`](../config/) for configuration details.
 
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
+## Part of Glion
 
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+`@glion/builder` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,27 +1,18 @@
 # @glion/config
 
-Configuration schema and loader for hl7v2-specific settings.
+Configuration schema and loader for `.hl7v2rc.json` and related config files.
 
-## Overview
+## What it does
 
-This package provides type-safe configuration loading for hl7v2-specific settings that augment the standard [unified-args](https://github.com/unifiedjs/unified-args) configuration system.
+Discovers and validates HL7v2-specific configuration from `.hl7v2rc.*` files, `hl7v2.config.*`, or a `hl7v2` field in `package.json`. Supports JSON, YAML, JavaScript (ESM/CJS), and TypeScript config formats, returns a typed object with `plugins` and `settings`, and ships a JSON Schema so editors can autocomplete config files. Augments the standard [unified-args](https://github.com/unifiedjs/unified-args) configuration system rather than replacing it — `plugins` is passed through, `settings` is validated here.
 
-**Key Features:**
-
-- ✅ Type-safe settings with TypeScript types
-- ✅ Runtime validation with Zod
-- ✅ JSON Schema for IDE autocomplete
-- ✅ Compatible with all unified-args RC file formats
-- ✅ Validates only hl7v2-specific `settings` - `plugins` handled by unified-args
-- ✅ Synchronous API for fast startup
-
-## Installation
+## Install
 
 ```bash
 npm install @glion/config
 ```
 
-## Quick Start
+## Use
 
 Create a `.hl7v2rc.json` file in your project:
 
@@ -55,11 +46,72 @@ console.log(settings.delimiters.field); // "|"
 console.log(settings.experimental.emptyMode); // "empty"
 ```
 
-## Configuration Schema
+## API
 
-### Settings
+### `loadConfig(searchFrom?)`
 
-The `settings` field contains hl7v2-specific configuration:
+Loads and validates HL7v2 configuration synchronously. Recommended for CLI tools and startup code.
+
+```typescript
+import { loadConfig } from "@glion/config";
+
+// Load full config
+const config = loadConfig();
+
+// Load from a specific directory
+const config2 = loadConfig("/path/to/project");
+
+// Destructure to get only settings
+const { settings } = loadConfig();
+```
+
+- Parameters: `searchFrom` (optional) — Directory to start searching from (defaults to cwd).
+- Returns: `HL7v2Config` — object containing `plugins` and `settings`.
+- Throws: `ConfigurationError` if configuration is invalid.
+
+### `loadConfigAsync(searchFrom?)`
+
+Loads and validates HL7v2 configuration asynchronously. Use when you need non-blocking I/O or are in an async context.
+
+```typescript
+import { loadConfigAsync } from "@glion/config";
+
+const config = await loadConfigAsync();
+const { settings } = await loadConfigAsync();
+```
+
+- Parameters: `searchFrom` (optional) — Directory to start searching from (defaults to cwd).
+- Returns: `Promise<HL7v2Config>`.
+- Throws: `ConfigurationError` if configuration is invalid.
+
+### `defineConfig(config)`
+
+Type-safe helper for authoring configuration files. Provides IDE autocomplete with no runtime overhead (identity function for type inference).
+
+```typescript
+// hl7v2.config.ts
+import { defineConfig } from "@glion/config";
+
+export default defineConfig({
+  plugins: ["preset-lint-recommended"],
+  settings: {
+    delimiters: { field: "|", component: "^" },
+    experimental: { emptyMode: "empty" },
+  },
+});
+```
+
+### `ConfigurationError`
+
+Error thrown when configuration validation fails.
+
+```typescript
+class ConfigurationError extends Error {
+  cause?: unknown;
+}
+```
+
+### `HL7v2Settings`
 
 ```typescript
 type HL7v2Settings = {
@@ -77,11 +129,13 @@ type HL7v2Settings = {
 };
 ```
 
-#### Delimiters
+## Configuration keys
+
+### `settings.delimiters`
 
 Configure custom delimiters for HL7v2 message parsing. Each delimiter must be exactly one character.
 
-| Option         | Default | Description            |
+| Key            | Default | Description            |
 | -------------- | ------- | ---------------------- |
 | `field`        | `\|`    | Field separator        |
 | `component`    | `^`     | Component separator    |
@@ -90,7 +144,7 @@ Configure custom delimiters for HL7v2 message parsing. Each delimiter must be ex
 | `escape`       | `\\`    | Escape character       |
 | `segment`      | `\r`    | Segment terminator     |
 
-**Example:** Using custom delimiters for a non-standard system:
+Example — using custom delimiters for a non-standard system:
 
 ```json
 {
@@ -103,22 +157,20 @@ Configure custom delimiters for HL7v2 message parsing. Each delimiter must be ex
 }
 ```
 
-#### Experimental Features
+### `settings.experimental.emptyMode`
 
-##### `emptyMode`
+Controls how empty fields and components are represented in the AST.
 
-Controls how empty fields/components are represented in the AST.
+| Value                | Description                                                                     |
+| -------------------- | ------------------------------------------------------------------------------- |
+| `"legacy"` (default) | Empty fields create full structure (Field → Rep → Comp → Sub with `value: ""`). |
+| `"empty"`            | Empty fields have no children (Field with `children: []`).                      |
 
-| Value                | Description                                                                       |
-| -------------------- | --------------------------------------------------------------------------------- |
-| `"legacy"` (default) | Empty fields create full structure (Field -> Rep -> Comp -> Sub with `value: ""`) |
-| `"empty"`            | Empty fields have no children (Field with `children: []`)                         |
+Experimental — will become the default in v0.6.0.
 
-**Status:** Experimental. Will become the default in v0.6.0.
+### `plugins`
 
-### Plugins
-
-The `plugins` field is handled by unified-args and follows the standard unified plugin configuration format:
+Handled by unified-args; follows the standard unified plugin configuration format:
 
 ```json
 {
@@ -130,16 +182,17 @@ The `plugins` field is handled by unified-args and follows the standard unified 
 }
 ```
 
-**Severity Levels:**
-| Value | Description |
-|-------|-------------|
-| `"off"` or `0` | Disable the rule |
-| `"on"` or `"warn"` or `1` | Enable as warning |
-| `"error"` or `2` | Enable as error |
+Severity levels:
 
-## Configuration Files
+| Value                   | Description       |
+| ----------------------- | ----------------- |
+| `"off"` or `0`          | Disable the rule  |
+| `"on"` / `"warn"` / `1` | Enable as warning |
+| `"error"` or `2`        | Enable as error   |
 
-The loader searches for configuration in the following locations (in order):
+### Configuration file locations
+
+The loader searches for configuration in the following locations, in order:
 
 | Location                                                    | Format              |
 | ----------------------------------------------------------- | ------------------- |
@@ -150,7 +203,9 @@ The loader searches for configuration in the following locations (in order):
 | `.hl7v2rc.js` / `.hl7v2rc.cjs` / `.hl7v2rc.mjs`             | JavaScript          |
 | `hl7v2.config.js` / `hl7v2.config.cjs` / `hl7v2.config.mjs` | JavaScript          |
 
-### JSON Configuration
+## Examples
+
+### JSON configuration
 
 ```json
 {
@@ -167,9 +222,7 @@ The loader searches for configuration in the following locations (in order):
 }
 ```
 
-### TypeScript Configuration
-
-For type-safe configuration with IDE autocomplete, use `defineConfig()`:
+### TypeScript configuration
 
 ```typescript
 // hl7v2.config.ts
@@ -178,20 +231,13 @@ import { defineConfig } from "@glion/config";
 export default defineConfig({
   plugins: ["preset-lint-recommended"],
   settings: {
-    delimiters: {
-      field: "|",
-      component: "^",
-    },
-    experimental: {
-      emptyMode: "empty",
-    },
+    delimiters: { field: "|", component: "^" },
+    experimental: { emptyMode: "empty" },
   },
 });
 ```
 
-### JavaScript Configuration
-
-For dynamic configuration, use a JavaScript config file:
+### JavaScript configuration
 
 ```javascript
 // hl7v2.config.js
@@ -214,7 +260,7 @@ export default {
 };
 ```
 
-### Package.json Configuration
+### Package.json configuration
 
 ```json
 {
@@ -223,108 +269,15 @@ export default {
   "hl7v2": {
     "plugins": ["preset-lint-recommended"],
     "settings": {
-      "experimental": {
-        "emptyMode": "empty"
-      }
+      "experimental": { "emptyMode": "empty" }
     }
   }
 }
 ```
 
-## API
+### Parser integration
 
-### `loadConfig(searchFrom?)`
-
-Load and validate hl7v2 configuration synchronously.
-
-**Recommended for:** CLI tools, startup code, and most use cases.
-
-```typescript
-import { loadConfig } from "@glion/config";
-
-// Load full config
-const config = loadConfig();
-
-// Load from a specific directory
-const config = loadConfig("/path/to/project");
-
-// Destructure to get only settings
-const { settings } = loadConfig();
-```
-
-**Parameters:**
-
-- `searchFrom` (optional): Directory to start searching from (defaults to cwd)
-
-**Returns:** `HL7v2Config` - Configuration object containing `plugins` and `settings`
-
-**Throws:** `ConfigurationError` if configuration is invalid
-
-### `loadConfigAsync(searchFrom?)`
-
-Load and validate hl7v2 configuration asynchronously.
-
-**Use when:** You need non-blocking I/O or are in an async context.
-
-```typescript
-import { loadConfigAsync } from "@glion/config";
-
-const config = await loadConfigAsync();
-const { settings } = await loadConfigAsync();
-```
-
-**Parameters:**
-
-- `searchFrom` (optional): Directory to start searching from (defaults to cwd)
-
-**Returns:** `Promise<HL7v2Config>` - Configuration object containing `plugins` and `settings`
-
-**Throws:** `ConfigurationError` if configuration is invalid
-
-### `defineConfig(config)`
-
-Type-safe helper for authoring configuration files. Provides IDE autocomplete without any runtime overhead.
-
-```typescript
-import { defineConfig } from "@glion/config";
-
-export default defineConfig({
-  plugins: ["preset-lint-recommended"],
-  settings: {
-    experimental: { emptyMode: "empty" },
-  },
-});
-```
-
-**Parameters:**
-
-- `config`: Configuration object
-
-**Returns:** The same config object (identity function for type inference)
-
-### `ConfigurationError`
-
-Error thrown when configuration validation fails.
-
-```typescript
-class ConfigurationError extends Error {
-  cause?: unknown;
-}
-```
-
-## IDE Support
-
-For IDE autocomplete and validation, add the `$schema` field to your JSON configuration:
-
-```json
-{
-  "$schema": "https://raw.githubusercontent.com/rethinkhealth/glion/main/packages/hl7v2-config/schema.json"
-}
-```
-
-## Integration with Parser
-
-The parser automatically reads settings from the unified processor:
+The parser reads settings from the unified processor:
 
 ```typescript
 import { unified } from "unified";
@@ -333,58 +286,30 @@ import { parseHL7v2 } from "@glion/hl7v2";
 const processor = unified()
   .use(parseHL7v2)
   .data("settings", {
-    delimiters: {
-      field: "|",
-      component: "^",
-    },
-    experimental: {
-      emptyMode: "empty",
-    },
+    delimiters: { field: "|", component: "^" },
+    experimental: { emptyMode: "empty" },
   });
 
 const tree = processor.parse("MSH|^~\\&|...");
 ```
 
-When using the CLI, settings are automatically loaded from configuration files.
+When using the CLI, settings are loaded from configuration files automatically.
 
-## Design Principles
+### IDE support
 
-1. **Augments, not replaces** - Extends unified-args via the `settings` field
-2. **Validates only settings** - The `plugins` field is handled by unified-args
-3. **Type-safe** - Full TypeScript support with Zod validation
-4. **IDE-friendly** - JSON Schema for autocomplete and validation
-5. **Backward compatible** - Defaults work without configuration
+For autocomplete and validation, add the `$schema` field to your JSON configuration:
 
-## Related Packages
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/rethinkhealth/glion/main/packages/hl7v2-config/schema.json"
+}
+```
 
-- [@glion/hl7v2](../hl7v2) - Main hl7v2 parser
-- [@glion/cli](../hl7v2-cli) - CLI that uses this configuration
-- [unified-args](https://github.com/unifiedjs/unified-args) - Plugin configuration system
+This package only validates configuration and does not execute arbitrary code from config files, except JS/MJS/TS config files which are explicitly imported. Ensure you trust the source of your configuration files.
 
-## Security
+## Part of Glion
 
-This package only validates configuration and does not execute arbitrary code from configuration files (except JS/MJS config files which are explicitly imported). Ensure you trust the source of your configuration files.
+`@glion/config` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-## Contributing
-
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## Code of Conduct
-
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
-
-## License
-
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
-
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
-
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/decode-escapes/README.md
+++ b/packages/decode-escapes/README.md
@@ -1,57 +1,33 @@
 # @glion/decode-escapes
 
-**[unified](https://unifiedjs.com/)** plugin to decode HL7v2 escape sequences in literal values.
+Unified plugin to decode HL7v2 escape sequences in literal values.
 
-## What is this?
+## What it does
 
-`@glion/decode-escapes` is a [unified](https://unifiedjs.com/) plugin that traverses an HL7v2 syntax tree (produced by a parser such as [`@glion/ast`](https://github.com/rethinkhealth/glion/tree/main/packages/hl7v2-parser)) and decodes HL7v2 escape sequences in all literal values (`subcomponent` nodes).
-
-It preserves the original raw value and replaces the `value` property with the decoded text, handling:
-
-- HL7 delimiter escapes (`\F\`, `\S\`, `\R\`, `\T\`, `\E\`)
-- Hexadecimal escapes (`\Xdddd\`)
-- Line break directives (`\.br\`)
-- Strips highlighting markers (`\H\`, `\N\`)
-
-## When should I use this?
-
-Use this plugin when you need:
-
-- Human-readable HL7v2 values with escape sequences decoded.
-- To process or display HL7v2 message content where `\F\` and similar escapes should be expanded.
-
-If you need to parse HL7v2 messages first, use [`@glion/ast`](https://github.com/rethinkhealth/glion/tree/main/packages/hl7v2-parser) before applying this plugin.
+Walks an HL7v2 AST and decodes escape sequences found in `subcomponent` nodes, replacing `node.value` with the decoded text. It handles the HL7 delimiter escapes (`\F\`, `\S\`, `\R\`, `\T\`, `\E\`), hexadecimal escapes (`\Xdddd\`), line-break directives (`\.br\`), and strips the highlighting markers (`\H\`, `\N\`). The original raw text is preserved on `node.data.raw` so the transformation is non-destructive.
 
 ## Install
 
-This package is [ESM only](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
-
-In Node.js (version 16+), install with [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm):
-
-```sh
+```bash
 npm install @glion/decode-escapes
 ```
 
 ## Use
 
-Say we have an HL7v2 message with escapes:
-
 ```js
+import { hl7v2DecodeEscapes } from "@glion/decode-escapes";
+import { hl7v2Parser } from "@glion/parser";
 import { unified } from "unified";
-import { hl7v2Parse } from "@glion/ast";
-import { hl7v2DecodeLiterals } from "@glion/decode-escapes";
 
 const msg = `OBX|1|TX|ID123||Patient allergic to \\F\\Peanuts\\F\\ and \\.br\\Severe reaction`;
 
 const file = await unified()
-  .use(hl7v2Parse)
-  .use(hl7v2DecodeLiterals)
+  .use(hl7v2Parser)
+  .use(hl7v2DecodeEscapes)
   .process(msg);
-
-console.log(String(file));
 ```
 
-Before decoding, the `subcomponent.value` contains the raw HL7 text:
+Before decoding, `subcomponent.value` contains the raw HL7 text:
 
 ```json
 {
@@ -73,7 +49,7 @@ After this plugin runs:
 
 ## API
 
-### `unified().use(hl7v2DecodeLiterals[, options])`
+### `unified().use(hl7v2DecodeEscapes[, options])`
 
 Decode HL7v2 escape sequences in literal nodes.
 
@@ -87,35 +63,29 @@ Nothing (`undefined`). Mutates the AST in-place.
 
 ## Behavior
 
-- Preserves original text in `node.data.raw`.
-- Decodes into `node.value`.
-- Uses `Root.data.delimiters` (preferred) or `options.delimiters`.
-- Falls back to defaults if neither is present.
+The plugin visits every `subcomponent` node and rewrites `node.value`. The original text is preserved on `node.data.raw` so downstream plugins can recover it.
 
-## Security
+Each escape sequence is decoded as follows:
 
-This plugin only transforms AST nodes and does not execute code. Ensure you trust the source of HL7v2 messages before processing.
+| Input     | Output                                         |
+| --------- | ---------------------------------------------- |
+| `\F\`     | field separator (default `\|`)                 |
+| `\S\`     | component separator (default `^`)              |
+| `\R\`     | repetition separator (default `~`)             |
+| `\T\`     | subcomponent separator (default `&`)           |
+| `\E\`     | escape character (default `\`)                 |
+| `\Xdddd\` | character(s) for the given hexadecimal code(s) |
+| `\.br\`   | carriage return (`\r`)                         |
+| `\H\`     | stripped (highlight-on marker, no output)      |
+| `\N\`     | stripped (normal-text marker, no output)       |
 
-## Contributing
+Delimiter resolution order: `Root.data.delimiters` (preferred, set by the parser) → `options.delimiters` → HL7 defaults.
 
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
+The plugin only transforms AST nodes and does not execute code. The inverse operation is provided by [`@glion/encode-escapes`](https://github.com/rethinkhealth/glion/tree/main/packages/encode-escapes).
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+## Part of Glion
 
-## Code of Conduct
+`@glion/decode-escapes` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
-
-## License
-
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
-
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
-
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/encode-escapes/README.md
+++ b/packages/encode-escapes/README.md
@@ -1,40 +1,23 @@
 # @glion/encode-escapes
 
-**[unified](https://unifiedjs.com/)** plugin to encode special characters as HL7v2 escape sequences in literal values.
+Unified plugin to encode special characters as HL7v2 escape sequences in literal values.
 
-## What is this?
+## What it does
 
-`@glion/encode-escapes` is a [unified](https://unifiedjs.com/) plugin that traverses an HL7v2 syntax tree and encodes delimiter characters in all literal values (`subcomponent` nodes) as HL7v2 escape sequences.
-
-This is the inverse of [`@glion/decode-escapes`](https://github.com/rethinkhealth/glion/tree/main/packages/hl7v2-decode-escapes), handling:
-
-- Delimiter encoding (`|` → `\F\`, `^` → `\S\`, `~` → `\R\`, `&` → `\T\`)
-- Escape character encoding (`\` → `\E\`)
-- Line break encoding (`\r` → `\.br\`)
-
-## When should I use this?
-
-Use this plugin when you need to:
-
-- Prepare an HL7v2 AST for serialization after modifying subcomponent values that may contain delimiter characters.
-- Ensure values with special characters are safely encoded before converting the AST back to HL7v2 text with [`@glion/to-hl7v2`](https://github.com/rethinkhealth/glion/tree/main/packages/hl7v2-to-hl7v2).
+Walks an HL7v2 AST and encodes delimiter characters found in `subcomponent` node values as HL7v2 escape sequences, so a tree that has been modified in memory can be safely serialized back to HL7v2 text without breaking the delimiter structure. It is the inverse of [`@glion/decode-escapes`](https://github.com/rethinkhealth/glion/tree/main/packages/decode-escapes): encode then decode round-trips to the original values.
 
 ## Install
 
-This package is [ESM only](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
-
-In Node.js (version 18+), install with [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm):
-
-```sh
+```bash
 npm install @glion/encode-escapes
 ```
 
 ## Use
 
 ```js
-import { unified } from "unified";
 import { hl7v2EncodeEscapes } from "@glion/encode-escapes";
 import { hl7v2ToHl7v2 } from "@glion/to-hl7v2";
+import { unified } from "unified";
 
 // After modifying AST values that may contain delimiters:
 const file = await unified()
@@ -75,9 +58,22 @@ Encode special characters as HL7v2 escape sequences in literal nodes.
 
 Nothing (`undefined`). Mutates the AST in-place.
 
-## Round-trip compatibility
+## Behavior
 
-This plugin is the inverse of `@glion/decode-escapes`. Encoding then decoding restores the original value:
+The plugin visits every `subcomponent` node and rewrites `node.value`, substituting delimiter and control characters with their HL7v2 escape sequences:
+
+| Input | Output                         |
+| ----- | ------------------------------ |
+| `\|`  | `\F\` (field separator)        |
+| `^`   | `\S\` (component separator)    |
+| `~`   | `\R\` (repetition separator)   |
+| `&`   | `\T\` (subcomponent separator) |
+| `\`   | `\E\` (escape character)       |
+| `\r`  | `\.br\` (line break directive) |
+
+Delimiter resolution order: `Root.data.delimiters` (preferred, set by the parser) → `options.delimiters` → HL7 defaults.
+
+This is the inverse of [`@glion/decode-escapes`](https://github.com/rethinkhealth/glion/tree/main/packages/decode-escapes):
 
 ```js
 import { hl7v2DecodeEscapes } from "@glion/decode-escapes";
@@ -89,30 +85,11 @@ const decoded = await unified().use(hl7v2DecodeEscapes).run(encoded);
 // decoded values === original values
 ```
 
-## Security
+The plugin only transforms AST nodes and does not execute code.
 
-This plugin only transforms AST nodes and does not execute code. Ensure you trust the source of HL7v2 messages before processing.
+## Part of Glion
 
-## Contributing
+`@glion/encode-escapes` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## Code of Conduct
-
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
-
-## License
-
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
-
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
-
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/glion/README.md
+++ b/packages/glion/README.md
@@ -1,6 +1,6 @@
 # @glion/cli
 
-> The `glion` command — development and production runtime for Glion MLLP applications.
+The `glion` command — development and production runtime for Glion MLLP applications.
 
 ## What it does
 
@@ -9,10 +9,8 @@
 ## Install
 
 ```bash
-pnpm add @glion/cli
+npm install @glion/cli
 ```
-
-> Using npm? `npm install @glion/cli`
 
 ## Use
 
@@ -42,7 +40,7 @@ Add the two scripts to `package.json`:
 }
 ```
 
-Run `pnpm dev` during development. Run `pnpm start` in production.
+Run `npm run dev` during development. Run `npm start` in production.
 
 ## API
 
@@ -94,14 +92,13 @@ The `glion` binary ships with `#!/usr/bin/env node`. Bun and Deno require explic
 
 | Runtime | Invocation                                                          |
 | ------- | ------------------------------------------------------------------- |
-| Node    | `pnpm dev` / `pnpm start` / `npx glion dev`                         |
+| Node    | `npm run dev` / `npm start` / `npx glion dev`                       |
 | Bun     | `bun --bun run dev` (package.json script) or `bunx --bun glion dev` |
 | Deno    | `deno task dev` with a `deno.json` task that runs the bin           |
 
 ## Part of Glion
 
-`@glion/cli` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/cli` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/glion/README.md
+++ b/packages/glion/README.md
@@ -1,0 +1,107 @@
+# @glion/cli
+
+> The `glion` command — development and production runtime for Glion MLLP applications.
+
+## What it does
+
+`@glion/cli` provides the `glion` binary that runs Glion applications. A single-file MLLP app exported as `export default new Mllp()` becomes a running server with `glion dev` (for development with live reload and a terminal UI) or `glion start` (for production with graceful shutdown and structured logs). The CLI reads configuration from a `glion.config.ts` file when present or infers defaults when not.
+
+## Install
+
+```bash
+pnpm add @glion/cli
+```
+
+> Using npm? `npm install @glion/cli`
+
+## Use
+
+Define your app in a single file:
+
+```ts
+// glion.app.ts
+import { parseHL7v2 } from "@glion/hl7v2";
+import { Mllp } from "@glion/mllp";
+import { ackMiddleware } from "@glion/mllp-ack";
+
+export default new Mllp()
+  .parser(parseHL7v2)
+  .use(ackMiddleware())
+  .on("ADT^A01", handleAdmit)
+  .on("ORU^R01", handleResult);
+```
+
+Add the two scripts to `package.json`:
+
+```json
+{
+  "scripts": {
+    "dev": "glion dev",
+    "start": "glion start"
+  }
+}
+```
+
+Run `pnpm dev` during development. Run `pnpm start` in production.
+
+## API
+
+### `defineConfig(config)`
+
+Identity helper for `glion.config.ts` that gives TypeScript inference over the configuration schema:
+
+```ts
+// glion.config.ts
+import { defineConfig } from "@glion/cli/config";
+
+export default defineConfig({
+  entry: "./src/app.ts",
+  port: 2575,
+  hostname: "0.0.0.0",
+});
+```
+
+### `GlionConfig`
+
+Type exported from `@glion/cli/config`:
+
+| Field             | Type                            | Description                                                          |
+| ----------------- | ------------------------------- | -------------------------------------------------------------------- |
+| `entry`           | `string`                        | Path to the app file. Defaults to `./glion.app.ts` when unspecified. |
+| `port`            | `number`                        | Port to listen on. Defaults to `2575` (the MLLP standard).           |
+| `hostname`        | `string`                        | Interface to bind. Defaults to `0.0.0.0`.                            |
+| `tls`             | `{ cert: string; key: string }` | Enable MLLP over TLS.                                                |
+| `watch`           | `string[]`                      | Additional paths the dev watcher should reload on.                   |
+| `gracefulCloseMs` | `number`                        | Drain timeout for `glion start`. Defaults to `5000`.                 |
+
+## Commands
+
+### `glion dev`
+
+Runs the app with live reload. Watches the entry file and any paths listed in `watch`, cold-restarts on change, and renders a live terminal UI showing request/response counts, uptime, and error summaries. Falls back to log-only mode when stdout is not a TTY (CI, piped output).
+
+### `glion start`
+
+Runs the app in production. Emits JSON-line events to stdout for log aggregators, handles `SIGTERM` with a graceful drain (`gracefulCloseMs`, default 5000), and exits cleanly when the drain completes.
+
+### Zero-config mode
+
+Both commands work without a `glion.config.ts` when the app file is at `./glion.app.ts` at the project root. The TUI shows a `zero-config` badge to indicate no config was loaded. Create a `glion.config.ts` when you need custom ports, TLS, or additional watch paths.
+
+### Cross-runtime invocation
+
+The `glion` binary ships with `#!/usr/bin/env node`. Bun and Deno require explicit opt-in:
+
+| Runtime | Invocation                                                          |
+| ------- | ------------------------------------------------------------------- |
+| Node    | `pnpm dev` / `pnpm start` / `npx glion dev`                         |
+| Bun     | `bun --bun run dev` (package.json script) or `bunx --bun glion dev` |
+| Deno    | `deno task dev` with a `deno.json` task that runs the bin           |
+
+## Part of Glion
+
+`@glion/cli` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/hl7v2/README.md
+++ b/packages/hl7v2/README.md
@@ -1,26 +1,74 @@
 # @glion/hl7v2
 
-A processor based on **[unified](https://github.com/unifiedjs/unified)** framework to parse, validate, and serialize HL7v2 messages.
+Pre-configured `unified` processor that parses, annotates, decodes, lints, and serializes HL7v2 messages.
 
-## What is this?
+## What it does
 
-This package provides a pre-configured `unified` processor pipeline that handles the full lifecycle of an HL7v2 message:
+`@glion/hl7v2` exports `parseHL7v2`, a frozen `unified` processor assembled from the Glion plugin set. Feeding it an HL7v2 string returns a `VFile` whose `result` is the JSON serialization, whose `tree` is the transformed AST, and whose `messages` list holds every lint diagnostic gathered along the way. Use it when you want the full pipeline; reach for individual plugins when you need a different composition.
 
-1. **Parse** — convert raw HL7v2 text into an AST
-2. **Annotate** — extract message structure metadata
-3. **Decode** — resolve HL7v2 escape sequences
-4. **Lint** — apply recommended validation rules
-5. **Profile lint** — validate against HL7v2 field definitions, datatypes, and table values
-6. **Serialize** — convert to JSON
+## Install
 
-## When should I use this?
+```bash
+npm install @glion/hl7v2
+```
 
-Use this package when you want the full, batteries-included pipeline. It is a shortcut for:
+## Use
 
-```typescript
-unified()
+```ts
+import { parseHL7v2 } from "@glion/hl7v2";
+
+const file = await parseHL7v2.process(
+  "MSH|^~\\&|SENDER||RECEIVER||20241201||ADT^A01|MSG123|P|2.5\rPID|1||12345"
+);
+
+console.log(file.messages); // lint diagnostics (warnings + errors)
+console.log(String(file)); // JSON output
+```
+
+The processor is frozen. To extend it, call `.use(...)` on a fresh `unified()` instance composed of the plugins you need.
+
+## API
+
+### `parseHL7v2`
+
+The frozen processor exported by this package. Its type is `Processor<Root, Root, Root, Root, string>` — it parses strings into an HL7v2 AST (`Root`), transforms the tree, and compiles it back to a JSON string via `@glion/jsonify`.
+
+```ts
+import type { Processor } from "unified";
+import type { Root } from "@glion/ast";
+
+export const parseHL7v2: Processor<Root, Root, Root, Root, string>;
+```
+
+Common methods inherited from `unified`:
+
+| Method                       | Description                                                                  |
+| ---------------------------- | ---------------------------------------------------------------------------- |
+| `parseHL7v2.process(input)`  | Parse, transform, and compile. Returns a `Promise<VFile>`.                   |
+| `parseHL7v2.parse(input)`    | Parse only. Returns a `Root` AST without running transforms or the compiler. |
+| `parseHL7v2.run(tree)`       | Run the transform phase on a pre-parsed tree. Returns a `Promise<Root>`.     |
+| `parseHL7v2.stringify(tree)` | Compile a tree to the JSON output without re-running transforms.             |
+
+### AST
+
+The syntax tree produced by `parseHL7v2` is defined in [`@glion/ast`](../ast/). Every node is a `unist` node; see the AST README for the full hierarchy.
+
+## Pipeline
+
+`parseHL7v2` composes six plugins in this order (see `packages/hl7v2/src/index.ts`):
+
+```ts
+import { unified } from "unified";
+import { hl7v2Parser } from "@glion/parser";
+import { hl7v2AnnotateDelimiters } from "@glion/annotate-delimiters";
+import { hl7v2DecodeEscapes } from "@glion/decode-escapes";
+import hl7v2PresetLintRecommended from "@glion/preset-lint-recommended";
+import hl7v2PresetLintProfileRecommended from "@glion/preset-lint-profile-recommended";
+import { hl7v2Jsonify } from "@glion/jsonify";
+
+export const parseHL7v2 = unified()
   .use(hl7v2Parser)
-  .use(hl7v2MessageStructure)
+  .use(hl7v2AnnotateDelimiters)
   .use(hl7v2DecodeEscapes)
   .use(hl7v2PresetLintRecommended)
   .use(hl7v2PresetLintProfileRecommended)
@@ -28,59 +76,33 @@ unified()
   .freeze();
 ```
 
-If you want to inspect and format HL7v2 files in a project on the command line, you can use [`@glion/cli`](../hl7v2-cli/).
+| Stage                               | Package                                  | What it contributes                                                                          |
+| ----------------------------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `hl7v2Parser`                       | `@glion/parser`                          | Tokenizes HL7v2 text into a `Root` AST following the `@glion/ast` spec.                      |
+| `hl7v2AnnotateDelimiters`           | `@glion/annotate-delimiters`             | Resolves delimiters from MSH-1/MSH-2 and stores them on `file.data.delimiters`.              |
+| `hl7v2DecodeEscapes`                | `@glion/decode-escapes`                  | Decodes HL7 escape sequences (`\F\`, `\S\`, `\Xdddd\`, `\.br\`, …) into subcomponent values. |
+| `hl7v2PresetLintRecommended`        | `@glion/preset-lint-recommended`         | Applies the general lint rule set (structural checks, required segments, version).           |
+| `hl7v2PresetLintProfileRecommended` | `@glion/preset-lint-profile-recommended` | Applies profile-aware lint rules (field definitions, datatypes, table values).               |
+| `hl7v2Jsonify`                      | `@glion/jsonify`                         | Compiles the transformed tree to the simplified JSON representation.                         |
 
-## Install
+To build your own pipeline, import the plugins directly and compose them on a fresh `unified()` instance.
 
-This package is [ESM only](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c). In Node.js (version 18+), install with [npm](https://docs.npmjs.com/cli/install):
+## Custom pipelines
 
-```sh
-npm install @glion/hl7v2
+```ts
+import { unified } from "unified";
+import { hl7v2Parser } from "@glion/parser";
+import { hl7v2ToHl7v2 } from "@glion/to-hl7v2";
+
+// Parse-and-reserialize (round-trip)
+const roundtrip = unified().use(hl7v2Parser).use(hl7v2ToHl7v2).freeze();
 ```
 
-## Use
+Any `unified` plugin that operates on the `@glion/ast` tree can be slotted in — custom lints, annotators, transformers, or alternative compilers like `@glion/to-hl7v2`.
 
-```typescript
-import { parseHL7v2 } from "@glion/hl7v2";
+## Part of Glion
 
-const result = await parseHL7v2.process("MSH|^~\\&|...\rPID|1||12345...");
+`@glion/hl7v2` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-console.log(result.messages); // validation messages (warnings/errors)
-console.log(result.result); // JSON output
-```
-
-## Syntax tree
-
-The syntax tree format used in `@glion/hl7v2` is [@glion/ast](../hl7v2-ast/).
-
-## Types
-
-This package is fully typed with [TypeScript](https://www.typescriptlang.org). It exports no additional types.
-
-## Security
-
-Use of `@glion/hl7v2` plugins could open you up to some potential attacks. Carefully assess each plugin and the risks involved in using them.
-
-## Contributing
-
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## Code of Conduct
-
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
-
-## License
-
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
-
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
-
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/jsonify/README.md
+++ b/packages/jsonify/README.md
@@ -1,44 +1,27 @@
 # @glion/jsonify
 
-**[unified](https://unifiedjs.com/)** plugin to transform HL7v2 message ASTs into a simplified JSON representation.
+Serialize an HL7v2 AST into a compact, structured JSON document.
 
-## What is this?
+## What it does
 
-`@glion/jsonify` is a [unified](https://unifiedjs.com/) plugin that takes an HL7v2 syntax tree (produced by a parser such as [`@glion/ast`][https://github.com/rethinkhealth/glion/tree/main/packages/hl7v2-parser]) and compiles it to a clean, structured JSON format.
-
-It strips away [unist](https://github.com/syntax-tree/unist) metadata and preserves only meaningful HL7v2 properties such as segment type, field indexes, and values.
-
-## When should I use this?
-
-Use this plugin when you need:
-
-- A minimal JSON representation of HL7v2 messages for downstream processing.
-- To serialize HL7v2 ASTs into a format suitable for APIs or storage.
-
-If you need to parse raw HL7v2 messages first, use [`@glion/ast`](https://github.com/rethinkhealth/glion/tree/main/packages/hl7v2-parser) before applying this plugin.
+`@glion/jsonify` takes an HL7v2 AST — typically produced by `@glion/parser` — and emits a JSON representation that strips `unist` metadata (position, raw, type discriminators) and keeps only the meaningful HL7v2 shape: segment names, field indexes, values, and children. The result is a clean payload for downstream APIs, message queues, and analytics stores that want structured HL7v2 without the parser's internal tree representation.
 
 ## Install
 
-This package is [ESM only](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
-
-In Node.js (version 16+), install with [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm):
-
-```sh
+```bash
 npm install @glion/jsonify
 ```
 
 ## Use
 
-Say we have an HL7v2 message and want to convert it to JSON:
-
-```js
-import { unified } from "unified";
-import { hl7v2Parse } from "@glion/ast";
+```ts
+import { hl7v2Parser } from "@glion/parser";
 import { hl7v2Jsonify } from "@glion/jsonify";
+import { unified } from "unified";
 
 const msg = `MSH|^~\\&|HIS|RIH|EKG|EKG|200202150930||ADT^A01|MSG00001|P|2.4\rPID|||555-44-4444||DOE^JOHN`;
 
-const file = await unified().use(hl7v2Parse).use(hl7v2Jsonify).process(msg);
+const file = await unified().use(hl7v2Parser).use(hl7v2Jsonify).process(msg);
 
 console.log(String(file));
 ```
@@ -54,8 +37,7 @@ Yields:
       "name": "MSH",
       "children": [
         { "type": "Field", "name": "MSH-1", "value": "|" },
-        { "type": "Field", "name": "MSH-2", "value": "^~\\&" },
-        ...
+        { "type": "Field", "name": "MSH-2", "value": "^~\\&" }
       ]
     },
     {
@@ -74,55 +56,28 @@ Yields:
 
 ### `unified().use(hl7v2Jsonify)`
 
-Transform an HL7v2 AST into JSON.
+Register the plugin as the compiler of a `unified` processor. The processor's `process()` call returns a file whose stringified contents is the JSON document. No options.
 
-###### Parameters
+## JSON shape
 
-There are no options.
-
-###### Returns
-
-Nothing (`undefined`). The unified compiler returns a stringified JSON document.
-
-## JSON Schema
-
-The output JSON has the following shape:
+Every node in the output has the following shape:
 
 ```ts
 interface HL7v2JsonNode {
-  type: string;
-  name?: string;
-  index?: number;
-  value?: string;
-  delimiter?: string;
-  children?: HL7v2JsonNode[];
+  type: string; // "Message", "Segment", "Field", "Component", ...
+  name?: string; // segment name (e.g. "MSH") or field id (e.g. "PID-3")
+  index?: number; // positional index where relevant
+  value?: string; // leaf value for Field / Component / Subcomponent
+  delimiter?: string; // delimiter character when it is meaningful to preserve
+  children?: HL7v2JsonNode[]; // recursive shape for composite nodes
 }
 ```
 
-## Security
+Only the fields relevant to a given node appear in the output — `Field` nodes carry `name` and `value`, composite nodes carry `name` and `children`, and so on.
 
-This plugin only transforms AST nodes and does not execute code. Ensure you trust the source of HL7v2 messages before processing.
+## Part of Glion
 
-## Contributing
+`@glion/jsonify` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## Code of Conduct
-
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
-
-## License
-
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
-
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
-
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-max-message-size/README.md
+++ b/packages/lint-max-message-size/README.md
@@ -1,51 +1,32 @@
 # @glion/lint-max-message-size
 
-A [`unified`][github-unified] lint rule that warns when an HL7v2 message exceeds a configurable maximum size in bytes or number of segments.
+Lint rule that flags HL7v2 messages exceeding a maximum byte size or segment count.
 
-- **Default max size:** 10,000,000 bytes (10MB)
-- **Optional:** Limit the number of segments
+## What it does
 
-## What is this?
-
-This package validates the **maximum message size** in HL7v2 syntax trees produced by parsers like [`@glion/parser`][github-hl7v2-parser].
-
-It reports a message when the HL7v2 message exceeds a configurable maximum size in bytes (default: 1,000,000 bytes) or, optionally, a maximum number of segments.
-
-## When should I use this?
-
-Use this rule to enforce a maximum HL7v2 message size (in bytes) and/or segment count, helping to prevent oversized messages that may cause downstream processing issues or violate system constraints.
-
-This linter is useful for:
-
-- Ensuring HL7v2 messages do not exceed a safe or expected size limit (default: 10MB).
-- Optionally restricting the number of segments in a message to catch unusually large or malformed messages.
-- Improving reliability and performance by catching messages that could cause resource exhaustion or be rejected by receivers.
-
-Configure the rule to match your system's requirements for message size and segment count.
+Measures the UTF-8 byte length of the source message and, optionally, the number of segment nodes in the tree. Reports a warning when the message is larger than `maxBytes` (default 10,000,000) or when `maxSegments` is set and the tree contains more segments than allowed. Intended to protect downstream systems from oversized payloads that would cause resource or protocol limits to be hit.
 
 ## Install
 
-This package is **ESM only**. In Node.js (v16+), install with npm:
-
-```sh
+```bash
 npm install @glion/lint-max-message-size
 ```
 
 ## Use
 
-On the API:
-
-```js
-import { unified } from "unified";
-import { hl7v2Parse } from "@glion/parser";
+```ts
+import { hl7v2Parser } from "@glion/parser";
 import hl7v2LintMaxMessageSize from "@glion/lint-max-message-size";
+import { unified } from "unified";
 import { reporter } from "vfile-reporter";
 
-const msg = `MSH|^~\\&|...`;
+const message =
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5";
+
 const file = await unified()
-  .use(hl7v2Parse)
-  .use(hl7v2LintMaxMessageSize)
-  .process(msg);
+  .use(hl7v2Parser)
+  .use(hl7v2LintMaxMessageSize, { maxBytes: 1_000_000, maxSegments: 100 })
+  .process(message);
 
 console.error(reporter([file]));
 ```
@@ -54,39 +35,55 @@ console.error(reporter([file]));
 
 ### `unified().use(hl7v2LintMaxMessageSize[, options])`
 
-Warns when the HL7v2 message exceeds a configurable maximum size in bytes (default: 10,000,000 bytes) or, optionally, a maximum number of segments.  
-Reports a message if the message is too large or has too many segments.
+A `unified` lint rule plugin.
 
-###### Returns
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
 
-A `unified` Transformer that adds messages to the file.
+export interface MaxMessageSizeOptions {
+  /** Max allowed size of the source message in UTF-8 bytes. Default: 10_000_000 (10MB). */
+  maxBytes?: number;
+  /** Max allowed number of `segment` nodes. Default: undefined (disabled). */
+  maxSegments?: number;
+}
 
-## Security
+declare const hl7v2LintMaxMessageSize: Plugin<[MaxMessageSizeOptions?], Root>;
+export default hl7v2LintMaxMessageSize;
+```
 
-This plugin only transforms AST nodes and does not execute code. Ensure you trust the source of HL7v2 messages before processing.
+## What it checks
 
-## Contributing
+The message's UTF-8 byte length must not exceed `maxBytes`, and (when configured) the number of `segment` nodes must not exceed `maxSegments`.
 
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
+### Valid
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+A small message with `maxBytes: 1_000_000` (well under the limit):
 
-## Code of Conduct
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
 
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
+### Invalid
 
-## License
+A message whose UTF-8 size exceeds `maxBytes`:
 
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
+```
+Message size 2,000,000 bytes exceeds 1,000,000 bytes limit — trim payload or raise "maxBytes"
+```
 
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
+A tree with more segments than `maxSegments`:
 
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
-[github-unified]: https://github.com/unifiedjs/unified
-[github-hl7v2-parser]: https://github.com/rethinkhealth/glion/tree/main/packages/hl7v2-parser
+```
+Message contains 150 segments (limit 100 segments) — reduce segment count or raise "maxSegments"
+```
+
+Byte and segment counts are interpolated with pluralization. Both checks are independent — if the message violates both thresholds, two messages are reported.
+
+## Part of Glion
+
+`@glion/lint-max-message-size` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-message-version/README.md
+++ b/packages/lint-message-version/README.md
@@ -1,80 +1,103 @@
-## @glion/lint-message-version
+# @glion/lint-message-version
 
-> Lint rule that checks an HL7v2 message version (MSH-12) satisfies a version expression.
+Lint rule that checks an HL7v2 message's `MSH-12` version satisfies a semver range expression.
 
-### Installation
+## What it does
+
+Reads `MSH-12.1` from the tree and evaluates it against the configured `expression` using `@glion/util-semver`. Reports a message when `MSH-12` is missing or empty, when the value is not a valid semver-like version, or when it falls outside the allowed range. The default expression (`"<3.0.0 >=2.3"`) accepts HL7v2 versions 2.3 through 2.9 and excludes future v3 values.
+
+## Install
 
 ```bash
-pnpm add -D @glion/lint-message-version
+npm install @glion/lint-message-version
 ```
 
-### Usage
+## Use
 
-```typescript
-import { unified } from "unified";
+```ts
 import { hl7v2Parser } from "@glion/parser";
 import hl7v2LintMessageVersion from "@glion/lint-message-version";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
 
-const message = `MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01^ADT_A01|MSG00001|P|2.5`;
+const message =
+  "MSH|^~\\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01^ADT_A01|MSG00001|P|2.5";
 
-const processor = unified()
+const file = await unified()
   .use(hl7v2Parser)
-  // default expression is "<3.0.0 >=2.3"
-  .use(hl7v2LintMessageVersion, { expression: "<3.0.0 >=2.3" });
+  .use(hl7v2LintMessageVersion, { expression: "<3.0.0 >=2.3" })
+  .process(message);
 
-await processor.process(message);
+console.error(reporter([file]));
 ```
 
-### Options
+## API
 
-- **expression**: string (optional)
-  - A semver-like range expression evaluated against `MSH-12`.
-  - Defaults to `"<3.0.0 >=2.3"`.
+### `unified().use(hl7v2LintMessageVersion[, options])`
+
+A `unified` lint rule plugin.
+
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
+
+export interface MessageVersionLintOptions {
+  /** Semver range expression to evaluate against `MSH-12.1`. Default: "<3.0.0 >=2.3". */
+  expression: string;
+}
+
+declare const hl7v2LintMessageVersion: Plugin<
+  [MessageVersionLintOptions?],
+  Root
+>;
+export default hl7v2LintMessageVersion;
+```
 
 Expressions are parsed and evaluated by `@glion/util-semver`.
 
-### Examples
+## What it checks
 
-- **✅ Valid within default range** (default `"<3.0.0 >=2.3"`)
+The value of `MSH-12.1` must be present and must satisfy the configured semver expression.
 
-```
+### Valid
+
+`MSH-12` is `2.5`, within the default range `<3.0.0 >=2.3`:
+
+```hl7
 MSH|^~\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01^ADT_A01|MSG00001|P|2.5
 ```
 
-- **❌ Invalid: below minimum (2.3)**
+### Invalid
 
-```
+`MSH-12` is `2.2`, below the default minimum:
+
+```hl7
 MSH|^~\&|SENDER|FAC|RCVR|FAC|20250101010101||ADT^A01^ADT_A01|MSG00001|P|2.2
 ```
 
-- **✅ Custom expression allowing 2.2**
+Reported message:
 
-```typescript
-unified()
-  .use(hl7v2Parser)
-  .use(hl7v2LintMessageVersion, { expression: "<3.0.0 >=2.2" });
+```
+MSH-12 (version) field value '2.2' does not satisfy expression '<3.0.0 >=2.3'
 ```
 
-## Contributing
+`MSH-12` is missing:
 
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
+```
+Required MSH-12 (version) field is missing or empty
+```
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+`MSH-12` contains a value that cannot be parsed as semver:
 
-## Code of Conduct
+```
+MSH-12 (version) field value 'abc' is not valid
+```
 
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
+Both the offending value and the configured expression are interpolated into the message. The rule reports at most one message per tree and exits as soon as the first problem is detected.
 
-## License
+## Part of Glion
 
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
+`@glion/lint-message-version` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
-
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-no-trailing-empty-field/README.md
+++ b/packages/lint-no-trailing-empty-field/README.md
@@ -1,44 +1,32 @@
 # @glion/lint-no-trailing-empty-field
 
-A [`unified`][github-unified] lint rule that warns when an HL7v2 message contains a **trailing empty field** at the end of a segment.
+Lint rule that flags HL7v2 segments ending with one or more empty trailing fields.
 
-## What is this?
+## What it does
 
-This package validates HL7v2 syntax trees produced by parsers like [`@glion/parser`][github-hl7v2-parser] and **warns if any segment ends with at least one empty trailing field or more**. HL7v2 segments should not end with an extra field separator (`|`). This rule helps ensure message conformance and prevents subtle bugs in message processing.
-
-## When should I use this?
-
-Use this rule to enforce HL7v2 message conformance and catch formatting mistakes that may cause interoperability issues. Trailing field separators are sometimes added by mistake and can lead to parsing errors or misinterpretation by strict receivers.
-
-This linter is useful for:
-
-- Ensuring HL7v2 segments do not end with unnecessary field separators.
-- Improving message quality and interoperability.
-- Catching formatting mistakes early in development or integration pipelines.
+For each segment, finds the index of the last non-empty field and reports a warning if any empty fields appear after it. Trailing empty fields come from stray field separators (`|`) at the end of a segment and should be stripped — some strict receivers reject such segments, and downstream tools may misinterpret the empty positions.
 
 ## Install
 
-This package is **ESM only**. In Node.js (v16+), install with npm:
-
-```sh
+```bash
 npm install @glion/lint-no-trailing-empty-field
 ```
 
 ## Use
 
-On the API:
-
-```js
-import { unified } from "unified";
-import { hl7v2Parse } from "@glion/parser";
+```ts
+import { hl7v2Parser } from "@glion/parser";
 import hl7v2LintNoTrailingEmptyField from "@glion/lint-no-trailing-empty-field";
+import { unified } from "unified";
 import { reporter } from "vfile-reporter";
 
-const msg = `MSH|^~\\&|...`;
+const message =
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5";
+
 const file = await unified()
-  .use(hl7v2Parse)
+  .use(hl7v2Parser)
   .use(hl7v2LintNoTrailingEmptyField)
-  .process(msg);
+  .process(message);
 
 console.error(reporter([file]));
 ```
@@ -47,47 +35,51 @@ console.error(reporter([file]));
 
 ### `unified().use(hl7v2LintNoTrailingEmptyField)`
 
-Warns when any HL7v2 segment ends with one or more trailing field separators (`|`).  
-Reports a message for each segment that violates this rule.
+A `unified` lint rule plugin. Takes no options.
 
-#### Returns
+Visits every `segment` node, scans its `field` children from the end, and reports one message per segment that has trailing empty fields. The reported position spans the first empty field to the end of the segment (including the separator after the last empty field).
 
-A `unified` Transformer that adds warning messages to the file for each segment with a trailing field separator.
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
 
-## Presets
+declare const hl7v2LintNoTrailingEmptyField: Plugin<[], Root>;
+export default hl7v2LintNoTrailingEmptyField;
+```
 
-This plugin is included in the following presets:
+## What it checks
 
-| Preset                    | Options |
-| ------------------------- | ------- |
-| `@glion/lint-recommended` |         |
+A segment's last field must be non-empty. Any empty fields after the last populated field are trailing and therefore flagged.
 
-## Security
+### Valid
 
-This plugin only transforms AST nodes and does not execute code. Ensure you trust the source of HL7v2 messages before processing.
+`PID` ends with a populated field (`F`):
 
-## Contributing
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
 
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
+### Invalid
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+`PID` has two trailing empty fields after the sex component:
 
-## Code of Conduct
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F||
+```
 
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
+Reported message:
 
-## License
+```
+Segment has 2 trailing empty fields
+```
 
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
+The count of trailing fields is interpolated with pluralization (`1 trailing empty field`, `2 trailing empty fields`). One message is reported per offending segment.
 
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
+## Part of Glion
 
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
-[github-unified]: https://github.com/unifiedjs/unified
-[github-hl7v2-parser]: https://github.com/rethinkhealth/glion/tree/main/packages/hl7v2-parser
+`@glion/lint-no-trailing-empty-field` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-events-segments-order/README.md
+++ b/packages/lint-profile-events-segments-order/README.md
@@ -1,18 +1,10 @@
 # @glion/lint-profile-events-segments-order
 
-**[unified](https://github.com/unifiedjs/unified)** lint rule that validates HL7v2 segment order against message structure profiles.
+Lint rule that validates HL7v2 segment order against the message structure defined by the profile.
 
-## What is this?
+## What it does
 
-This package is a lint rule that validates segments appear in the correct order according to HL7v2 message structure definitions. It uses the DFA (Deterministic Finite Automaton) runner from `@glion/profiles` for efficient, stateful validation.
-
-## When should I use this?
-
-Use this rule when:
-
-- You need to validate that segments follow the structure defined by the HL7v2 specification
-- You want to catch segment ordering errors before downstream processing
-- You're building a validation pipeline for HL7v2 messages
+Walks the parsed tree segment-by-segment, feeding each segment name into a DFA (Deterministic Finite Automaton) built from the message structure definition in `@glion/profiles`. Reports one message for the first segment that is not valid at its position, or for a message that ends before reaching an accepting state. When no explicit `definition` is given, the rule resolves one from `tree.data.messageInfo` or directly from `MSH-9.3` and `MSH-12`.
 
 ## Install
 
@@ -22,117 +14,141 @@ npm install @glion/lint-profile-events-segments-order
 
 ## Use
 
-### With explicit definition
-
-```typescript
-import { profiles } from "@glion/profiles";
-import hl7v2LintSegmentOrder from "@glion/lint-profile-events-segments-order";
-import { unified } from "unified";
-import { VFile } from "vfile";
-
-const definition = await profiles.events.load("2.5", "ADT_A01");
-
-const processor = unified().use(hl7v2LintSegmentOrder, { definition });
-
-const file = new VFile();
-await processor.run(tree, file);
-
-console.log(file.messages);
-```
-
-### With automatic profile loading
-
-When no `definition` is provided, the rule resolves the profile from:
-
-1. `tree.data.messageInfo` (set by `@glion/annotate-message` + `@glion/annotate-message-structure`)
-2. MSH-9.3 (message structure) and MSH-12 (version) fields directly from the AST
-
-```typescript
+```ts
 import { hl7v2AnnotateMessage } from "@glion/annotate-message";
 import { hl7v2AnnotateMessageStructure } from "@glion/annotate-message-structure";
 import { hl7v2Parser } from "@glion/parser";
 import hl7v2LintSegmentOrder from "@glion/lint-profile-events-segments-order";
 import { unified } from "unified";
+import { reporter } from "vfile-reporter";
 
-const processor = unified()
+const message = [
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "EVN|A01|20250601120000",
+  "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
+].join("\r");
+
+const file = await unified()
   .use(hl7v2Parser)
   .use(hl7v2AnnotateMessage)
   .use(hl7v2AnnotateMessageStructure)
-  .use(hl7v2LintSegmentOrder);
+  .use(hl7v2LintSegmentOrder)
+  .process(message);
 
-const result = await processor.process(message);
-console.log(result.messages);
+console.error(reporter([file]));
+```
+
+With an explicit DFA definition (skips automatic resolution):
+
+```ts
+import { profiles } from "@glion/profiles";
+import hl7v2LintSegmentOrder from "@glion/lint-profile-events-segments-order";
+import { unified } from "unified";
+
+const definition = await profiles.events.load("2.5", "ADT_A01");
+
+const processor = unified().use(hl7v2LintSegmentOrder, { definition });
 ```
 
 ## API
 
 ### `unified().use(hl7v2LintSegmentOrder[, options])`
 
-Validate segment order against a message structure profile.
+A `unified` lint rule plugin.
 
-###### Parameters
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
+import type { Definition } from "@glion/profiles";
 
-- `options` (`SegmentOrderOptions`, optional)
-  - `definition` (`Definition`) — Pre-loaded DFA definition. If not provided, the rule loads it from message metadata.
+export interface SegmentOrderOptions {
+  /**
+   * Pre-loaded DFA definition for the message structure. When provided, the
+   * rule uses it directly and skips automatic resolution from tree metadata
+   * or MSH fields.
+   */
+  definition?: Definition;
+}
 
-## Messages
+declare const hl7v2LintSegmentOrder: Plugin<[SegmentOrderOptions?], Root>;
+export default hl7v2LintSegmentOrder;
+```
 
-All messages use `ruleId: "segment-order"` and `source: "hl7v2-lint"`. Severity is controlled by the consumer via standard unified-lint configuration.
+All messages use `ruleId: "segment-order"` and `source: "hl7v2-lint"`. The rule stops at the first error because a rejected DFA transition leaves the automaton in an undefined state, and subsequent errors would be misleading.
 
-### Validation errors
+## What it checks
 
-These are reported during segment-by-segment DFA validation. The rule stops at the first error — the DFA cannot recover from an invalid transition, so subsequent errors would be misleading.
+Segments must appear in an order that the message structure DFA accepts, and the message must end in an accepting state. The rule also surfaces two resolution errors that prevent validation from running.
 
-#### Unexpected segment
+### Valid
 
-> Unexpected segment 'PID'. Expected: EVN, SFT
+An `ADT_A01` message whose segments follow the structure defined for v2.5:
 
-A segment appears that is not valid in the current DFA state. The message includes the segment name and the list of segments the profile expected at this position.
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+EVN|A01|20250601120000
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+PV1|1|I|WARD^101^1
+```
 
-#### Empty segment name
+### Invalid — unexpected segment
 
-> Segment has empty segment name at this position
+`PID` appears before `EVN` in an `ADT_A01`:
 
-A segment node in the AST has an empty or undefined `name` property. This indicates a malformed tree.
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
 
-#### Message ended prematurely
+Reported message:
 
-> Message ended prematurely. Expected: PV1, PV2
+```
+Unexpected segment 'PID'. Expected: EVN, SFT
+```
 
-All segments were consumed but the DFA did not reach a final (accepting) state. The message includes the segments expected from the current state. Only reported when no other validation error was found.
+The offending segment name and the set of segments the DFA expected at that position are interpolated.
 
-### Resolution errors
+### Invalid — message ended prematurely
 
-These are reported when the rule cannot load a profile definition. Validation is skipped entirely.
+All segments were consumed but the DFA did not reach an accepting state:
 
-#### Missing metadata
+```
+Message ended prematurely. Expected: PV1, PV2
+```
 
-> Cannot validate segment order: missing version (MSH-12) or message structure (MSH-9.3)
+The list is the set of segments that would have satisfied the accepting state from the current position. Only reported when no other validation error was emitted.
 
-Neither `tree.data.messageInfo` nor the MSH fields provide the version or message structure needed to load a profile.
+### Invalid — empty segment name
 
-#### Profile not found
+A `segment` node in the AST has an empty or undefined `name`:
 
-> Cannot validate segment order: no profile found for ZZZ_Z99 (v2.5)
+```
+Segment has empty segment name at this position
+```
 
-The version and structure were resolved, but no matching profile definition exists in `@glion/profiles`.
+Indicates a malformed tree.
 
-## Compatibility
+### Resolution — missing metadata
 
-- **Node.js**: 18+
-- **TypeScript**: 5.0+
-- **unified**: 11.0+
+Neither `tree.data.messageInfo` nor the MSH fields yield the version and message structure:
 
-## Related
+```
+Cannot validate segment order: missing version (MSH-12) or message structure (MSH-9.3)
+```
 
-- [`@glion/profiles`](../hl7v2-profiles) — Profile definitions and DFA runner
-- [`@glion/annotate-message`](../hl7v2-annotate-message) — Extract message metadata
-- [`@glion/annotate-message-structure`](../hl7v2-annotate-message-structure) — Resolve message structure
+### Resolution — profile not found
 
-## License
+The version and structure were resolved, but no matching profile definition exists:
 
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
+```
+Cannot validate segment order: no profile found for ZZZ_Z99 (v2.5)
+```
 
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+Resolution errors cause validation to be skipped entirely.
 
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+## Part of Glion
+
+`@glion/lint-profile-events-segments-order` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-extra-components/README.md
+++ b/packages/lint-profile-extra-components/README.md
@@ -1,0 +1,108 @@
+# @glion/lint-profile-extra-components
+
+> Lint rule to warn when a composite field contains more components than its datatype profile defines.
+
+## What it does
+
+Flags fields whose repetitions contain more components than the
+datatype's profile allows. For composite datatypes, the maximum is the
+highest sequence key in the datatype definition; for primitive datatypes
+the maximum is 1 (the value itself). The rule reads profile context
+attached by `@glion/annotate-profile-context`. Empty fields, fields on
+unknown segments, and fields whose datatype definition is missing are
+silently skipped.
+
+## Install
+
+```bash
+pnpm add @glion/lint-profile-extra-components
+```
+
+> Using npm? `npm install @glion/lint-profile-extra-components`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2Parser } from "@glion/parser";
+import hl7v2LintExtraComponents from "@glion/lint-profile-extra-components";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+
+const message = [
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
+].join("\r");
+
+const file = await unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2LintExtraComponents)
+  .process(message);
+
+console.error(reporter([file]));
+```
+
+## API
+
+### `unified().use(hl7v2LintExtraComponents)`
+
+A `unified` lint rule plugin. Takes no options.
+
+Reads `file.data.profile`. For each non-empty field it resolves the
+datatype definition. For primitives the allowed component count is 1; for
+composites it is the highest key in `dtDef.componentsBySequence`. Every
+component at a position greater than that max produces one message per
+offending repetition.
+
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
+
+declare const hl7v2LintExtraComponents: Plugin<[], Root>;
+export default hl7v2LintExtraComponents;
+```
+
+## What it checks
+
+This rule flags `^`-delimited components past the profile's defined range
+for a datatype. `PID-8` (Administrative Sex) is a primitive field in
+v2.5, so it allows exactly one component.
+
+### Valid
+
+`PID-8` has a single component (`F`), which matches the primitive limit:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+### Invalid
+
+`PID-8` has two components (`F^EXTRA`), which exceeds the v2.5 primitive
+limit of 1:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F^EXTRA
+```
+
+Reported message:
+
+```
+Component PID-8.2 is beyond the defined components for IS (max: 1 in v2.5)
+```
+
+The datatype code (for example `IS`, `CX`, `XPN`) comes from the field's
+profile. For composite datatypes the same rule applies — a `CX` field in
+v2.5 defines up to 10 components, so a value carrying an 11th is
+reported against that datatype.
+
+## Part of Glion
+
+`@glion/lint-profile-extra-components` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-extra-components/README.md
+++ b/packages/lint-profile-extra-components/README.md
@@ -1,24 +1,16 @@
 # @glion/lint-profile-extra-components
 
-> Lint rule to warn when a composite field contains more components than its datatype profile defines.
+Lint rule to warn when a composite field contains more components than its datatype profile defines.
 
 ## What it does
 
-Flags fields whose repetitions contain more components than the
-datatype's profile allows. For composite datatypes, the maximum is the
-highest sequence key in the datatype definition; for primitive datatypes
-the maximum is 1 (the value itself). The rule reads profile context
-attached by `@glion/annotate-profile-context`. Empty fields, fields on
-unknown segments, and fields whose datatype definition is missing are
-silently skipped.
+Flags fields whose repetitions contain more components than the datatype's profile allows. For composite datatypes, the maximum is the highest sequence key in the datatype definition; for primitive datatypes the maximum is 1 (the value itself). The rule reads profile context attached by `@glion/annotate-profile-context`. Empty fields, fields on unknown segments, and fields whose datatype definition is missing are silently skipped.
 
 ## Install
 
 ```bash
-pnpm add @glion/lint-profile-extra-components
+npm install @glion/lint-profile-extra-components
 ```
-
-> Using npm? `npm install @glion/lint-profile-extra-components`
 
 ## Use
 
@@ -49,11 +41,7 @@ console.error(reporter([file]));
 
 A `unified` lint rule plugin. Takes no options.
 
-Reads `file.data.profile`. For each non-empty field it resolves the
-datatype definition. For primitives the allowed component count is 1; for
-composites it is the highest key in `dtDef.componentsBySequence`. Every
-component at a position greater than that max produces one message per
-offending repetition.
+Reads `file.data.profile`. For each non-empty field it resolves the datatype definition. For primitives the allowed component count is 1; for composites it is the highest key in `dtDef.componentsBySequence`. Every component at a position greater than that max produces one message per offending repetition.
 
 ```ts
 import type { Plugin } from "unified";
@@ -65,9 +53,7 @@ export default hl7v2LintExtraComponents;
 
 ## What it checks
 
-This rule flags `^`-delimited components past the profile's defined range
-for a datatype. `PID-8` (Administrative Sex) is a primitive field in
-v2.5, so it allows exactly one component.
+This rule flags `^`-delimited components past the profile's defined range for a datatype. `PID-8` (Administrative Sex) is a primitive field in v2.5, so it allows exactly one component.
 
 ### Valid
 
@@ -80,8 +66,7 @@ PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
 
 ### Invalid
 
-`PID-8` has two components (`F^EXTRA`), which exceeds the v2.5 primitive
-limit of 1:
+`PID-8` has two components (`F^EXTRA`), which exceeds the v2.5 primitive limit of 1:
 
 ```hl7
 MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
@@ -94,15 +79,11 @@ Reported message:
 Component PID-8.2 is beyond the defined components for IS (max: 1 in v2.5)
 ```
 
-The datatype code (for example `IS`, `CX`, `XPN`) comes from the field's
-profile. For composite datatypes the same rule applies — a `CX` field in
-v2.5 defines up to 10 components, so a value carrying an 11th is
-reported against that datatype.
+The datatype code (for example `IS`, `CX`, `XPN`) comes from the field's profile. For composite datatypes the same rule applies — a `CX` field in v2.5 defines up to 10 components, so a value carrying an 11th is reported against that datatype.
 
 ## Part of Glion
 
-`@glion/lint-profile-extra-components` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-extra-components` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-extra-fields/README.md
+++ b/packages/lint-profile-extra-fields/README.md
@@ -1,0 +1,106 @@
+# @glion/lint-profile-extra-fields
+
+> Lint rule that warns when a segment contains fields beyond the maximum sequence defined in its profile.
+
+## What it does
+
+Flags fields whose sequence number exceeds the highest field position
+defined in the HL7v2 profile for that segment at the message's version.
+The rule reads profile context attached by
+`@glion/annotate-profile-context`, computes the maximum defined sequence
+per segment, and reports each field past that boundary. Segments without
+a known profile (for example Z-segments) are silently skipped.
+
+## Install
+
+```bash
+pnpm add @glion/lint-profile-extra-fields
+```
+
+> Using npm? `npm install @glion/lint-profile-extra-fields`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2Parser } from "@glion/parser";
+import hl7v2LintExtraFields from "@glion/lint-profile-extra-fields";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+
+const message = [
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
+].join("\r");
+
+const file = await unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2LintExtraFields)
+  .process(message);
+
+console.error(reporter([file]));
+```
+
+## API
+
+### `unified().use(hl7v2LintExtraFields)`
+
+A `unified` lint rule plugin. Takes no options.
+
+Reads `file.data.profile`. For each segment it looks up the field
+definition set and takes the largest key (a 1-based HL7 sequence number)
+as the maximum. It then walks the segment's fields and reports each
+field whose sequence is greater than that maximum.
+
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
+
+declare const hl7v2LintExtraFields: Plugin<[], Root>;
+export default hl7v2LintExtraFields;
+```
+
+## What it checks
+
+This rule flags fields past the defined range for a segment. `MSH` in
+v2.5 ends at `MSH-21`, so any field at sequence 22 or higher is
+unexpected for that segment and version.
+
+### Valid
+
+`MSH` stops at `MSH-12` (Version ID) and all fields are within the v2.5
+definition:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+### Invalid
+
+`MSH` carries a field at sequence 22, which is past the v2.5 maximum
+of `MSH-21`:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5||||||||||EXTRA
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+Reported message:
+
+```
+Field MSH-22 is beyond the defined fields for MSH (max: 21 in v2.5)
+```
+
+The reported max comes from the profile's highest sequence number and
+the version is taken from the annotated profile context. One message is
+reported per extra field.
+
+## Part of Glion
+
+`@glion/lint-profile-extra-fields` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-extra-fields/README.md
+++ b/packages/lint-profile-extra-fields/README.md
@@ -1,23 +1,16 @@
 # @glion/lint-profile-extra-fields
 
-> Lint rule that warns when a segment contains fields beyond the maximum sequence defined in its profile.
+Lint rule that warns when a segment contains fields beyond the maximum sequence defined in its profile.
 
 ## What it does
 
-Flags fields whose sequence number exceeds the highest field position
-defined in the HL7v2 profile for that segment at the message's version.
-The rule reads profile context attached by
-`@glion/annotate-profile-context`, computes the maximum defined sequence
-per segment, and reports each field past that boundary. Segments without
-a known profile (for example Z-segments) are silently skipped.
+Flags fields whose sequence number exceeds the highest field position defined in the HL7v2 profile for that segment at the message's version. The rule reads profile context attached by `@glion/annotate-profile-context`, computes the maximum defined sequence per segment, and reports each field past that boundary. Segments without a known profile (for example Z-segments) are silently skipped.
 
 ## Install
 
 ```bash
-pnpm add @glion/lint-profile-extra-fields
+npm install @glion/lint-profile-extra-fields
 ```
-
-> Using npm? `npm install @glion/lint-profile-extra-fields`
 
 ## Use
 
@@ -48,10 +41,7 @@ console.error(reporter([file]));
 
 A `unified` lint rule plugin. Takes no options.
 
-Reads `file.data.profile`. For each segment it looks up the field
-definition set and takes the largest key (a 1-based HL7 sequence number)
-as the maximum. It then walks the segment's fields and reports each
-field whose sequence is greater than that maximum.
+Reads `file.data.profile`. For each segment it looks up the field definition set and takes the largest key (a 1-based HL7 sequence number) as the maximum. It then walks the segment's fields and reports each field whose sequence is greater than that maximum.
 
 ```ts
 import type { Plugin } from "unified";
@@ -63,14 +53,11 @@ export default hl7v2LintExtraFields;
 
 ## What it checks
 
-This rule flags fields past the defined range for a segment. `MSH` in
-v2.5 ends at `MSH-21`, so any field at sequence 22 or higher is
-unexpected for that segment and version.
+This rule flags fields past the defined range for a segment. `MSH` in v2.5 ends at `MSH-21`, so any field at sequence 22 or higher is unexpected for that segment and version.
 
 ### Valid
 
-`MSH` stops at `MSH-12` (Version ID) and all fields are within the v2.5
-definition:
+`MSH` stops at `MSH-12` (Version ID) and all fields are within the v2.5 definition:
 
 ```hl7
 MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
@@ -79,8 +66,7 @@ PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
 
 ### Invalid
 
-`MSH` carries a field at sequence 22, which is past the v2.5 maximum
-of `MSH-21`:
+`MSH` carries a field at sequence 22, which is past the v2.5 maximum of `MSH-21`:
 
 ```hl7
 MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5||||||||||EXTRA
@@ -93,14 +79,11 @@ Reported message:
 Field MSH-22 is beyond the defined fields for MSH (max: 21 in v2.5)
 ```
 
-The reported max comes from the profile's highest sequence number and
-the version is taken from the annotated profile context. One message is
-reported per extra field.
+The reported max comes from the profile's highest sequence number and the version is taken from the annotated profile context. One message is reported per extra field.
 
 ## Part of Glion
 
-`@glion/lint-profile-extra-fields` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-extra-fields` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-field-max-length/README.md
+++ b/packages/lint-profile-field-max-length/README.md
@@ -1,0 +1,106 @@
+# @glion/lint-profile-field-max-length
+
+> Lint rule to validate field value lengths against HL7v2 profile maxLength.
+
+## What it does
+
+Flags field values that exceed the `maxLength` declared in the HL7v2
+profile for the message's version. Length is computed by recursively
+summing the string lengths of all subcomponent values in a repetition,
+so delimiters (`^`, `&`, `~`) are not counted. The rule reads profile
+context attached by `@glion/annotate-profile-context` and reports once
+per offending repetition. Fields without a declared `maxLength`, empty
+fields, and Z-segments are skipped.
+
+## Install
+
+```bash
+pnpm add @glion/lint-profile-field-max-length
+```
+
+> Using npm? `npm install @glion/lint-profile-field-max-length`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2Parser } from "@glion/parser";
+import hl7v2LintFieldMaxLength from "@glion/lint-profile-field-max-length";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+
+const message = [
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
+].join("\r");
+
+const file = await unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2LintFieldMaxLength)
+  .process(message);
+
+console.error(reporter([file]));
+```
+
+## API
+
+### `unified().use(hl7v2LintFieldMaxLength)`
+
+A `unified` lint rule plugin. Takes no options.
+
+Reads `file.data.profile`. For each segment in the tree it walks its
+fields, looks up the profile entry by sequence, and — if a `maxLength`
+is declared — compares it against `getLength()` from `@glion/utils` for
+every repetition. Each repetition over the limit produces one message.
+
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
+
+declare const hl7v2LintFieldMaxLength: Plugin<[], Root>;
+export default hl7v2LintFieldMaxLength;
+```
+
+## What it checks
+
+This rule flags fields whose measured content length is greater than the
+`maxLength` declared for that field in the HL7v2 profile. In v2.5,
+`MSH-10` (Message Control ID) has `maxLength: 20`.
+
+### Valid
+
+`MSH-10` carries a 9-character Message Control ID, well within the v2.5
+limit of 20:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+### Invalid
+
+`MSH-10` is 28 characters long, exceeding the v2.5 limit of 20:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG0000000000000000000000001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+Reported message:
+
+```
+Field MSH-10 exceeds max length of 20 (actual: 28)
+```
+
+One message is produced per offending repetition. Delimiters are not
+included in the measured length — a composite value like `DOE^JANE`
+counts as 7 characters, not 8.
+
+## Part of Glion
+
+`@glion/lint-profile-field-max-length` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-field-max-length/README.md
+++ b/packages/lint-profile-field-max-length/README.md
@@ -1,24 +1,16 @@
 # @glion/lint-profile-field-max-length
 
-> Lint rule to validate field value lengths against HL7v2 profile maxLength.
+Lint rule to validate field value lengths against HL7v2 profile maxLength.
 
 ## What it does
 
-Flags field values that exceed the `maxLength` declared in the HL7v2
-profile for the message's version. Length is computed by recursively
-summing the string lengths of all subcomponent values in a repetition,
-so delimiters (`^`, `&`, `~`) are not counted. The rule reads profile
-context attached by `@glion/annotate-profile-context` and reports once
-per offending repetition. Fields without a declared `maxLength`, empty
-fields, and Z-segments are skipped.
+Flags field values that exceed the `maxLength` declared in the HL7v2 profile for the message's version. Length is computed by recursively summing the string lengths of all subcomponent values in a repetition, so delimiters (`^`, `&`, `~`) are not counted. The rule reads profile context attached by `@glion/annotate-profile-context` and reports once per offending repetition. Fields without a declared `maxLength`, empty fields, and Z-segments are skipped.
 
 ## Install
 
 ```bash
-pnpm add @glion/lint-profile-field-max-length
+npm install @glion/lint-profile-field-max-length
 ```
-
-> Using npm? `npm install @glion/lint-profile-field-max-length`
 
 ## Use
 
@@ -49,10 +41,7 @@ console.error(reporter([file]));
 
 A `unified` lint rule plugin. Takes no options.
 
-Reads `file.data.profile`. For each segment in the tree it walks its
-fields, looks up the profile entry by sequence, and — if a `maxLength`
-is declared — compares it against `getLength()` from `@glion/utils` for
-every repetition. Each repetition over the limit produces one message.
+Reads `file.data.profile`. For each segment in the tree it walks its fields, looks up the profile entry by sequence, and — if a `maxLength` is declared — compares it against `getLength()` from `@glion/utils` for every repetition. Each repetition over the limit produces one message.
 
 ```ts
 import type { Plugin } from "unified";
@@ -64,14 +53,11 @@ export default hl7v2LintFieldMaxLength;
 
 ## What it checks
 
-This rule flags fields whose measured content length is greater than the
-`maxLength` declared for that field in the HL7v2 profile. In v2.5,
-`MSH-10` (Message Control ID) has `maxLength: 20`.
+This rule flags fields whose measured content length is greater than the `maxLength` declared for that field in the HL7v2 profile. In v2.5, `MSH-10` (Message Control ID) has `maxLength: 20`.
 
 ### Valid
 
-`MSH-10` carries a 9-character Message Control ID, well within the v2.5
-limit of 20:
+`MSH-10` carries a 9-character Message Control ID, well within the v2.5 limit of 20:
 
 ```hl7
 MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
@@ -93,14 +79,11 @@ Reported message:
 Field MSH-10 exceeds max length of 20 (actual: 28)
 ```
 
-One message is produced per offending repetition. Delimiters are not
-included in the measured length — a composite value like `DOE^JANE`
-counts as 7 characters, not 8.
+One message is produced per offending repetition. Delimiters are not included in the measured length — a composite value like `DOE^JANE` counts as 7 characters, not 8.
 
 ## Part of Glion
 
-`@glion/lint-profile-field-max-length` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-field-max-length` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-field-repetition/README.md
+++ b/packages/lint-profile-field-repetition/README.md
@@ -1,24 +1,16 @@
 # @glion/lint-profile-field-repetition
 
-> Lint rule that flags non-repeatable fields with multiple repetitions.
+Lint rule that flags non-repeatable fields with multiple repetitions.
 
 ## What it does
 
-Flags fields that contain more than one repetition (delimited by `~`) when
-the HL7v2 profile for the message's version declares `repeatable: false`
-for that field. The rule reads profile context attached by
-`@glion/annotate-profile-context`. A single repetition is always valid
-regardless of the `repeatable` flag; only 2+ repetitions on a
-non-repeatable field are reported. Segments without a known profile are
-silently skipped.
+Flags fields that contain more than one repetition (delimited by `~`) when the HL7v2 profile for the message's version declares `repeatable: false` for that field. The rule reads profile context attached by `@glion/annotate-profile-context`. A single repetition is always valid regardless of the `repeatable` flag; only 2+ repetitions on a non-repeatable field are reported. Segments without a known profile are silently skipped.
 
 ## Install
 
 ```bash
-pnpm add @glion/lint-profile-field-repetition
+npm install @glion/lint-profile-field-repetition
 ```
-
-> Using npm? `npm install @glion/lint-profile-field-repetition`
 
 ## Use
 
@@ -49,10 +41,7 @@ console.error(reporter([file]));
 
 A `unified` lint rule plugin. Takes no options.
 
-Reads `file.data.profile`. For each field under a segment with a known
-profile it looks up the field entry by sequence. If the field's profile
-sets `repeatable: false` and the AST has more than one repetition, the
-rule emits one message for that field.
+Reads `file.data.profile`. For each field under a segment with a known profile it looks up the field entry by sequence. If the field's profile sets `repeatable: false` and the AST has more than one repetition, the rule emits one message for that field.
 
 ```ts
 import type { Plugin } from "unified";
@@ -64,9 +53,7 @@ export default hl7v2LintFieldRepetition;
 
 ## What it checks
 
-This rule flags fields with multiple `~`-delimited repetitions when the
-profile marks the field as non-repeatable. For example, `PID-7` (Date of
-Birth) is not repeatable in v2.5.
+This rule flags fields with multiple `~`-delimited repetitions when the profile marks the field as non-repeatable. For example, `PID-7` (Date of Birth) is not repeatable in v2.5.
 
 ### Valid
 
@@ -79,8 +66,7 @@ PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
 
 ### Invalid
 
-`PID-7` carries two `~`-separated values, which violates the v2.5 profile
-for the `PID-7` field:
+`PID-7` carries two `~`-separated values, which violates the v2.5 profile for the `PID-7` field:
 
 ```hl7
 MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
@@ -93,14 +79,11 @@ Reported message:
 Field PID-7 (Date/Time of Birth) is not repeatable but has 2 repetitions
 ```
 
-When the field name is available in the profile it appears in parentheses
-after the position. The reported count equals the number of repetitions
-present in the field.
+When the field name is available in the profile it appears in parentheses after the position. The reported count equals the number of repetitions present in the field.
 
 ## Part of Glion
 
-`@glion/lint-profile-field-repetition` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-field-repetition` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-field-repetition/README.md
+++ b/packages/lint-profile-field-repetition/README.md
@@ -1,0 +1,106 @@
+# @glion/lint-profile-field-repetition
+
+> Lint rule that flags non-repeatable fields with multiple repetitions.
+
+## What it does
+
+Flags fields that contain more than one repetition (delimited by `~`) when
+the HL7v2 profile for the message's version declares `repeatable: false`
+for that field. The rule reads profile context attached by
+`@glion/annotate-profile-context`. A single repetition is always valid
+regardless of the `repeatable` flag; only 2+ repetitions on a
+non-repeatable field are reported. Segments without a known profile are
+silently skipped.
+
+## Install
+
+```bash
+pnpm add @glion/lint-profile-field-repetition
+```
+
+> Using npm? `npm install @glion/lint-profile-field-repetition`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2Parser } from "@glion/parser";
+import hl7v2LintFieldRepetition from "@glion/lint-profile-field-repetition";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+
+const message = [
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
+].join("\r");
+
+const file = await unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2LintFieldRepetition)
+  .process(message);
+
+console.error(reporter([file]));
+```
+
+## API
+
+### `unified().use(hl7v2LintFieldRepetition)`
+
+A `unified` lint rule plugin. Takes no options.
+
+Reads `file.data.profile`. For each field under a segment with a known
+profile it looks up the field entry by sequence. If the field's profile
+sets `repeatable: false` and the AST has more than one repetition, the
+rule emits one message for that field.
+
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
+
+declare const hl7v2LintFieldRepetition: Plugin<[], Root>;
+export default hl7v2LintFieldRepetition;
+```
+
+## What it checks
+
+This rule flags fields with multiple `~`-delimited repetitions when the
+profile marks the field as non-repeatable. For example, `PID-7` (Date of
+Birth) is not repeatable in v2.5.
+
+### Valid
+
+`PID-7` carries a single Date of Birth:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+### Invalid
+
+`PID-7` carries two `~`-separated values, which violates the v2.5 profile
+for the `PID-7` field:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101~19800102|F
+```
+
+Reported message:
+
+```
+Field PID-7 (Date/Time of Birth) is not repeatable but has 2 repetitions
+```
+
+When the field name is available in the profile it appears in parentheses
+after the position. The reported count equals the number of repetitions
+present in the field.
+
+## Part of Glion
+
+`@glion/lint-profile-field-repetition` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-required-components/README.md
+++ b/packages/lint-profile-required-components/README.md
@@ -1,23 +1,16 @@
 # @glion/lint-profile-required-components
 
-> Lint rule to validate required components in composite datatype fields.
+Lint rule to validate required components in composite datatype fields.
 
 ## What it does
 
-Flags composite fields whose required components (as declared by the
-datatype profile for the message's version) are missing or empty in any
-repetition. The rule reads profile context attached by
-`@glion/annotate-profile-context`, resolves each field's datatype, and
-checks the required components on every repetition. Empty fields,
-primitive datatypes, and segments without a known profile are skipped.
+Flags composite fields whose required components (as declared by the datatype profile for the message's version) are missing or empty in any repetition. The rule reads profile context attached by `@glion/annotate-profile-context`, resolves each field's datatype, and checks the required components on every repetition. Empty fields, primitive datatypes, and segments without a known profile are skipped.
 
 ## Install
 
 ```bash
-pnpm add @glion/lint-profile-required-components
+npm install @glion/lint-profile-required-components
 ```
-
-> Using npm? `npm install @glion/lint-profile-required-components`
 
 ## Use
 
@@ -48,10 +41,7 @@ console.error(reporter([file]));
 
 A `unified` lint rule plugin. Takes no options.
 
-Reads `file.data.profile`. For each non-empty field, resolves the datatype
-definition from the field profile and iterates
-`dtDef.requiredSequences`. For every field repetition, checks that each
-required component is present with a non-empty first subcomponent value.
+Reads `file.data.profile`. For each non-empty field, resolves the datatype definition from the field profile and iterates `dtDef.requiredSequences`. For every field repetition, checks that each required component is present with a non-empty first subcomponent value.
 
 ```ts
 import type { Plugin } from "unified";
@@ -63,9 +53,7 @@ export default hl7v2LintRequiredComponents;
 
 ## What it checks
 
-This rule flags missing required components on composite fields. The
-classic case is `MSH-9` (Message Type), where the `MSG` datatype requires
-the message code (`.1`) and trigger event (`.2`) components.
+This rule flags missing required components on composite fields. The classic case is `MSH-9` (Message Type), where the `MSG` datatype requires the message code (`.1`) and trigger event (`.2`) components.
 
 ### Valid
 
@@ -78,8 +66,7 @@ PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
 
 ### Invalid
 
-`MSH-9.2` (Trigger Event) is empty, which violates the `MSG` datatype
-profile in v2.5:
+`MSH-9.2` (Trigger Event) is empty, which violates the `MSG` datatype profile in v2.5:
 
 ```hl7
 MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^|MSG00001|P|2.5
@@ -92,14 +79,11 @@ Reported message:
 Required component MSH-9.2 (Trigger Event) is missing or empty
 ```
 
-When the component name is available in the datatype profile it appears
-in parentheses. One message is reported per missing required component
-per repetition.
+When the component name is available in the datatype profile it appears in parentheses. One message is reported per missing required component per repetition.
 
 ## Part of Glion
 
-`@glion/lint-profile-required-components` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-required-components` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-required-components/README.md
+++ b/packages/lint-profile-required-components/README.md
@@ -1,0 +1,105 @@
+# @glion/lint-profile-required-components
+
+> Lint rule to validate required components in composite datatype fields.
+
+## What it does
+
+Flags composite fields whose required components (as declared by the
+datatype profile for the message's version) are missing or empty in any
+repetition. The rule reads profile context attached by
+`@glion/annotate-profile-context`, resolves each field's datatype, and
+checks the required components on every repetition. Empty fields,
+primitive datatypes, and segments without a known profile are skipped.
+
+## Install
+
+```bash
+pnpm add @glion/lint-profile-required-components
+```
+
+> Using npm? `npm install @glion/lint-profile-required-components`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2Parser } from "@glion/parser";
+import hl7v2LintRequiredComponents from "@glion/lint-profile-required-components";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+
+const message = [
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
+].join("\r");
+
+const file = await unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2LintRequiredComponents)
+  .process(message);
+
+console.error(reporter([file]));
+```
+
+## API
+
+### `unified().use(hl7v2LintRequiredComponents)`
+
+A `unified` lint rule plugin. Takes no options.
+
+Reads `file.data.profile`. For each non-empty field, resolves the datatype
+definition from the field profile and iterates
+`dtDef.requiredSequences`. For every field repetition, checks that each
+required component is present with a non-empty first subcomponent value.
+
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
+
+declare const hl7v2LintRequiredComponents: Plugin<[], Root>;
+export default hl7v2LintRequiredComponents;
+```
+
+## What it checks
+
+This rule flags missing required components on composite fields. The
+classic case is `MSH-9` (Message Type), where the `MSG` datatype requires
+the message code (`.1`) and trigger event (`.2`) components.
+
+### Valid
+
+`MSH-9` carries message code, trigger event, and message structure:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+### Invalid
+
+`MSH-9.2` (Trigger Event) is empty, which violates the `MSG` datatype
+profile in v2.5:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+Reported message:
+
+```
+Required component MSH-9.2 (Trigger Event) is missing or empty
+```
+
+When the component name is available in the datatype profile it appears
+in parentheses. One message is reported per missing required component
+per repetition.
+
+## Part of Glion
+
+`@glion/lint-profile-required-components` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-required-fields/README.md
+++ b/packages/lint-profile-required-fields/README.md
@@ -1,0 +1,105 @@
+# @glion/lint-profile-required-fields
+
+> Lint rule to validate required fields per HL7v2 profile.
+
+## What it does
+
+Flags segments whose required fields (as declared by the HL7v2 profile for
+the message's version) are missing or empty. The rule reads profile context
+attached to the file by `@glion/annotate-profile-context` and reports one
+message per missing required field. Segments without a known profile (for
+example Z-segments like `ZPD`) are silently skipped.
+
+## Install
+
+```bash
+pnpm add @glion/lint-profile-required-fields
+```
+
+> Using npm? `npm install @glion/lint-profile-required-fields`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2Parser } from "@glion/parser";
+import hl7v2LintRequiredFields from "@glion/lint-profile-required-fields";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+
+const message = [
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
+].join("\r");
+
+const file = await unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2LintRequiredFields)
+  .process(message);
+
+console.error(reporter([file]));
+```
+
+## API
+
+### `unified().use(hl7v2LintRequiredFields)`
+
+A `unified` lint rule plugin. Takes no options.
+
+The plugin reads `file.data.profile` (populated by
+`@glion/annotate-profile-context`). If no profile context is present the
+rule exits silently. For each segment, it iterates
+`fieldDef.requiredSequences` and checks that the corresponding field at
+that 1-based position is present and non-empty.
+
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
+
+declare const hl7v2LintRequiredFields: Plugin<[], Root>;
+export default hl7v2LintRequiredFields;
+```
+
+## What it checks
+
+This rule flags fields declared `required: true` in the HL7v2 profile for
+the message's version when those fields are missing or empty on the
+corresponding segment.
+
+### Valid
+
+`PID-3` (Patient Identifier List) and `PID-5` (Patient Name) are required
+in v2.5 and both are populated:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+### Invalid
+
+`PID-3` is empty, which violates the v2.5 profile for the `PID` segment:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||||DOE^JANE||19800101|F
+```
+
+Reported message:
+
+```
+Required field PID-3 (Patient Identifier List) is missing or empty
+```
+
+When the profile attaches a field name, it appears in parentheses after
+the position. Segments shorter than the highest required sequence produce
+one message per missing required field.
+
+## Part of Glion
+
+`@glion/lint-profile-required-fields` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-required-fields/README.md
+++ b/packages/lint-profile-required-fields/README.md
@@ -1,22 +1,16 @@
 # @glion/lint-profile-required-fields
 
-> Lint rule to validate required fields per HL7v2 profile.
+Lint rule to validate required fields per HL7v2 profile.
 
 ## What it does
 
-Flags segments whose required fields (as declared by the HL7v2 profile for
-the message's version) are missing or empty. The rule reads profile context
-attached to the file by `@glion/annotate-profile-context` and reports one
-message per missing required field. Segments without a known profile (for
-example Z-segments like `ZPD`) are silently skipped.
+Flags segments whose required fields (as declared by the HL7v2 profile for the message's version) are missing or empty. The rule reads profile context attached to the file by `@glion/annotate-profile-context` and reports one message per missing required field. Segments without a known profile (for example Z-segments like `ZPD`) are silently skipped.
 
 ## Install
 
 ```bash
-pnpm add @glion/lint-profile-required-fields
+npm install @glion/lint-profile-required-fields
 ```
-
-> Using npm? `npm install @glion/lint-profile-required-fields`
 
 ## Use
 
@@ -47,11 +41,7 @@ console.error(reporter([file]));
 
 A `unified` lint rule plugin. Takes no options.
 
-The plugin reads `file.data.profile` (populated by
-`@glion/annotate-profile-context`). If no profile context is present the
-rule exits silently. For each segment, it iterates
-`fieldDef.requiredSequences` and checks that the corresponding field at
-that 1-based position is present and non-empty.
+The plugin reads `file.data.profile` (populated by `@glion/annotate-profile-context`). If no profile context is present the rule exits silently. For each segment, it iterates `fieldDef.requiredSequences` and checks that the corresponding field at that 1-based position is present and non-empty.
 
 ```ts
 import type { Plugin } from "unified";
@@ -63,14 +53,11 @@ export default hl7v2LintRequiredFields;
 
 ## What it checks
 
-This rule flags fields declared `required: true` in the HL7v2 profile for
-the message's version when those fields are missing or empty on the
-corresponding segment.
+This rule flags fields declared `required: true` in the HL7v2 profile for the message's version when those fields are missing or empty on the corresponding segment.
 
 ### Valid
 
-`PID-3` (Patient Identifier List) and `PID-5` (Patient Name) are required
-in v2.5 and both are populated:
+`PID-3` (Patient Identifier List) and `PID-5` (Patient Name) are required in v2.5 and both are populated:
 
 ```hl7
 MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
@@ -92,14 +79,11 @@ Reported message:
 Required field PID-3 (Patient Identifier List) is missing or empty
 ```
 
-When the profile attaches a field name, it appears in parentheses after
-the position. Segments shorter than the highest required sequence produce
-one message per missing required field.
+When the profile attaches a field name, it appears in parentheses after the position. Segments shorter than the highest required sequence produce one message per missing required field.
 
 ## Part of Glion
 
-`@glion/lint-profile-required-fields` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-required-fields` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-table-values/README.md
+++ b/packages/lint-profile-table-values/README.md
@@ -1,24 +1,16 @@
 # @glion/lint-profile-table-values
 
-> Lint rule to validate coded field values against HL7v2 tables.
+Lint rule to validate coded field values against HL7v2 tables.
 
 ## What it does
 
-Flags coded field values that are not present in the HL7-defined table
-referenced by the field's profile. The rule reads profile context
-attached by `@glion/annotate-profile-context`, resolves the table by id
-(stripping the `HL7` prefix, so `HL70001` looks up table `0001`), and
-checks the first component value of each repetition against the table's
-code set. Only `hl7`-type tables are validated; user-defined tables,
-empty fields, and Z-segments are skipped.
+Flags coded field values that are not present in the HL7-defined table referenced by the field's profile. The rule reads profile context attached by `@glion/annotate-profile-context`, resolves the table by id (stripping the `HL7` prefix, so `HL70001` looks up table `0001`), and checks the first component value of each repetition against the table's code set. Only `hl7`-type tables are validated; user-defined tables, empty fields, and Z-segments are skipped.
 
 ## Install
 
 ```bash
-pnpm add @glion/lint-profile-table-values
+npm install @glion/lint-profile-table-values
 ```
-
-> Using npm? `npm install @glion/lint-profile-table-values`
 
 ## Use
 
@@ -49,10 +41,7 @@ console.error(reporter([file]));
 
 A `unified` lint rule plugin. Takes no options.
 
-Reads `file.data.profile`. For each non-empty field with a declared
-`table` reference in its profile, loads the table definition from
-`ctx.tables`. If the table is HL7-defined it checks each repetition's
-first subcomponent value against the table's code set.
+Reads `file.data.profile`. For each non-empty field with a declared `table` reference in its profile, loads the table definition from `ctx.tables`. If the table is HL7-defined it checks each repetition's first subcomponent value against the table's code set.
 
 ```ts
 import type { Plugin } from "unified";
@@ -64,10 +53,7 @@ export default hl7v2LintTableValues;
 
 ## What it checks
 
-This rule flags coded values that are not members of the HL7 table
-referenced by the field's profile. For example, `PID-8` (Administrative
-Sex) references table `HL70001`, whose v2.5 codes include `F`, `M`, `O`,
-`U`, `A`, `N`.
+This rule flags coded values that are not members of the HL7 table referenced by the field's profile. For example, `PID-8` (Administrative Sex) references table `HL70001`, whose v2.5 codes include `F`, `M`, `O`, `U`, `A`, `N`.
 
 ### Valid
 
@@ -93,14 +79,11 @@ Reported message:
 Field PID-8 (Administrative Sex) value 'Z' is not in table 0001 (Administrative Sex)
 ```
 
-When the field has a profile name it appears in parentheses. The table
-id is reported without the `HL7` prefix, matching the way the tables
-store keys its entries. One message is reported per offending repetition.
+When the field has a profile name it appears in parentheses. The table id is reported without the `HL7` prefix, matching the way the tables store keys its entries. One message is reported per offending repetition.
 
 ## Part of Glion
 
-`@glion/lint-profile-table-values` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-table-values` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-table-values/README.md
+++ b/packages/lint-profile-table-values/README.md
@@ -1,0 +1,106 @@
+# @glion/lint-profile-table-values
+
+> Lint rule to validate coded field values against HL7v2 tables.
+
+## What it does
+
+Flags coded field values that are not present in the HL7-defined table
+referenced by the field's profile. The rule reads profile context
+attached by `@glion/annotate-profile-context`, resolves the table by id
+(stripping the `HL7` prefix, so `HL70001` looks up table `0001`), and
+checks the first component value of each repetition against the table's
+code set. Only `hl7`-type tables are validated; user-defined tables,
+empty fields, and Z-segments are skipped.
+
+## Install
+
+```bash
+pnpm add @glion/lint-profile-table-values
+```
+
+> Using npm? `npm install @glion/lint-profile-table-values`
+
+## Use
+
+```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
+import { hl7v2Parser } from "@glion/parser";
+import hl7v2LintTableValues from "@glion/lint-profile-table-values";
+import { unified } from "unified";
+import { reporter } from "vfile-reporter";
+
+const message = [
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
+].join("\r");
+
+const file = await unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2LintTableValues)
+  .process(message);
+
+console.error(reporter([file]));
+```
+
+## API
+
+### `unified().use(hl7v2LintTableValues)`
+
+A `unified` lint rule plugin. Takes no options.
+
+Reads `file.data.profile`. For each non-empty field with a declared
+`table` reference in its profile, loads the table definition from
+`ctx.tables`. If the table is HL7-defined it checks each repetition's
+first subcomponent value against the table's code set.
+
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
+
+declare const hl7v2LintTableValues: Plugin<[], Root>;
+export default hl7v2LintTableValues;
+```
+
+## What it checks
+
+This rule flags coded values that are not members of the HL7 table
+referenced by the field's profile. For example, `PID-8` (Administrative
+Sex) references table `HL70001`, whose v2.5 codes include `F`, `M`, `O`,
+`U`, `A`, `N`.
+
+### Valid
+
+`PID-8` is `F`, which is a valid code in table `0001`:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+```
+
+### Invalid
+
+`PID-8` is `Z`, which is not in table `0001`:
+
+```hl7
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|Z
+```
+
+Reported message:
+
+```
+Field PID-8 (Administrative Sex) value 'Z' is not in table 0001 (Administrative Sex)
+```
+
+When the field has a profile name it appears in parentheses. The table
+id is reported without the `HL7` prefix, matching the way the tables
+store keys its entries. One message is reported per offending repetition.
+
+## Part of Glion
+
+`@glion/lint-profile-table-values` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-required-message-header/README.md
+++ b/packages/lint-required-message-header/README.md
@@ -1,135 +1,85 @@
 # @glion/lint-required-message-header
 
-A [`unified`][github-unified] lint rule for HL7v2 that warns when the message header segment (`MSH`) is missing or not the first segment in a message. This helps ensure all HL7v2 messages begin with the required header, improving interoperability and data quality.
+Lint rule that requires the message header segment (`MSH`) to be the first segment of an HL7v2 message.
 
-HL7v2 messages must always begin with a message header segment, known as `MSH`. This rule checks that the first segment in a message is `MSH` and warns if it is missing or replaced by another segment.
+## What it does
 
-## What is this?
-
-This package validates the **segment header** in HL7v2 syntax trees produced by parsers like [`@glion/parser`][github-hl7v2-parser].
-
-It reports a message when the first segment of an HL7v2 message is not a segment header (MSH).
-
-## When should I use this?
-
-Use this rule to enforce canonical HL7v2 segment identifiers across messages, catch typos (e.g., `PID1`, `Obx`, `MS`), and improve downstream processing reliability.
-
-## Presets
-
-This plugin is included in the following presets:
-
-| Preset                    | Options |
-| ------------------------- | ------- |
-| `@glion/lint-recommended` |         |
+Walks the parsed tree and checks that the first `segment` node is named `MSH`. If a different segment appears first, the rule reports one fail message naming the offending segment and stops. HL7v2 messages must begin with `MSH` because it carries the metadata required for routing and interpretation.
 
 ## Install
 
-This package is **ESM only**. In Node.js (v16+), install with npm:
-
-```sh
+```bash
 npm install @glion/lint-required-message-header
 ```
 
 ## Use
 
-On the API:
-
-```js
-import { unified } from "unified";
-import { hl7v2Parse } from "@glion/parser";
+```ts
+import { hl7v2Parser } from "@glion/parser";
 import hl7v2LintRequiredMessageHeader from "@glion/lint-required-message-header";
+import { unified } from "unified";
 import { reporter } from "vfile-reporter";
 
-const msg = `MSH|^~\\&|...`;
+const message =
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5";
+
 const file = await unified()
-  .use(hl7v2Parse)
+  .use(hl7v2Parser)
   .use(hl7v2LintRequiredMessageHeader)
-  .process(msg);
+  .process(message);
 
 console.error(reporter([file]));
 ```
 
 ## API
 
-### `unified().use(hl7v2LintSegmentHeaderLength[, options])`
+### `unified().use(hl7v2LintRequiredMessageHeader)`
 
-Warn when a segment header is not a three-letter uppercase code.
+A `unified` lint rule plugin. Takes no options.
 
-###### Returns
+The plugin visits the tree and finds the first `segment` node (descending through any nested groups). If it is not named `MSH`, the plugin calls `file.fail(...)` — this is a hard failure, not a warning.
 
-A `unified` Transformer that adds messages to the file.
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
 
-## Recommendation
+declare const hl7v2LintRequiredMessageHeader: Plugin<[], Root>;
+export default hl7v2LintRequiredMessageHeader;
+```
 
-This helps ensure that HL7v2 messages are well-formed and can be reliably parsed and processed by downstream systems. If the message does not start with `MSH`, a warning is reported indicating which segment was found instead.
+## What it checks
 
-**Why is this important?**
+The first segment of the message must be `MSH`.
 
-- The `MSH` segment contains metadata required for routing and interpreting the message.
-- Missing or misplaced `MSH` segments can cause interoperability issues and data loss.
+### Valid
 
-**When to disable:**
-
-You should only disable this rule if you are intentionally working with non-standard HL7v2 messages that do not require a message header segment, which is rare in practice.
-
-It’s recommended to enable this rule in most pipelines.
-
-## Examples
-
-##### `ok.hl7`
-
-###### In
+`MSH` comes first, followed by any other segments:
 
 ```hl7
-MSH|^~\&|...
-PID|1||12345^^^HOSP^MR||DOE^JANE||...
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
 OBX|1|TX|...
 ```
 
-###### Out
+### Invalid
 
-No messages.
-
-##### `not-ok.hl7`
-
-###### In
+A non-`MSH` segment appears first:
 
 ```hl7
-PID|1||12345||DOE^JANE||...
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
 ```
 
-###### Out
+Reported message:
 
-```text
-Message header (MSH) segment is required. Received PID instead.
+```
+Message header (MSH) segment is required as the first segment — received 'PID' instead
 ```
 
-## Security
+The name of the first segment found is interpolated into the message. The rule reports at most one failure per tree.
 
-This plugin only transforms AST nodes and does not execute code. Ensure you trust the source of HL7v2 messages before processing.
+## Part of Glion
 
-## Contributing
+`@glion/lint-required-message-header` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## Code of Conduct
-
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
-
-## License
-
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
-
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
-
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
-[github-unified]: https://github.com/unifiedjs/unified
-[github-hl7v2-parser]: https://github.com/rethinkhealth/glion/tree/main/packages/hl7v2-parser
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-segment-header-length/README.md
+++ b/packages/lint-segment-header-length/README.md
@@ -1,174 +1,97 @@
 # @glion/lint-segment-header-length
 
-A [`unified`][github-unified] lint rule for HL7v2 that warns when a segment **header** (segment ID) is not exactly three uppercase ASCII letters (e.g., `MSH`, `PID`, `OBX`).
+Lint rule that flags HL7v2 segment headers whose name is not exactly three characters.
 
-## What is this?
+## What it does
 
-This package validates the **segment header** in HL7v2 syntax trees produced by parsers like [`@glion/parser`][github-hl7v2-parser].
-
-It reports a message when the header before the first field delimiter is not a 3-letter uppercase code.
-
-## When should I use this?
-
-Use this rule to enforce canonical HL7v2 segment identifiers across messages, catch typos (e.g., `PID1`, `Obx`, `MS`), and improve downstream processing reliability.
-
-## Presets
-
-This plugin is included in the following presets:
-
-| Preset                    | Options |
-| ------------------------- | ------- |
-| `@glion/lint-recommended` |         |
+Visits every `segment` node and checks that `node.name.length === 3`. HL7v2 segments are identified by a three-character code (`MSH`, `PID`, `OBX`, `ZAD`). Lengths other than three usually indicate a typo (`PID1`, `MS`, `Obx`), malformed input, or a miscoded private extension.
 
 ## Install
 
-This package is **ESM only**. In Node.js (v16+), install with npm:
-
-```sh
+```bash
 npm install @glion/lint-segment-header-length
 ```
 
 ## Use
 
-On the API:
-
-```js
-import { unified } from "unified";
-import { hl7v2Parse } from "@glion/parser";
+```ts
+import { hl7v2Parser } from "@glion/parser";
 import hl7v2LintSegmentHeaderLength from "@glion/lint-segment-header-length";
+import { unified } from "unified";
 import { reporter } from "vfile-reporter";
 
-const msg = `MSH|^~\\&|...`;
+const message =
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5";
+
 const file = await unified()
-  .use(hl7v2Parse)
+  .use(hl7v2Parser)
   .use(hl7v2LintSegmentHeaderLength)
-  .process(msg);
+  .process(message);
 
 console.error(reporter([file]));
 ```
 
 ## API
 
-### `unified().use(hl7v2LintSegmentHeaderLength[, options])`
+### `unified().use(hl7v2LintSegmentHeaderLength)`
 
-Warn when a segment header is not a three-letter uppercase code.
+A `unified` lint rule plugin. Takes no options.
 
-###### Parameters
+Visits every `segment` node and reports one message per segment whose `name.length !== 3`. The reported text names how many characters to add or remove to reach the three-character target.
 
-- `options.allow` (optional, `string[]`) — an allowlist of additional 3-letter codes (e.g., private segments such as `ZAD`). Values must still be 3 uppercase letters.
+```ts
+import type { Plugin } from "unified";
+import type { Root } from "@glion/ast";
 
-###### Returns
+declare const hl7v2LintSegmentHeaderLength: Plugin<[], Root>;
+export default hl7v2LintSegmentHeaderLength;
+```
 
-A `unified` Transformer that adds messages to the file.
+## What it checks
 
-## Recommendation
+Each segment name must be exactly three characters long.
 
-HL7v2 segments are identified by **exactly three uppercase letters**. Deviations often indicate malformed input, private extensions used incorrectly, or typos that can break routing and transformations.
+### Valid
 
-It’s recommended to enable this rule in most pipelines.
-
-## Examples
-
-##### `ok.hl7`
-
-###### In
+All segments have three-character names:
 
 ```hl7
-MSH|^~\&|...
-PID|1||12345^^^HOSP^MR||DOE^JANE||...
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
+PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
 OBX|1|TX|...
 ```
 
-###### Out
+### Invalid
 
-No messages.
-
-##### `not-ok-too-long.hl7`
-
-###### In
+A four-character segment name:
 
 ```hl7
-PID1|1||12345||DOE^JANE||...
+PID1|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
 ```
 
-###### Out
+Reported message:
 
-```text
-1:1-1:4: Invalid segment header `PID1`: expected exactly 3 uppercase letters (e.g., `PID`)
+```
+Unexpected 4 header length, expected 3 characters, remove 1 character
 ```
 
-##### `not-ok-too-short.hl7`
-
-###### In
+A two-character segment name:
 
 ```hl7
 MS|^~\&|...
 ```
 
-###### Out
+Reported message:
 
-```text
-1:1-1:3: Invalid segment header `MS`: expected 3 uppercase letters
+```
+Unexpected 2 header length, expected 3 characters, add 1 character
 ```
 
-##### `not-ok-lowercase.hl7`
+The delta between the actual length and three is interpolated with pluralization (`remove 1 character`, `add 2 characters`). One message is reported per offending segment.
 
-###### In
+## Part of Glion
 
-```hl7
-obx|1|TX|...
-```
+`@glion/lint-segment-header-length` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-###### Out
-
-```text
-1:1-1:4: Invalid segment header `obx`: expected uppercase `OBX`
-```
-
-##### `ok-with-allowlist.hl7`
-
-###### In
-
-```hl7
-ZAD|1|...
-```
-
-With:
-
-```js
-.unified().use(hl7v2LintSegmentHeaderLength, { allow: ['ZAD'] })
-```
-
-###### Out
-
-No messages.
-
-## Security
-
-This plugin only transforms AST nodes and does not execute code. Ensure you trust the source of HL7v2 messages before processing.
-
-## Contributing
-
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## Code of Conduct
-
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
-
-## License
-
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
-
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
-
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
-[github-unified]: https://github.com/unifiedjs/unified
-[github-hl7v2-parser]: https://github.com/rethinkhealth/glion/tree/main/packages/hl7v2-parser
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/mllp-ack/README.md
+++ b/packages/mllp-ack/README.md
@@ -1,56 +1,41 @@
 # @glion/mllp-ack
 
-MLLP middleware for automatic HL7v2 acknowledgment generation — wraps handlers with ACK/NAK response building.
+MLLP middleware that generates HL7v2 acknowledgments automatically from handler outcomes.
 
-## Overview
+## What it does
 
-This package provides `ackMiddleware()`, a middleware for `@glion/mllp` that automatically generates HL7v2 ACK/NAK responses based on handler outcomes:
+`@glion/mllp-ack` exports `ackMiddleware()`, a middleware for `@glion/mllp` that wraps your route handlers and produces an ACK/NAK response for every accepted message. When a handler returns without throwing, the middleware emits an AA (or a configurable success code such as CA for commit-level acknowledgments). When a handler throws an `AckException` from `@glion/ack`, the middleware translates it into the matching AE/AR/CE/CR response with an ERR segment. Plain `Error` values become `ApplicationInternalError` (AE, error code 207), so routes that forget to handle a failure still produce a valid NAK instead of silence.
 
-- **No error** → AA (application accept) or CA (commit accept) via `successCode`
-- **`AckApplicationError`** → AE (application error) with ERR segment
-- **`AckApplicationReject`** → AR (application reject) with ERR segment
-- **`AckCommitError`** → CE (commit error) with ERR segment
-- **`AckCommitReject`** → CR (commit reject) with ERR segment
-- **Unknown `Error`** → AE via `ApplicationInternalError` (error code 207)
-
-If the handler sets its own response and doesn't throw, the middleware passes it through untouched.
-
-## Installation
+## Install
 
 ```bash
-pnpm add @glion/mllp-ack
+npm install @glion/mllp-ack
 ```
 
-This package has a peer dependency on `@glion/mllp`.
+The package has a peer dependency on `@glion/mllp`.
 
-## Usage
+## Use
 
-### Basic Setup
-
-```typescript
+```ts
 import { Mllp } from "@glion/mllp";
-import { parseHL7v2 } from "@glion/hl7v2";
 import { serve } from "@glion/mllp/node";
+import { parseHL7v2 } from "@glion/hl7v2";
 import { ackMiddleware } from "@glion/mllp-ack";
 
 const app = new Mllp().parser(parseHL7v2);
 
-// Add ACK middleware — all routes get automatic ACK/NAK
 app.use(ackMiddleware());
 
 app.on("ADT^A01", async (ctx) => {
-  // Process the message...
-  // No return needed — middleware sends AA automatically
+  // Process the message; no return needed — middleware sends AA automatically.
 });
 
 const server = serve(app, { port: 2575 });
 ```
 
-### Throwing Errors
+Throw a typed exception to produce a NAK:
 
-Use the exception classes from `@glion/ack` to control the NAK response. Each exception maps to a specific MSA-1 acknowledgment code:
-
-```typescript
+```ts
 import {
   AckApplicationError,
   Hl7ErrorCode,
@@ -60,9 +45,7 @@ import {
 
 app.on("ADT^A01", async (ctx) => {
   const patient = await findPatient(ctx);
-
   if (!patient) {
-    // Application error (AE) with specific error code
     throw new AckApplicationError("Patient not found", {
       errorCode: Hl7ErrorCode.UnknownKeyIdentifier,
       severity: Severity.Error,
@@ -70,7 +53,6 @@ app.on("ADT^A01", async (ctx) => {
   }
 });
 
-// Catch-all — reject unhandled message types (AR)
 app.on("*", async (ctx) => {
   throw new UnsupportedMessageTypeReject(
     `Unsupported: ${ctx.messageType}^${ctx.triggerEvent}`
@@ -78,24 +60,17 @@ app.on("*", async (ctx) => {
 });
 ```
 
-Unknown errors (plain `Error` or non-Error throws) are wrapped as `ApplicationInternalError` (AE, error code 207).
+For enhanced-mode processing, switch the success code to CA and use commit-level exceptions:
 
-### Commit-Level Acknowledgments
-
-For enhanced mode processing, use `successCode` and the commit-level exception classes:
-
-```typescript
+```ts
 import { AckCode, AckCommitError, Hl7ErrorCode, Severity } from "@glion/ack";
 
-// Commit-level middleware — success returns CA instead of AA
 app.use(ackMiddleware({ successCode: AckCode.CommitAccept }));
 
 app.on("ADT^A01", async (ctx) => {
   try {
     await persistMessage(ctx);
-    // No throw → CA (commit accept)
   } catch (err) {
-    // Commit-level error → CE
     throw new AckCommitError("Failed to persist message", {
       errorCode: Hl7ErrorCode.ApplicationInternalError,
       severity: Severity.Error,
@@ -104,33 +79,6 @@ app.on("ADT^A01", async (ctx) => {
   }
 });
 ```
-
-### Options
-
-```typescript
-ackMiddleware({
-  // Override MSH-3/MSH-4 of the ACK (defaults to original MSH-5/MSH-6)
-  sending: { application: "MyApp", facility: "MyFac" },
-
-  // Custom MSH-10 control ID generator (defaults to uid() from hl7v2-ack)
-  generateId: () => `ACK-${Date.now()}`,
-
-  // MSA-1 code for success (defaults to AckCode.ApplicationAccept "AA")
-  successCode: AckCode.CommitAccept, // "CA" for commit-level
-});
-```
-
-### Interaction with `onError`
-
-The middleware catches errors from handlers and converts them into ACK responses. If ACK construction itself fails (e.g., malformed AST, serialization error), the error propagates to `Mllp`'s `onError` handler, which serves as the infrastructure-level safety net.
-
-### Performance: `ctx.ast` vs `ctx.tree()`
-
-The ACK middleware uses `ctx.ast` (the raw parsed tree) rather than `await ctx.tree()` (the transformed tree). This is intentional — `acknowledge()` only reads MSH header fields (MSH-3 through MSH-12) to build the acknowledgment, and these fields are present in the pre-transform tree without modification.
-
-By avoiding `ctx.tree()`, the middleware does **not** trigger the transform pipeline (escape decoding, annotations, lint). This means ACK generation has zero async overhead and does not pay for transformers that are irrelevant to acknowledgment building.
-
-If you are writing a custom ACK middleware or handler that only needs MSH fields, prefer `ctx.ast` over `await ctx.tree()` for the same reason. See the [MLLP README](../hl7v2-mllp/README.md#ctxast-vs-await-ctxtree--choosing-the-right-one) for full guidance on when to use each.
 
 ## API
 
@@ -141,10 +89,10 @@ Returns a `Middleware` function for use with `Mllp.use()`.
 | Option        | Type             | Description                                                          |
 | ------------- | ---------------- | -------------------------------------------------------------------- |
 | `sending`     | `SendingInfo`    | MSH-3/MSH-4 of the ACK. Defaults to original message's MSH-5/MSH-6   |
-| `generateId`  | `() => string`   | Custom ID generator for MSH-10. Uses `uid()` when omitted            |
+| `generateId`  | `() => string`   | Custom ID generator for MSH-10. Uses `uid()` from `@glion/ack`       |
 | `successCode` | `AckSuccessCode` | MSA-1 code for success. Defaults to `AckCode.ApplicationAccept` (AA) |
 
-### Exception Classes
+### Exception classes
 
 | Class                          | MSA-1 | Description                                |
 | ------------------------------ | ----- | ------------------------------------------ |
@@ -156,26 +104,35 @@ Returns a `Middleware` function for use with `Mllp.use()`.
 | `UnsupportedMessageTypeReject` | AR    | Pre-configured: error code 200, severity E |
 | `CommitInternalError`          | CE    | Pre-configured: error code 207, severity E |
 
-## Contributing
+All exception classes are re-exported from `@glion/ack`.
 
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
+## Behavior
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+### Handler outcome to MSA-1 mapping
 
-## Code of Conduct
+| Handler outcome                         | MSA-1          | ERR segment |
+| --------------------------------------- | -------------- | ----------- |
+| returns (no throw)                      | `successCode`  | no          |
+| throws `AckApplicationError`            | AE             | yes         |
+| throws `AckApplicationReject`           | AR             | yes         |
+| throws `AckCommitError`                 | CE             | yes         |
+| throws `AckCommitReject`                | CR             | yes         |
+| throws a plain `Error` or non-`Error`   | AE (code 207)  | yes         |
+| handler set `ctx.res` and did not throw | passed through | —           |
 
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
+If `ctx.res` was already set by a handler and nothing threw, the middleware leaves it untouched.
 
-## License
+### `ctx.ast` vs `ctx.tree()`
 
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
+The middleware reads `ctx.ast` — the raw parsed tree — rather than `await ctx.tree()`. `acknowledge()` only needs the MSH header fields (MSH-3 through MSH-12), which are already present in the pre-transform tree. Avoiding `ctx.tree()` means the transform pipeline (escape decoding, annotations, lint) is not triggered for ACK construction, so the middleware adds zero async overhead. If you write custom ACK middleware, follow the same pattern.
 
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
+### Interaction with `onError`
 
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+The middleware catches handler errors and converts them into ACK responses. If ACK construction itself fails (for example, a malformed AST or a serialization error), the error propagates to the `Mllp` instance's `onError` handler as an infrastructure-level safety net.
+
+## Part of Glion
+
+`@glion/mllp-ack` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/mllp/README.md
+++ b/packages/mllp/README.md
@@ -1,232 +1,123 @@
 # @glion/mllp
 
-MLLP (Minimal Lower Layer Protocol) transport for HL7v2 messaging — primitives, streaming, and a [Hono](https://hono.dev)-style middleware server.
+Transport-agnostic MLLP engine and middleware-driven MLLP server for HL7v2 messaging.
 
-## Overview
+## What it does
 
-This package provides everything needed to send and receive HL7v2 messages over MLLP/TCP:
+`@glion/mllp` provides everything you need to send and receive HL7v2 messages over MLLP/TCP: frame encoding and decoding primitives, streaming TransformStreams for chunked TCP, and an `Mllp` class with pattern-based routing, composable middleware, and first-class `unified` processor integration. The server is transport-agnostic at its core and ships with a `serve()` helper for Node.js and Bun.
 
-1. **Primitives** — Frame encoding/decoding, streaming TransformStreams
-2. **Server** — Hono-style `Mllp` class with middleware, pattern-based routing, and unified processor integration
-
-**Key characteristics:**
-
-- **Hono-style API** — `.use()` middleware, `.on()` pattern routing, fluent chaining
-- **Unified integration** — pass a unified processor directly to `.use()`
-- **Web Streams** — built on `ReadableStream`/`WritableStream` throughout
-- **Dual API** — simple functions for one-shot operations + streaming for TCP
-
-## Installation
+## Install
 
 ```bash
-pnpm add @glion/mllp
+npm install @glion/mllp
 ```
 
-### Package Exports
+### Package exports
 
-| Subpath            | Description                        |
-| ------------------ | ---------------------------------- |
-| `@glion/mllp`      | Core `Mllp` class and primitives   |
-| `@glion/mllp/node` | `serve()` function for Node.js/Bun |
+| Subpath            | Description                       |
+| ------------------ | --------------------------------- |
+| `@glion/mllp`      | Core `Mllp` class and primitives  |
+| `@glion/mllp/node` | `serve()` helper for Node and Bun |
 
-## Glion CLI — dev and start
+## Use
 
-The `glion` CLI provides a zero-config development server with live reload and a production-ready start command.
-
-### Quick Start (Zero-Config)
-
-Create a single entry file and run:
-
-```bash
-cat > glion.app.ts <<'EOF'
+```ts
 import { Mllp } from "@glion/mllp";
-import { parseHL7v2 } from "@glion/hl7v2";
-export default new Mllp().parser(parseHL7v2);
-EOF
-
-pnpm add -D @glion/mllp @glion/hl7v2
-pnpm glion dev
-```
-
-The server starts on port `2575` listening on all interfaces. The TUI shows a `zero-config` badge to indicate no config file was loaded.
-
-### With an Explicit Config File
-
-For more control, create a `glion.config.ts`:
-
-```typescript
-// glion.config.ts
-import { defineConfig } from "@glion/mllp/config";
-
-export default defineConfig({
-  entry: "./src/app.ts",
-  port: 2575,
-  hostname: "0.0.0.0",
-  // tls: { cert: "./certs/server.pem", key: "./certs/server.key" },
-  // watch: ["./src"],
-  // gracefulCloseMs: 5000,
-});
-```
-
-```typescript
-// src/app.ts
-import { Mllp } from "@glion/mllp";
+import { serve } from "@glion/mllp/node";
 import { parseHL7v2 } from "@glion/hl7v2";
 
-export default new Mllp()
+const app = new Mllp()
   .parser(parseHL7v2)
-  .on("ADT^A01", async (ctx) => ({ raw: buildAck(ctx) }))
-  .on("ORU^R01", async (ctx) => ({ raw: buildAck(ctx) }))
-  .on("*", async (ctx) => ({ raw: buildNak(ctx, "Unsupported") }));
-```
-
-```json
-// package.json
-{
-  "scripts": {
-    "dev": "glion dev",
-    "start": "glion start"
-  }
-}
-```
-
-### Two Verbs
-
-**`glion dev`** — Development mode with a live Ink TUI, file watcher, and cold restarts on save:
-
-- Shows request/response counts, uptime, and error summaries in the TUI
-- Watches the entry file (and configured paths) for changes
-- Cold-restarts the server on save (~100–300ms interruption in-flight TCP sessions)
-- Falls back to log-only mode when stdout is not a TTY (CI, piped output)
-
-**`glion start`** — Production mode with no TUI and graceful shutdown:
-
-- Runs without a watcher
-- Emits JSON-line events to stdout for log aggregators
-- Handles SIGTERM with graceful drain (configurable via `gracefulCloseMs`, default 5000ms)
-- No in-flight connection interruption — existing TCP sessions complete before exit
-
-### Cross-Runtime Usage
-
-The glion bin ships with `#!/usr/bin/env node` — the standard for Node.js. Bun and Deno require explicit opt-in because they default to honoring the Node shebang.
-
-| Runtime        | Invocation                                                               |
-| -------------- | ------------------------------------------------------------------------ |
-| Node (default) | `pnpm dev` or `npm run dev` or `npx glion dev`                           |
-| Bun            | `bun --bun run dev` (from package.json script) or `bunx --bun glion dev` |
-| Deno           | `deno task dev` with a `deno.json` task that runs the compiled bin       |
-
-### Zero-Config Fallback
-
-If no `glion.config.*` file is found, glion looks for a conventional entry file in this order:
-
-1. `glion.app.ts`
-2. `glion.app.mts`
-3. `glion.app.mjs`
-4. `glion.app.js`
-5. `src/glion.app.ts`
-6. `src/glion.app.js`
-
-When found, it starts with sensible defaults: port `2575`, hostname `0.0.0.0`, no TLS, and watches `dirname(entry)`. The TUI header shows a `zero-config` badge to make this discoverable.
-
-### Programmatic API
-
-To embed glion in another tool, use the `runGlion` function:
-
-```typescript
-import { runGlion } from "@glion/mllp/cli";
-import { defineConfig, type GlionConfig } from "@glion/mllp/config";
-
-const exitCode = await runGlion({
-  argv: ["dev"],
-  cwd: process.cwd(),
-});
-```
-
-## Server
-
-### Quick Start
-
-```typescript
-import { Mllp } from "@glion/mllp";
-import { parseHL7v2 } from "@glion/hl7v2";
-import { serve } from "@glion/mllp/node";
-
-const app = new Mllp().parser(parseHL7v2);
-
-// Route by message type
-app.on("ADT^A01", async (ctx) => {
-  // Handle patient admission
-  return { raw: buildAckFor(ctx) };
-});
-
-app.on("ORU^R01", async (ctx) => {
-  // Handle lab results
-  return { raw: buildAckFor(ctx) };
-});
-
-app.on("*", async (ctx) => {
-  return { raw: buildNakFor(ctx, "Unsupported message type") };
-});
+  .on("ADT^A01", async (ctx) => ({ raw: buildAckFor(ctx) }))
+  .on("ORU^R01", async (ctx) => ({ raw: buildAckFor(ctx) }))
+  .on("*", async (ctx) => ({
+    raw: buildNakFor(ctx, "Unsupported message type"),
+  }));
 
 const server = serve(app, { port: 2575 });
 ```
 
-### Unified Processor Integration
+To run the app with live reload during development and a production start command, use the `@glion/cli` package — it provides the `glion dev` / `glion start` binary and configuration loader. This README focuses on the server primitives themselves.
 
-Pass a unified processor directly to `.parser()` — the server runs `parse()` eagerly for routing, then `run()` and `stringify()` lazily when handlers access `ctx.tree()` or `ctx.result()`:
+## API
 
-```typescript
-import { Mllp } from "@glion/mllp";
-import { serve } from "@glion/mllp/node";
-import { parseHL7v2 } from "@glion/hl7v2";
+### `Mllp`
 
-const app = new Mllp().parser(parseHL7v2);
+The server class. Built with a fluent chainable API:
 
-app.on("ADT^A01", async (ctx) => {
-  const tree = await ctx.tree(); // transformed AST (escape decoding, annotations, lint)
-  const result = await ctx.result(); // compiled output (e.g., JSON from hl7v2Jsonify)
-  console.log(ctx.file.messages); // lint warnings
-  return { raw: "..." };
-});
+| Method                      | Description                                                                 |
+| --------------------------- | --------------------------------------------------------------------------- |
+| `.parser(processor)`        | Attach a `unified` processor (or `@glion/parser` alone) as the parse stage. |
+| `.use(middleware)`          | Register global middleware that runs for every message.                     |
+| `.use(pattern, middleware)` | Register scoped middleware that runs only for matching message types.       |
+| `.on(pattern, handler)`     | Register a terminal route handler for a message type or trigger event.      |
+| `.onError(errorHandler)`    | Register a catch-all error handler.                                         |
 
-const server = serve(app, { port: 2575 });
+### `serve(app, options)` — from `@glion/mllp/node`
+
+Start a Node.js or Bun TCP server that dispatches incoming MLLP frames through the `Mllp` instance.
+
+- `port` (`number`) — TCP port to listen on.
+- `hostname` (`string`, optional) — interface to bind. Defaults to all interfaces.
+- `tls` (`{ cert, key }`, optional) — enable MLLP over TLS.
+
+### Primitives
+
+| Function                        | Description                                            |
+| ------------------------------- | ------------------------------------------------------ |
+| `encode(message)`               | Encode a message string into an MLLP frame.            |
+| `decode(frame)`                 | Decode a single MLLP frame to its message.             |
+| `encodeMultiple(messages)`      | Encode an array of messages in one pass.               |
+| `createDecoderStream(options?)` | TransformStream for streaming decode from chunked TCP. |
+
+### Types
+
+| Type               | Description                                                         |
+| ------------------ | ------------------------------------------------------------------- |
+| `Context`          | Request context with message data and routing fields.               |
+| `Response`         | Response object `{ raw: string }`.                                  |
+| `Hl7v2Processor`   | Unified `Processor` type for HL7v2 (`Processor<Root, Root, Root>`). |
+| `Middleware`       | Middleware function `(ctx, next) => ...`.                           |
+| `Handler`          | Terminal route handler `(ctx) => Response`.                         |
+| `ErrorHandler`     | Error handler `(err, ctx) => Response`.                             |
+| `RouteFilter`      | Filter function `(ctx) => boolean` used for routing.                |
+| `MiddlewareReturn` | Return type of middleware functions.                                |
+| `ConnectionInfo`   | Connection metadata (remote/local address, TLS flag).               |
+| `RoutePattern`     | Parsed route pattern.                                               |
+
+## Routing
+
+Register routes by message type, trigger event, or pattern:
+
+```ts
+app.on("ADT^A01", handler); // exact match
+app.on("ADT^*", handler); // any ADT trigger event
+app.on("*^A01", handler); // any message type with A01
+app.on("ADT", handler); // any ADT (same as ADT^*)
+app.on("*", handler); // catch-all
 ```
 
-### Routing Patterns
+Routes are matched first-match-wins — register specific routes before catch-alls.
 
-```typescript
-app.on("ADT^A01", handler); // Exact match
-app.on("ADT^*", handler); // Any ADT trigger event
-app.on("*^A01", handler); // Any message type with A01
-app.on("ADT", handler); // Any ADT (same as ADT^*)
-app.on("*", handler); // Catch-all
-```
+## Middleware
 
-Routes are matched **first-match-wins** — register specific routes before catch-alls.
+Middleware functions receive the request context and a `next()` callback. Pre-work runs before `next()`; post-work runs after. Returning a response from any middleware short-circuits the handler.
 
-### Middleware
-
-Middleware follows the Hono/Koa onion model:
-
-```typescript
-// Global middleware — runs for all messages
+```ts
+// Global middleware — runs for every message.
 app.use(async (ctx, next) => {
   const start = Date.now();
   await next();
   console.log(`Processed in ${Date.now() - start}ms`);
 });
 
-// Scoped middleware — only for matching messages
+// Scoped middleware — only for matching message types.
 app.use("ADT^*", async (ctx, next) => {
   ctx.set("isAdmission", true);
   await next();
 });
-```
 
-Middleware can short-circuit by returning a response without calling `next()`:
-
-```typescript
+// Short-circuit: return a response without calling next().
 app.use(async (ctx) => {
   if (!isAuthorized(ctx.connection.remoteAddress)) {
     return { raw: buildNakFor(ctx, "Unauthorized") };
@@ -234,62 +125,53 @@ app.use(async (ctx) => {
 });
 ```
 
-### Context
+## Context
 
-The `Context` object is available in all middleware and handlers. The pipeline is **lazy** — only the parse step runs eagerly. Transforms and compilation are deferred until accessed.
+Available in every middleware and handler. The pipeline is lazy: only the parse step runs eagerly; transforms and compilation are deferred until accessed.
 
-#### Sync properties (always available, zero cost)
+### Sync properties
 
-| Property               | Description                                            |
-| ---------------------- | ------------------------------------------------------ |
-| `ctx.req.raw`          | Original HL7v2 message string                          |
-| `ctx.req.bytes`        | Raw bytes from the MLLP frame                          |
-| `ctx.connection`       | `{ remoteAddress, remotePort, localPort, secure }`     |
-| `ctx.messageType`      | MSH-9.1 (e.g., `"ADT"`)                                |
-| `ctx.triggerEvent`     | MSH-9.2 (e.g., `"A01"`)                                |
-| `ctx.messageStructure` | MSH-9.3 (e.g., `"ADT_A01"`)                            |
-| `ctx.version`          | MSH-12 (e.g., `"2.5.1"`)                               |
-| `ctx.controlId`        | MSH-10 message control ID                              |
-| `ctx.ast`              | Raw parsed AST — pre-transform, straight from the wire |
-| `ctx.file`             | VFile (diagnostics accumulate after `tree()`)          |
-| `ctx.set(key, value)`  | Store a variable                                       |
-| `ctx.get(key)`         | Retrieve a variable                                    |
-| `ctx.var`              | Read-only snapshot of all variables                    |
+| Property               | Description                                             |
+| ---------------------- | ------------------------------------------------------- |
+| `ctx.req.raw`          | Original HL7v2 message string.                          |
+| `ctx.req.bytes`        | Raw bytes from the MLLP frame.                          |
+| `ctx.connection`       | `{ remoteAddress, remotePort, localPort, secure }`.     |
+| `ctx.messageType`      | MSH-9.1 (e.g. `"ADT"`).                                 |
+| `ctx.triggerEvent`     | MSH-9.2 (e.g. `"A01"`).                                 |
+| `ctx.messageStructure` | MSH-9.3 (e.g. `"ADT_A01"`).                             |
+| `ctx.version`          | MSH-12 (e.g. `"2.5.1"`).                                |
+| `ctx.controlId`        | MSH-10 message control ID.                              |
+| `ctx.ast`              | Raw parsed AST — pre-transform, straight from the wire. |
+| `ctx.file`             | VFile (diagnostics accumulate after `tree()`).          |
+| `ctx.set(key, value)`  | Store a variable.                                       |
+| `ctx.get(key)`         | Retrieve a variable.                                    |
+| `ctx.var`              | Read-only snapshot of all variables.                    |
 
-#### Async methods (lazy, trigger pipeline stages on first call)
+### Async methods
 
-| Method               | Triggers                | Description                                          |
-| -------------------- | ----------------------- | ---------------------------------------------------- |
-| `await ctx.tree()`   | `run()` (transform)     | Transformed AST — escape decoding, annotations, lint |
-| `await ctx.result()` | `run()` + `stringify()` | Compiled output (e.g., JSON from hl7v2Jsonify)       |
+| Method               | Triggers                | Description                                           |
+| -------------------- | ----------------------- | ----------------------------------------------------- |
+| `await ctx.tree()`   | `run()` (transform)     | Transformed AST — escape decoding, annotations, lint. |
+| `await ctx.result()` | `run()` + `stringify()` | Compiled output (e.g. JSON from `hl7v2Jsonify`).      |
 
 Both are cached — subsequent calls return the same value instantly.
 
-### `ctx.ast` vs `await ctx.tree()` — Choosing the Right One
+### `ctx.ast` vs `await ctx.tree()`
 
-**Use `ctx.ast`** when you only need the raw message structure:
+Use `ctx.ast` when you only need the raw message structure — reading MSH fields, building ACK/NAK responses, route filter functions, or middleware that doesn't need escape-decoded values:
 
-- Reading MSH fields (message type, version, control ID)
-- Building ACK/NAK responses
-- Route filter functions
-- Middleware that doesn't need escape-decoded values
-
-```typescript
-// Fast — no pipeline cost
+```ts
+// Fast — no pipeline cost.
 app.use((ctx, next) => {
   console.log(`Received ${ctx.messageType}^${ctx.triggerEvent}`);
   return next();
 });
 ```
 
-**Use `await ctx.tree()`** when you need the fully processed tree:
+Use `await ctx.tree()` when you need the fully processed tree — business logic that reads decoded field values, or handlers that inspect annotations or resolved message structures:
 
-- Business logic that reads decoded field values
-- Handlers that inspect annotations or resolved message structures
-- Any operation that depends on transformer output
-
-```typescript
-// Triggers transform pipeline on first call
+```ts
+// Triggers transform pipeline on first call.
 app.on("ADT^A01", async (ctx) => {
   const tree = await ctx.tree();
   // tree has escape sequences decoded, message structure resolved, etc.
@@ -297,23 +179,22 @@ app.on("ADT^A01", async (ctx) => {
 });
 ```
 
-**Use `await ctx.result()`** when you need the compiled output:
+Use `await ctx.result()` when you need the compiled output:
 
-```typescript
+```ts
 app.on("ORU^R01", async (ctx) => {
   const json = await ctx.result(); // triggers transform + compile
-  // json is the Hl7v2JsonResult from hl7v2Jsonify
   await saveToDatabase(json);
   return { raw: "..." };
 });
 ```
 
-### Writing Middleware — Best Practices
+### Writing middleware — prefer `ctx.ast`
 
-**Prefer `ctx.ast` over `await ctx.tree()` in middleware.** Most middleware only needs routing fields or raw MSH data — both available synchronously from `ctx.ast`. This keeps the middleware fast and avoids triggering the transform pipeline unnecessarily.
+Most middleware only needs routing fields or raw MSH data — both available synchronously from `ctx.ast`. Reach for `await ctx.tree()` only when you genuinely need the transformed tree.
 
-```typescript
-// ✅ Good — sync, fast, no pipeline cost
+```ts
+// Good — sync, fast, no pipeline cost.
 function authMiddleware(): Middleware {
   return (ctx, next) => {
     if (!isAuthorized(ctx.connection.remoteAddress)) {
@@ -323,8 +204,7 @@ function authMiddleware(): Middleware {
   };
 }
 
-// ✅ Good — ACK middleware uses ctx.ast (pre-transform tree)
-// The acknowledge() function only reads MSH fields
+// Good — ACK middleware reads MSH fields from the pre-transform tree.
 function ackMiddleware(): Middleware {
   return async (ctx, next) => {
     await next();
@@ -332,11 +212,10 @@ function ackMiddleware(): Middleware {
   };
 }
 
-// ⚠️ Only when needed — triggers transform pipeline
+// Only when needed — triggers transform pipeline.
 function validationMiddleware(): Middleware {
   return async (ctx, next) => {
     const tree = await ctx.tree();
-    // tree has escape sequences decoded — needed for value validation
     if (!isValid(tree)) {
       return { raw: buildNak(ctx.ast, "Invalid") };
     }
@@ -345,22 +224,22 @@ function validationMiddleware(): Middleware {
 }
 ```
 
-### Error Handling
+## Error handling
 
-```typescript
+```ts
 app.onError(async (err, ctx) => {
   console.error(`Error processing ${ctx.controlId}:`, err.message);
   return { raw: buildNakFor(ctx, err.message) };
 });
 ```
 
-Without an error handler, errors are absorbed and no response is sent. The sending system will time out and retry per standard MLLP behavior. See the [FAQ](#faq) for the rationale behind this design.
+Without an error handler, errors are absorbed and no response is sent. The sending system will time out and retry per standard MLLP behaviour. See the [design notes](#design-notes) below for the rationale.
 
-### TLS
+## TLS
 
 TLS is supported via `serve()` options:
 
-```typescript
+```ts
 import fs from "node:fs";
 import { Mllp } from "@glion/mllp";
 import { parseHL7v2 } from "@glion/hl7v2";
@@ -381,7 +260,7 @@ const server = serve(app, {
 
 ### Simple API
 
-```typescript
+```ts
 import { encode, decode, encodeMultiple } from "@glion/mllp";
 
 const mllpFrame = encode(hl7Message);
@@ -393,7 +272,7 @@ const frames = encodeMultiple(["MSH|1", "MSH|2"]);
 
 ### Streaming API
 
-```typescript
+```ts
 import { createDecoderStream } from "@glion/mllp";
 
 const decoder = createDecoderStream({
@@ -410,77 +289,35 @@ tcpSocket.readable.pipeThrough(decoder).pipeTo(
 );
 ```
 
-## API Reference
+## Design notes
 
-### Server
+### Why no default error response?
 
-| Export                               | Description                      |
-| ------------------------------------ | -------------------------------- |
-| `Mllp`                               | Hono-style MLLP server class     |
-| `serve()` (from `/node`)             | Start a Node.js/Bun TCP server   |
-| `parsePattern(pattern)`              | Parse a route pattern string     |
-| `matchPattern(pattern, type, event)` | Test a pattern against a message |
+HL7v2 has no universal error-response format. An ACK/NAK is version-dependent, varies by message type, and requires access to the inbound MSH segment to construct correctly. Building that into the core would couple the routing engine to HL7v2 message construction — the wrong layer of abstraction.
 
-### Types
+Instead, the `Mllp` engine is middleware-first:
 
-| Type               | Description                                                        |
-| ------------------ | ------------------------------------------------------------------ |
-| `Context`          | Request context with message data and routing fields               |
-| `Response`         | Response object `{ raw: string }`                                  |
-| `Hl7v2Processor`   | Unified `Processor` type for HL7v2 (`Processor<Root, Root, Root>`) |
-| `Middleware`       | Middleware function `(ctx, next) => ...`                           |
-| `Handler`          | Terminal route handler `(ctx) => Response`                         |
-| `ErrorHandler`     | Error handler `(err, ctx) => Response`                             |
-| `RouteFilter`      | Filter function `(ctx) => boolean` for routing                     |
-| `MiddlewareReturn` | Return type of middleware functions                                |
-| `ConnectionInfo`   | Connection metadata                                                |
-| `RoutePattern`     | Parsed route pattern                                               |
+- **Default behaviour** — no response is sent; the sending system times out and retries, which is valid MLLP behaviour.
+- **Logging** — add a logger middleware to make errors observable.
+- **ACK/NAK** — add an acknowledgment middleware to translate errors into proper NAK responses. `@glion/mllp-ack` provides this out of the box.
+- **Custom error responses** — use `app.onError()` for application-specific handling.
 
-### Primitives
-
-| Function                        | Description                       |
-| ------------------------------- | --------------------------------- |
-| `encode(message)`               | Encode a message to an MLLP frame |
-| `decode(frame)`                 | Decode a single MLLP frame        |
-| `encodeMultiple(messages)`      | Encode multiple messages          |
-| `createDecoderStream(options?)` | Streaming decoder TransformStream |
-
-## FAQ
-
-### Why doesn't the server return an error response by default?
-
-HTTP servers like [Hono](https://hono.dev) return a generic `500 Internal Server Error` when a handler throws. This works because HTTP has a universal error response format that every client understands.
-
-HL7v2 has no such universal format. An ACK/NAK message is version-dependent, varies by message type, and requires knowledge of the original MSH segment to construct correctly. Building ACK generation into the core would couple the routing engine to HL7v2 message construction — the wrong layer of abstraction.
-
-Instead, the `Mllp` class follows a **middleware-first** design:
-
-- **Default behavior**: No response is sent. The sending system times out and retries, which is valid and expected in MLLP.
-- **Logging**: Add a logger middleware to make errors observable.
-- **ACK/NAK**: Add an acknowledgment middleware to translate errors into proper NAK responses.
-- **Custom error handling**: Use `app.onError()` for application-specific error responses.
-
-```typescript
+```ts
 const app = new Mllp().parser(parseHL7v2);
 
-// Compose the behavior you need
 app.use(logger()); // observability — provided by middleware
 app.use(ackMiddleware()); // error → NAK translation — @glion/mllp-ack
 
 app.on("ADT^A01", handler);
 ```
 
-This keeps the core engine simple and protocol-agnostic, while middleware handles the HL7v2-specific concerns.
+### Why no built-in logging?
 
-### Why is there no built-in logging?
+The core has zero `console.log` or `console.error` calls. Logging is an opt-in middleware concern, giving you full control over format, destination, and verbosity without the core making assumptions about your observability stack.
 
-Same philosophy as Hono — the core has zero `console.log` or `console.error` calls. Logging is an opt-in middleware concern. This gives you full control over log format, destination, and verbosity without the core making assumptions about your observability stack.
+## Part of Glion
 
-## Requirements
+`@glion/mllp` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-- Node.js 18+ or Bun
-- ESM only
-
-## License
-
-MIT
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -1,24 +1,12 @@
-# HL7v2 Parser
+# @glion/parser
 
-This package is a utility that takes a raw HL7v2 message as input and turns it into an HL7v2 syntax tree following the [@glion/ast](../hl7v2-ast/README.md) definition.
+`unified`-compatible parser that converts HL7v2 text into a structured AST.
 
-This utility is a low level project. It’s used in [@glion/hl7v2](../hl7v2/), which focusses on making it easier to transform content by abstracting these internals away.
+## What it does
 
-## When should I use this?
-
-If you want to handle syntax trees manually, use this. For an easier time processing content, use the [@glion/hl7v2](../hl7v2/) ecosystem instead.
-
-## Features
-
-- **Speed-first**: pull-based tokenizer, single pass, minimal object allocations.
-- **Spec-aware**: auto-detects delimiters from MSH-1 and MSH-2.
-- **AST design**: outputs a unist-compatible tree for use in the HL7v2 unified ecosystem.
-- **Composable**: works directly as a unified parser plugin or as a standalone function.
-- **Streaming-friendly**: pull-based design is ready for streaming use cases.
+`@glion/parser` is a low-level parser that turns raw HL7v2 messages into a `unist`-compatible syntax tree following the [`@glion/ast`](../ast/) spec. It runs as a `unified` parser plugin — feeding its output into any downstream `unified` processor — and auto-detects delimiters from MSH-1 and MSH-2 so non-standard delimiter sets work without configuration. Most applications should use [`@glion/hl7v2`](../hl7v2/), which bundles this parser with the standard transform and compile stages; reach for `@glion/parser` when you are building a custom pipeline.
 
 ## Install
-
-This package is [ESM only](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c). In Node.js (version 16+), install with npm:
 
 ```bash
 npm install @glion/parser
@@ -26,128 +14,94 @@ npm install @glion/parser
 
 ## Use
 
-### Basic Usage
-
-```typescript
+```ts
 import { unified } from "unified";
 import { hl7v2Parser } from "@glion/parser";
 
-const message = `MSH|^~\\&|SENDING_APP|SENDING_FAC|...`;
+const message = "MSH|^~\\&|SENDING_APP|SENDING_FAC|...\rPID|1||12345";
 
 const tree = unified().use(hl7v2Parser).parse(message);
 
 console.log(tree);
 ```
 
-### Custom Delimiters
+## API
 
-You can specify custom delimiters for parsing non-standard HL7v2 messages. The `delimiters` option accepts a partial object, so you only need to specify the delimiters you want to override:
+### `unified().use(hl7v2Parser[, options])`
 
-```typescript
+Register the parser as the reader for a `unified` processor. The parser reads from the input string and produces a `Root` AST; it never mutates its input.
+
+### Options
+
+| Option                   | Type                  | Description                                                                              |
+| ------------------------ | --------------------- | ---------------------------------------------------------------------------------------- |
+| `delimiters`             | `Partial<Delimiters>` | Override one or more delimiters. The parser merges with MSH-derived values and defaults. |
+| `experimental.emptyMode` | `"empty-array"`       | Opt in to the empty-array representation of empty fields (see below).                    |
+
+The default delimiters are `|` (field), `^` (component), `~` (repetition), `&` (subcomponent), `\` (escape), and `\r` (segment).
+
+### Custom delimiters
+
+```ts
 import { unified } from "unified";
 import { hl7v2Parser } from "@glion/parser";
 
 // Override only the segment delimiter
 const tree = unified()
-  .use(hl7v2Parser, {
-    delimiters: {
-      segment: "\n", // Use newline instead of carriage return
-    },
-  })
+  .use(hl7v2Parser, { delimiters: { segment: "\n" } })
   .parse(message);
 
 // Override multiple delimiters
 const customTree = unified()
   .use(hl7v2Parser, {
-    delimiters: {
-      field: "$",
-      component: "%",
-      segment: "\n",
-    },
+    delimiters: { field: "$", component: "%", segment: "\n" },
   })
   .parse(customMessage);
 ```
 
-The default delimiters are:
+Options accept a partial `Delimiters` object, so only the characters you want to override need to be provided.
 
-- `field`: `|`
-- `component`: `^`
-- `repetition`: `~`
-- `subcomponent`: `&`
-- `escape`: `\`
-- `segment`: `\r`
+## Parsing model
 
-### Experimental Features
+- **Pull-based tokenizer.** Single pass, minimal object allocations — suitable for high-throughput ingestion.
+- **Delimiter auto-detection.** MSH-1 and MSH-2 are read before the rest of the message is tokenized so custom delimiter sets are honored without configuration.
+- **`unist`-compatible output.** Nodes follow the `@glion/ast` spec and integrate with `unist-util-visit`, `unist-builder`, and the wider Glion plugin ecosystem.
+- **Streaming-friendly.** The pull-based design is ready for streaming ingestion even though the current public API takes a complete string.
 
-The parser supports experimental features through the `experimental` option. These features are subject to change but provide opt-in access to upcoming behaviors.
+### Experimental: empty-array mode
 
-#### Empty Array Mode
+By default the parser represents empty fields with full scaffolding (`Field → FieldRepetition → Component → Subcomponent` with `value: ""`). Passing `experimental: { emptyMode: "empty-array" }` switches to a more compact representation where empty parents carry `children: []` instead of nested empties.
 
-By default, the parser represents empty fields with full scaffolding (Field → FieldRepetition → Component → Subcomponent with `value: ""`). The `emptyMode: 'empty'` option changes this behavior to use empty children arrays instead, making the AST more compact and easier to work with.
-
-```typescript
+```ts
 import { unified } from "unified";
 import { hl7v2Parser } from "@glion/parser";
 
-// With empty-array mode (new behavior)
 const tree = unified()
-  .use(hl7v2Parser, {
-    experimental: {
-      emptyMode: "empty-array",
-    },
-  })
+  .use(hl7v2Parser, { experimental: { emptyMode: "empty-array" } })
   .parse("PID|1||");
 
-// PID.2 (empty field) will have: { type: 'field', children: [] }
-// Instead of: Field → Rep → Comp → Sub with value: ""
+// PID-2 (empty field) becomes: { type: "field", children: [] }
+// rather than: Field → Rep → Comp → Sub with value: ""
 ```
 
-**Spec Rules:**
+Rules:
 
-- **Leaf nodes** (Subcomponent, SegmentHeader) with no value: `value: ""`
-- **Parent nodes** (Field, FieldRepetition, Component) with no content: `children: []`
-- **Presence vs Value**:
-  - Node exists in parent's children array = position exists
-  - Node has empty children array = no value at that position
+- **Leaf nodes** (`Subcomponent`, `SegmentHeader`) with no value carry `value: ""`.
+- **Parent nodes** (`Field`, `FieldRepetition`, `Component`) with no content carry `children: []`.
+- **Presence vs value:** a node in the parent's `children` array means the position exists; empty `children` means the position has no value.
 
-**Examples:**
-
-| Wire Format     | Legacy Mode                                    | Empty-Array Mode                       |
+| Wire format     | Legacy mode                                    | Empty-array mode                       |
 | --------------- | ---------------------------------------------- | -------------------------------------- |
 | `PID\|1\|\|`    | Field → Rep → Comp → Sub("")                   | Field(children: [])                    |
 | `PID\|1\|^\|`   | Field → Rep → [Comp → Sub(""), Comp → Sub("")] | Field → Rep → [Comp[], Comp[]]         |
 | `PID\|1\|~\|`   | Field → [Rep → Comp → Sub(""), Rep → ...]      | Field → [Rep[], Rep[]]                 |
 | `PID\|1\|ABC\|` | Field → Rep → Comp → Sub("ABC")                | Field → Rep → Comp → Sub("ABC") (same) |
 
-**Benefits:**
+For messages with many empty fields, the empty-array representation reduces node count by 37–63% and improves sparse-message parsing throughput by about 11%. Empty-array mode is planned to become the default; the legacy representation will be retired.
 
-- 37-63% reduction in node count for messages with empty fields
-- ~11% performance improvement for sparse messages
-- Cleaner AST structure for visitor patterns and transformations
-- Easier to distinguish "field exists but is empty" from "field has content"
+## Part of Glion
 
-**Note:** This feature will become the default behavior in future versions. The legacy mode will be deprecated.
+`@glion/parser` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-## Contributing
-
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## Code of Conduct
-
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
-
-## License
-
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
-
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
-
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/preset-annotate-profile-recommended/README.md
+++ b/packages/preset-annotate-profile-recommended/README.md
@@ -1,6 +1,6 @@
 # @glion/preset-annotate-profile-recommended
 
-> Preset bundling every profile-based annotation plugin so the AST carries full profile metadata after a single `.use(...)` call.
+Preset bundling every profile-based annotation plugin so the AST carries full profile metadata after a single `.use(...)` call.
 
 ## What it does
 
@@ -9,10 +9,8 @@ This preset wires the five profile annotation plugins plus the `annotate-profile
 ## Install
 
 ```bash
-pnpm add @glion/preset-annotate-profile-recommended
+npm install @glion/preset-annotate-profile-recommended
 ```
-
-> Using npm? `npm install @glion/preset-annotate-profile-recommended`
 
 ## Use
 
@@ -59,8 +57,7 @@ All five plugins read the HL7v2 version from `MSH-12` and load profiles via `@gl
 
 ## Part of Glion
 
-`@glion/preset-annotate-profile-recommended` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/preset-annotate-profile-recommended` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/preset-annotate-profile-recommended/README.md
+++ b/packages/preset-annotate-profile-recommended/README.md
@@ -1,0 +1,66 @@
+# @glion/preset-annotate-profile-recommended
+
+> Preset bundling every profile-based annotation plugin so the AST carries full profile metadata after a single `.use(...)` call.
+
+## What it does
+
+This preset wires the five profile annotation plugins plus the `annotate-profile-context` loader into a single `unified` plugin. One `.use(...)` call enriches every segment, field, field-repetition, component, sub-component, and coded value in the AST with its HL7v2 profile metadata — names, datatypes, required flags, repeatability, max lengths, table references, and code-system displays. The annotated tree is self-describing and can be walked without loading any profiles yourself.
+
+## Install
+
+```bash
+pnpm add @glion/preset-annotate-profile-recommended
+```
+
+> Using npm? `npm install @glion/preset-annotate-profile-recommended`
+
+## Use
+
+```ts
+import hl7v2PresetAnnotateProfileRecommended from "@glion/preset-annotate-profile-recommended";
+import { hl7v2Parser } from "@glion/parser";
+import { visit } from "@glion/util-visit";
+import { unified } from "unified";
+
+const processor = unified()
+  .use(hl7v2Parser)
+  .use(hl7v2PresetAnnotateProfileRecommended);
+
+const file = await processor.process(
+  "MSH|^~\\&|SENDER||RECEIVER||20250601120000||ADT^A01|MSG00001|P|2.5\rPID|1||12345||Doe^John"
+);
+
+visit(file.result, "field", (node) => {
+  if (node.data?.required && node.data.name) {
+    console.log(`Required: ${node.data.id} (${node.data.name})`);
+  }
+});
+```
+
+## API
+
+### `unified().use(hl7v2PresetAnnotateProfileRecommended)`
+
+Default export is a `Preset` (unified's `{ plugins: [...] }` shape). No options — to annotate selectively, compose individual plugins from their own packages instead.
+
+## What's bundled
+
+The preset applies these plugins in order. `annotate-profile-context` runs first so each subsequent plugin reads the pre-resolved profile from `file.data.profile`.
+
+| Plugin                                                                                   | Annotates                                                                                      |
+| ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [`@glion/annotate-profile-context`](../annotate-profile-context)                         | Loads the HL7v2 profile for the message version onto `file.data`.                              |
+| [`@glion/annotate-profile-segments`](../annotate-profile-segments)                       | Annotates Segment nodes with their human-readable title (e.g. `MSH` → `"Message Header"`).     |
+| [`@glion/annotate-profile-fields`](../annotate-profile-fields)                           | Annotates Field nodes with `name`, `required`, `repeatable`, `datatype`, `maxLength`, `table`. |
+| [`@glion/annotate-profile-datatypes`](../annotate-profile-datatypes)                     | Annotates FieldRepetition, Component, and Subcomponent nodes with datatype metadata.           |
+| [`@glion/annotate-profile-fields-code-systems`](../annotate-profile-fields-code-systems) | Annotates coded fields with UTG code-system identity and resolved display values.              |
+
+All five plugins read the HL7v2 version from `MSH-12` and load profiles via `@glion/profiles`. Unknown segments (Z-segments) are silently skipped so non-standard content passes through unchanged.
+
+## Part of Glion
+
+`@glion/preset-annotate-profile-recommended` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/preset-lint-profile-recommended/README.md
+++ b/packages/preset-lint-profile-recommended/README.md
@@ -1,6 +1,6 @@
 # @glion/preset-lint-profile-recommended
 
-> Preset bundling every profile-based HL7v2 lint rule for validating messages against their version-specific profiles.
+Preset bundling every profile-based HL7v2 lint rule for validating messages against their version-specific profiles.
 
 ## What it does
 
@@ -9,10 +9,8 @@ This preset wires the eight profile lint rules plus the `annotate-profile-contex
 ## Install
 
 ```bash
-pnpm add @glion/preset-lint-profile-recommended
+npm install @glion/preset-lint-profile-recommended
 ```
-
-> Using npm? `npm install @glion/preset-lint-profile-recommended`
 
 ## Use
 
@@ -60,8 +58,7 @@ The companion `@glion/preset-lint-recommended` covers the core (version-independ
 
 ## Part of Glion
 
-`@glion/preset-lint-profile-recommended` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/preset-lint-profile-recommended` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/preset-lint-profile-recommended/README.md
+++ b/packages/preset-lint-profile-recommended/README.md
@@ -1,0 +1,67 @@
+# @glion/preset-lint-profile-recommended
+
+> Preset bundling every profile-based HL7v2 lint rule for validating messages against their version-specific profiles.
+
+## What it does
+
+This preset wires the eight profile lint rules plus the `annotate-profile-context` loader into a single `unified` plugin. One `.use(...)` call enables required-field, field-length, field-repetition, required-component, table-value, extra-field, extra-component, and segment-order validation — all driven by the HL7v2 profile loaded for the message's MSH-12 version.
+
+## Install
+
+```bash
+pnpm add @glion/preset-lint-profile-recommended
+```
+
+> Using npm? `npm install @glion/preset-lint-profile-recommended`
+
+## Use
+
+```ts
+import hl7v2PresetLintProfileRecommended from "@glion/preset-lint-profile-recommended";
+import { hl7v2Parser } from "@glion/parser";
+import { unified } from "unified";
+
+const processor = unified()
+  .use(hl7v2Parser)
+  .use(hl7v2PresetLintProfileRecommended);
+
+const file = await processor.process(
+  "MSH|^~\\&|SENDER||RECEIVER||20250601120000||ADT^A01|MSG00001|P|2.5\rPID|1||PATID1234^^^HOSP^MR"
+);
+
+for (const message of file.messages) {
+  console.log(`${message.ruleId}: ${message.reason}`);
+}
+```
+
+## API
+
+### `unified().use(hl7v2PresetLintProfileRecommended)`
+
+Default export is a `Preset` (unified's `{ plugins: [...] }` shape). No options — to configure individual rules, compose them directly from their own packages instead of using the preset.
+
+## What's bundled
+
+The preset applies these plugins in order. `annotate-profile-context` runs first so every subsequent rule sees the resolved profile on `file.data.profile`.
+
+| Plugin                                                                               | Purpose                                                                  |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| [`@glion/annotate-profile-context`](../annotate-profile-context)                     | Loads the HL7v2 profile for the message version onto `file.data`.        |
+| [`@glion/lint-profile-required-fields`](../lint-profile-required-fields)             | Flags missing or empty required fields.                                  |
+| [`@glion/lint-profile-field-max-length`](../lint-profile-field-max-length)           | Enforces field-value `maxLength` from the profile.                       |
+| [`@glion/lint-profile-field-repetition`](../lint-profile-field-repetition)           | Flags non-repeatable fields that contain multiple repetitions.           |
+| [`@glion/lint-profile-required-components`](../lint-profile-required-components)     | Validates required components inside composite datatypes.                |
+| [`@glion/lint-profile-table-values`](../lint-profile-table-values)                   | Validates coded values against HL7 tables.                               |
+| [`@glion/lint-profile-events-segments-order`](../lint-profile-events-segments-order) | Validates segment order per the message structure definition.            |
+| [`@glion/lint-profile-extra-fields`](../lint-profile-extra-fields)                   | Warns when a segment contains more fields than the profile defines.      |
+| [`@glion/lint-profile-extra-components`](../lint-profile-extra-components)           | Warns when a composite field contains more components than its datatype. |
+
+The companion `@glion/preset-lint-recommended` covers the core (version-independent) lint rules; use both together for comprehensive validation.
+
+## Part of Glion
+
+`@glion/preset-lint-profile-recommended` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/preset-lint-recommended/README.md
+++ b/packages/preset-lint-recommended/README.md
@@ -1,81 +1,57 @@
 # @glion/preset-lint-recommended
 
-**Preset of linting rules for HL7v2**, built on top of the [`unified`][github-unified] ecosystem.
+Preset bundling the core (version-independent) HL7v2 lint rules.
 
-This preset is meant as a recommended baseline for catching common HL7v2 issues, such as segment structure, field length, and delimiter usage.
+## What it does
 
-## What is this?
-
-This package provides a **recommended set of HL7v2 linting rules**. It ensures a consistent baseline of message quality checks when processing HL7v2 messages with [`unified`][github-unified] and [`@glion/parser`][github-hl7v2-parser].
-
-Think of it like ESLint’s "recommended" rules, but for HL7v2.
-
-## When should I use this?
-
-Use this preset if you:
-
-- Want a **sensible default** for linting HL7v2 messages
-- Need a **starting point** for building custom HL7v2 lint configurations
-- Are using the [`hl7v2-parser`][github-hl7v2-parser] and want to catch common mistakes
-
-It is intended as a **minimum recommended set**. You can extend or override rules in your own configs.
+This preset wires the core HL7v2 lint rules into a single `unified` plugin. One `.use(...)` call enables structural checks that apply to every HL7v2 message regardless of version or profile: segment header shape, message header presence, version range, and trailing field hygiene.
 
 ## Install
 
-```sh
+```bash
 npm install @glion/preset-lint-recommended
 ```
 
 ## Use
 
-```typescript
+```ts
+import hl7v2PresetLintRecommended from "@glion/preset-lint-recommended";
+import { hl7v2Parser } from "@glion/parser";
 import { unified } from "unified";
-import parse from "@glion/parser";
-import lint from "@glion/lint";
-import recommended from "@glion/preset-lint-recommended";
 
-const file = await unified()
-  .use(parse)
-  .use(lint)
-  .use(recommended)
-  .process("MSH|^~\\&|...");
+const processor = unified().use(hl7v2Parser).use(hl7v2PresetLintRecommended);
+
+const file = await processor.process(
+  "MSH|^~\\&|SENDER||RECEIVER||20250601120000||ADT^A01|MSG00001|P|2.5"
+);
+
+for (const message of file.messages) {
+  console.log(`${message.ruleId}: ${message.reason}`);
+}
 ```
 
-## Presets
+## API
 
-This preset bundles a set of **recommended HL7v2 linting rules**.  
-Each rule has a default severity and may expose configuration options.
+### `unified().use(hl7v2PresetLintRecommended)`
 
-| Rule                                                                      | Options | Default Severity |
-| ------------------------------------------------------------------------- | ------- | ---------------- |
-| [`hl7v2-lint-segment-header-length`](../hl7v2-lint-segment-header-length) | _none_  | `error`          |
+Default export is a `Preset` (unified's `{ plugins: [...] }` shape). No options — to configure individual rules, compose them directly from their own packages instead of using the preset.
 
-## Security
+## What's bundled
 
-This plugin only transforms AST nodes and does not execute code. Ensure you trust the source of HL7v2 messages before processing.
+The preset applies these rules in order. Three are configured at `error` severity; `no-trailing-empty-field` uses its default severity.
 
-## Contributing
+| Plugin                                                                   | Purpose                                                                      |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| [`@glion/lint-segment-header-length`](../lint-segment-header-length)     | Flags segment headers that are not exactly three characters.                 |
+| [`@glion/lint-required-message-header`](../lint-required-message-header) | Flags messages whose first segment is not `MSH`.                             |
+| [`@glion/lint-message-version`](../lint-message-version)                 | Flags `MSH-12` values outside the configured semver range.                   |
+| [`@glion/lint-no-trailing-empty-field`](../lint-no-trailing-empty-field) | Flags segments that end with one or more empty fields (stray trailing `\|`). |
 
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
+The companion `@glion/preset-lint-profile-recommended` covers profile-driven, version-specific lint rules; use both together for comprehensive validation.
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+## Part of Glion
 
-## Code of Conduct
+`@glion/preset-lint-recommended` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
-
-## License
-
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
-
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
-
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
-[github-unified]: https://github.com/unifiedjs/unified
-[github-hl7v2-parser]: https://github.com/rethinkhealth/glion/tree/main/packages/hl7v2-parser
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/profiles/README.md
+++ b/packages/profiles/README.md
@@ -1,6 +1,6 @@
 # @glion/profiles
 
-> HL7v2 version-specific profile data — segments, fields, datatypes, and tables — with LRU-cached loaders.
+HL7v2 version-specific profile data — segments, fields, datatypes, and tables — with LRU-cached loaders.
 
 ## What it does
 
@@ -9,10 +9,8 @@
 ## Install
 
 ```bash
-pnpm add @glion/profiles
+npm install @glion/profiles
 ```
-
-> Using npm? `npm install @glion/profiles`
 
 ## Use
 
@@ -132,8 +130,7 @@ Same shape convention: each exposes its id, version, and the typed payload (valu
 
 ## Part of Glion
 
-`@glion/profiles` is part of **[Glion]**, the application framework for HL7v2.
-See the [Glion README] for the full package catalog and architecture.
+`@glion/profiles` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/profiles/README.md
+++ b/packages/profiles/README.md
@@ -1,0 +1,139 @@
+# @glion/profiles
+
+> HL7v2 version-specific profile data — segments, fields, datatypes, and tables — with LRU-cached loaders.
+
+## What it does
+
+`@glion/profiles` is the data source for Glion's profile-aware plugins. It provides structured HL7v2 profile definitions for every supported version (2.3 through 2.8), loaded on demand and cached in memory. The annotation plugins (`@glion/annotate-profile-*`) and the profile lint rules (`@glion/lint-profile-*`) read from this package to enrich and validate HL7v2 messages against the HL7-published specifications.
+
+## Install
+
+```bash
+pnpm add @glion/profiles
+```
+
+> Using npm? `npm install @glion/profiles`
+
+## Use
+
+```ts
+import { profiles } from "@glion/profiles";
+
+const msh = await profiles.segments.load("2.5", "MSH");
+console.log(msh.fields.length); // => 21
+
+const field = await profiles.fields.load("2.5", "MSH", "9");
+console.log(field.name); // => "Message Type"
+console.log(field.required); // => true
+console.log(field.datatype); // => "MSG"
+
+const cx = await profiles.datatypes.load("2.5", "CX");
+console.log(cx.kind); // => "composite"
+console.log(cx.components.length); // => 10
+```
+
+Event structure validation uses the same API:
+
+```ts
+const structure = await profiles.events.load("2.5", "ADT_A01");
+// structure.dfa — deterministic finite automaton for segment-order validation
+```
+
+## API
+
+### `profiles`
+
+Shared singleton store (eager LRU cache, 100 entries per kind). Use this unless you need a bespoke cache configuration.
+
+### `createProfiles(options)`
+
+Construct a dedicated store with a custom cache size or eviction strategy.
+
+```ts
+import { createLruCache, createProfiles } from "@glion/profiles";
+
+const store = createProfiles({
+  cache: createLruCache({ maxEntries: 500 }),
+});
+```
+
+### Loaders on each store
+
+| Method                                      | Returns                |
+| ------------------------------------------- | ---------------------- |
+| `segments.load(version, segmentId)`         | `SegmentDefinition`    |
+| `fields.load(version, segmentId, position)` | `FieldProfile`         |
+| `datatypes.load(version, datatypeId)`       | `DatatypeDefinition`   |
+| `tables.load(version, tableId)`             | `Table`                |
+| `events.load(version, structureId)`         | `EventStructure`       |
+| `codeSystems.load(version, codeSystemId)`   | `CodeSystemDefinition` |
+
+### `loadSegments(version)`
+
+Standalone helper that loads every segment definition for a given version in one call. Used by batch-processing plugins.
+
+### Automaton runner
+
+For segment-order validation, `@glion/profiles` exposes the underlying DFA engine:
+
+```ts
+import { runner, type Definition } from "@glion/profiles";
+
+const engine = runner(definition);
+engine.step("MSH");
+engine.step("EVN");
+// engine.state === RunnerState.Running
+```
+
+## Profile data format
+
+Each kind of profile is loaded on demand from pre-built chunks. The compiled output is sharded into ~170 chunks (merged from ~10,800 source files via Rolldown code-splitting) to keep install size and cold-start cost low.
+
+### Segments
+
+```ts
+interface SegmentDefinition {
+  id: string; // "MSH", "PID", ...
+  name: string; // "Message Header"
+  fields: FieldProfile[]; // in positional order
+}
+```
+
+### Fields
+
+```ts
+interface FieldProfile {
+  id: string; // "MSH-9"
+  name: string; // "Message Type"
+  position: number; // 9
+  datatype: string; // "MSG"
+  required: boolean;
+  repeatable: boolean;
+  maxLength?: number;
+  table?: string; // "HL70001" when the field is coded
+  item?: string;
+}
+```
+
+### Datatypes
+
+```ts
+interface DatatypeDefinition {
+  id: string; // "CX"
+  kind: "primitive" | "composite";
+  title: string;
+  components?: ComponentProfile[]; // only for composite kind
+}
+```
+
+### Tables, event structures, code systems
+
+Same shape convention: each exposes its id, version, and the typed payload (value lists for tables, DFA definitions for event structures, concept lists with displayNames for code systems).
+
+## Part of Glion
+
+`@glion/profiles` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/to-hl7v2/README.md
+++ b/packages/to-hl7v2/README.md
@@ -1,138 +1,69 @@
 # @glion/to-hl7v2
 
-**[unified](https://unifiedjs.com/)** plugin to transform HL7v2 message ASTs back into HL7v2 string format.
+Compile HL7v2 ASTs back to HL7v2 text — as a `unified` plugin or a standalone helper for any node in the tree.
 
-## What is this?
+## What it does
 
-`@glion/to-hl7v2` is a [unified](https://unifiedjs.com/) plugin that takes an HL7v2 syntax tree (produced by a parser such as [`@glion/parser`](https://github.com/rethinkhealth/glion/tree/main/packages/hl7v2-parser)) and compiles it back to the standard HL7v2 string format.
-
-This plugin is useful for transforming, sanitizing, or reconstructing HL7v2 messages while preserving their structure and delimiters.
-
-## When should I use this?
-
-Use this plugin when you need to:
-
-- Transform HL7v2 ASTs back to HL7v2 string format for transmission or storage.
-- Sanitize HL7v2 messages by parsing and rebuilding them.
-- Apply transformations to HL7v2 messages using AST manipulation.
-- Round-trip HL7v2 messages through parsing and compilation.
-
-If you need to parse raw HL7v2 messages first, use [`@glion/parser`](https://github.com/rethinkhealth/glion/tree/main/packages/hl7v2-parser) before applying this plugin.
+`@glion/to-hl7v2` serializes an HL7v2 AST — typically produced by `@glion/parser` — into the original HL7v2 wire format. Delimiters are read from the Root node's data when present, so a parse-then-serialize round trip preserves the message byte-for-byte (modulo intentional edits to the tree in between). The standalone `toHl7v2()` helper works on any subtree, not just the Root, which makes it useful for extracting a single segment, field, or component as text.
 
 ## Install
 
-This package is [ESM only](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
-
-In Node.js (version 16+), install with [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm):
-
-```sh
+```bash
 npm install @glion/to-hl7v2
 ```
 
 ## Use
 
-Say we have an HL7v2 AST and want to convert it back to HL7v2 string format:
-
-```js
-import { unified } from "unified";
-import { hl7v2Parse } from "@glion/parser";
+```ts
+import { hl7v2Parser } from "@glion/parser";
 import { hl7v2ToHl7v2 } from "@glion/to-hl7v2";
+import { unified } from "unified";
 
 const msg = `MSH|^~\\&|HIS|RIH|EKG|EKG|200202150930||ADT^A01|MSG00001|P|2.4\rPID|||555-44-4444||DOE^JOHN`;
 
-const file = await unified().use(hl7v2Parse).use(hl7v2ToHl7v2).process(msg);
+const file = await unified().use(hl7v2Parser).use(hl7v2ToHl7v2).process(msg);
 
 console.log(String(file));
+// MSH|^~\&|HIS|RIH|EKG|EKG|200202150930||ADT^A01|MSG00001|P|2.4
+// PID|||555-44-4444||DOE^JOHN
 ```
-
-Yields:
-
-```
-MSH|^~\&|HIS|RIH|EKG|EKG|200202150930||ADT^A01|MSG00001|P|2.4
-PID|||555-44-4444||DOE^JOHN
-```
-
-The plugin preserves the original HL7v2 delimiters and structure, making it perfect for round-trip processing.
 
 ## API
 
 ### `unified().use(hl7v2ToHl7v2)`
 
-Transform an HL7v2 AST back into HL7v2 string format.
-
-###### Parameters
-
-There are no options.
-
-###### Returns
-
-Nothing (`undefined`). The unified compiler returns a stringified HL7v2 message.
+Register the plugin as the compiler of a `unified` processor. Serializes the AST back to HL7v2 text and sets it as the file contents. No options.
 
 ### `toHl7v2(node, delimiters?)`
 
-Convert any HL7v2 AST node to HL7v2 string format.
+Standalone serializer. Converts any HL7v2 AST node — `Root`, `Segment`, `Field`, `FieldRepetition`, `Component`, or `Subcomponent` — to its HL7v2 text representation.
 
-###### Parameters
+- `node` (`Nodes`) — the node to serialize.
+- `delimiters` (`Delimiters`, optional) — custom delimiter set. When omitted, reads from the Root node's `data` or falls back to the HL7v2 defaults (`|`, `^`, `~`, `\`, `&`, `\r`).
 
-- `node` (`Nodes`) — Any HL7v2 AST node (Root, Segment, Field, FieldRepetition, Component, or Subcomponent)
-- `delimiters` (`Delimiters`, optional) — Custom delimiters to use. If not provided, will use delimiters from Root node data or defaults
+Returns the serialized `string`.
 
-###### Returns
-
-HL7v2 string (`string`)
-
-This function is highly flexible and can convert any level of the HL7v2 hierarchy:
-
-```js
+```ts
 import { toHl7v2 } from "@glion/to-hl7v2";
 
-// Convert entire message
 toHl7v2(rootNode); // "MSH|^~\&|...\rPID|..."
-
-// Convert individual segment
 toHl7v2(segmentNode); // "PID|12345|DOE^JOHN"
-
-// Convert individual field
 toHl7v2(fieldNode); // "DOE^JOHN"
-
-// Convert component
 toHl7v2(componentNode); // "SUB1&SUB2"
 ```
 
-## Features
+## Round-trip guarantees
 
-- **Universal node support**: Can convert any HL7v2 AST node type (Root, Segment, Field, FieldRepetition, Component, Subcomponent)
-- **Delimiter preservation**: Uses the original delimiters from Root AST metadata
-- **Flexible delimiter handling**: Accepts custom delimiters or falls back to defaults
-- **MSH segment handling**: Correctly handles the special MSH segment structure
-- **Complete hierarchy support**: Supports all HL7v2 levels with proper delimiter usage
-- **Empty value handling**: Properly handles empty fields and components
-- **Error handling**: Provides clear error messages for unsupported node types
+- **Delimiter preservation** — custom delimiters set on `Root.data` (by the parser or by hand) carry through to the output. Messages that do not use the defaults round-trip correctly.
+- **MSH handling** — the special case where `MSH-1` is the field separator and `MSH-2` carries the encoding characters is encoded correctly on serialization.
+- **Empty fields and components** — preserved in position so field indexes remain stable.
+- **Every node type supported** — serializing a partial subtree produces the exact fragment you would expect to find embedded inside the full message.
 
-## Security
+Pair with `@glion/parser` to read HL7v2 in and `@glion/to-hl7v2` to write it back out; layer `@glion/encode-escapes` and `@glion/decode-escapes` in between to handle delimiter characters that appear in content values.
 
-This plugin only transforms AST nodes and does not execute code. Ensure you trust the source of HL7v2 messages before processing.
+## Part of Glion
 
-## Contributing
+`@glion/to-hl7v2` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## Code of Conduct
-
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
-
-## License
-
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
-
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
-
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/util-query/README.md
+++ b/packages/util-query/README.md
@@ -1,21 +1,18 @@
-# HL7v2 Query Utility
+# @glion/util-query
 
-A tiny helper for reading HL7v2 ASTs with familiar canonical paths.
+Reads HL7v2 ASTs using canonical paths like `PID-5[1].2.1` or `ORDER-ORC-1`.
 
-## Features
+## What it does
 
-- **Six verbs** – `parse`, `select`, `selectAll`, `value`, `matches`, `format`
-- **Canonical paths** – same syntax you see in HL7 specs
-- **Deep traversal** – walks nested groups automatically
-- **Zero fuss** – no options, no surprises, just results
+Provides six path-based helpers — `parse`, `select`, `selectAll`, `value`, `matches`, `format` — that operate on HL7v2 AST trees using the same path syntax found in HL7 specs. Paths can address segments (`PID`), groups (`ORDER`), nested groups and segments (`ORDER-TIMING-TQ1`), field repetitions (`PID-5[2]`), components (`PID-5[1].2`), and subcomponents (`PID-5[1].2.1`). Path parsing is memoized in an LRU cache so repeated lookups stay fast.
 
-## Installation
+## Install
 
 ```bash
 npm install @glion/util-query
 ```
 
-## Quick Start
+## Use
 
 ```typescript
 import {
@@ -44,7 +41,7 @@ if (pidSegment?.node.type === "segment") {
   console.log(`PID has ${pidSegment.node.children.length - 1} fields`);
 }
 
-// Multiple nodes: get all matching elements
+// Multiple nodes
 const allObservations = selectAll(ast, "OBX");
 for (const { node } of allObservations) {
   console.log(`Found observation: ${node.type}`);
@@ -57,14 +54,13 @@ if (matches(ast, "PID-5")) {
 
 // Path parsing
 const parsed = parse("ORDERS[2]-OBX-5[1].2.1");
-console.log(parsed);
 ```
 
 ## API
 
 ### `parse(path: string): PathParts`
 
-Breaks a canonical HL7 path into structured pieces. Helpful for tooling and diagnostics.
+Breaks a canonical HL7 path into structured pieces. Useful for tooling and diagnostics.
 
 ```typescript
 parse("PID-5[1].2.1");
@@ -76,6 +72,8 @@ parse("PID-5[1].2.1");
 //   subcomponent: 1
 // }
 ```
+
+`parse` memoizes up to 1,000 unique paths using an LRU cache so repeated lookups stay fast without leaking memory.
 
 ### `select<Path>(root: Root, path: Path): { node: InferNodeType<Path>; ancestors: Nodes[] } | null`
 
@@ -91,11 +89,9 @@ if (result) {
 
 The `ancestors` array follows the [`unist-util-visit-parents`](https://github.com/syntax-tree/unist-util-visit-parents) convention: it starts at the root node, ends with the immediate parent, and never includes the node itself. You can rely on `ancestors[ancestors.length - 1]` being the direct parent.
 
-`parse` memoizes up to 1,000 unique paths using an LRU cache so repeated lookups stay fast without leaking memory. Long-running processes can call `clearParseCache()` to release cached entries (or inspect `getParseCacheSize()` if diagnostics are needed).
-
 ### `selectAll<Path>(root: Root, path: Path): Array<{ node: InferNodeType<Path>; ancestors: Nodes[] }>`
 
-Returns all AST nodes (segments or groups) that match the path. Useful when a message contains multiple segments/groups of the same type.
+Returns all AST nodes that match the path. Useful when a message contains multiple segments or groups of the same type.
 
 ```typescript
 // Get all OBX segments
@@ -119,7 +115,7 @@ for (const { node } of values) {
 
 ### `value(root: Root, path: string): { value: string; node: Nodes; ancestors: Nodes[] } | null`
 
-Returns the string value stored at the path. If the node is not a subcomponent, it will walk through single-child layers (field → field repetition → component → subcomponent) automatically.
+Returns the string value stored at the path. If the node is not a subcomponent, it walks through single-child layers (field → field repetition → component → subcomponent) automatically.
 
 ```typescript
 const result = value(ast, "PID-3[1].1.1");
@@ -132,14 +128,13 @@ if (result) {
 
 ### `matches(root: Root, path: string): boolean`
 
-Returns `true` when the path points to an existing node, otherwise `false`. More semantically clear than checking for `null`.
+Returns `true` when the path points to an existing node, otherwise `false`.
 
 ```typescript
 if (!matches(ast, "OBX-5")) {
   throw new Error("Missing observation value");
 }
 
-// Use in conditionals
 if (matches(ast, "PID-5")) {
   const name = value(ast, "PID-5.1.1");
 }
@@ -171,20 +166,9 @@ Clears the memoized parse results. Useful for long-running services that want to
 
 ### `getParseCacheSize(): number`
 
-Returns the current number of cached path entries so you can monitor cache pressure in diagnostics or tests.
+Returns the current number of cached path entries so you can monitor cache pressure.
 
-## Path Cheatsheet
-
-- `SEGMENT` – segment (e.g. `PID`)
-- `SEGMENT-FIELD` – field (e.g. `PID-5`)
-- `SEGMENT-FIELD[REP]` – field repetition (e.g. `PID-5[2]`)
-- `SEGMENT-FIELD[REP].COMP` – component (e.g. `PID-5[1].2`)
-- `SEGMENT-FIELD[REP].COMP.SUB` – subcomponent (e.g. `PID-5[1].2.1`)
-- `GROUP[N]-...` – qualify with group name and optional repetition (e.g. `ORDERS[2]-OBX-5`)
-
-Repetition indexes are **1-based**. If you omit `[n]`, `find` assumes `[1]`.
-
-## Types
+### Types
 
 ```typescript
 type PathParts = {
@@ -197,91 +181,20 @@ type PathParts = {
 };
 ```
 
-## Common Recipes
+## Path format
 
-### Patient Demographics
+Canonical path grammar:
 
-```typescript
-const lastName = value(ast, "PID-5[1].1.1")?.value;
-const firstName = value(ast, "PID-5[1].2.1")?.value;
-const middleName = value(ast, "PID-5[1].3.1")?.value;
-const dob = value(ast, "PID-7[1].1.1")?.value;
-```
+- `SEGMENT` — segment (e.g., `PID`)
+- `SEGMENT-FIELD` — field (e.g., `PID-5`)
+- `SEGMENT-FIELD[REP]` — field repetition (e.g., `PID-5[2]`)
+- `SEGMENT-FIELD[REP].COMP` — component (e.g., `PID-5[1].2`)
+- `SEGMENT-FIELD[REP].COMP.SUB` — subcomponent (e.g., `PID-5[1].2.1`)
+- `GROUP[N]-...` — qualify with group name and optional repetition (e.g., `ORDERS[2]-OBX-5`)
 
-### Observations
+Repetition indexes are **1-based**. If you omit `[n]`, `select`/`value`/`matches` assume `[1]`.
 
-```typescript
-// Single observation
-const obx = select(ast, "OBX");
-const obsValue = value(ast, "OBX-5[1].1.1")?.value;
-const units = value(ast, "OBX-6[1].1.1")?.value;
-const refRange = value(ast, "OBX-7[1].1.1")?.value;
-
-// Multiple observations
-const allOBX = selectAll(ast, "OBX");
-for (const { node } of allOBX) {
-  const val = value(node, "OBX-5")?.value;
-  const units = value(node, "OBX-6")?.value;
-  console.log(`${val} ${units}`);
-}
-```
-
-### Validation
-
-```typescript
-if (!matches(ast, "MSH")) throw new Error("Missing message header");
-if (!matches(ast, "PID-3[1].1.1")) throw new Error("Missing patient ID");
-
-// Conditional processing
-if (matches(ast, "OBX")) {
-  const observations = selectAll(ast, "OBX");
-  console.log(`Found ${observations.length} observations`);
-}
-```
-
-## Path Format & Design Philosophy
-
-### Groups & Segments: Structure-Based Selection
-
-**Paths select whatever exists in the AST - segments OR groups:**
-
-```typescript
-// Groups are selectable!
-const orderGroup = select(ast, "ORDER");
-// Returns the ORDER group if it exists
-
-// Segments are selectable!
-const pidSegment = select(ast, "PID");
-// Returns the PID segment if it exists
-
-// Groups also serve as navigation
-select(ast, "ORDER-ORC"); // Navigate through ORDER to ORC segment
-select(ast, "ORDER-TIMING-TQ1"); // Navigate through nested groups
-
-// Field access definitively indicates segment access
-select(ast, "MSH-3"); // MSH must be a segment (has field access)
-select(ast, "ORDER-ORC-1"); // ORC must be a segment (has field access)
-```
-
-### How It Works
-
-1. **No field access (`NAME`)**: Returns segment OR group, whichever exists
-   - Type: `Segment | Group`
-   - Tries segments first, then groups
-2. **With field access (`NAME-N`)**: Must be a segment
-   - Type: `Field | Component | Subcomponent`
-   - Field numbers indicate you're accessing segment internals
-
-3. **AST as Source of Truth**: The actual message structure determines what's returned
-
-### Why This Approach?
-
-- ✅ **Maximum flexibility**: Works with any valid HL7v2 names (standard 3-char segments, longer group names, custom segments)
-- ✅ **Structure indicates intent**: Field access (`-N`) tells us it's definitively a segment
-- ✅ **Runtime correctness**: AST determines what exists, not parsing rules
-- ✅ **Type safety**: TypeScript infers `Segment | Group` vs specific segment children
-
-### Practical Examples
+Paths select whatever exists in the AST — segments or groups. A bare name (`NAME`) returns whichever exists, trying segments first; adding a field suffix (`NAME-N`) forces segment access because field numbers only apply to segments. Groups can also appear as navigation prefixes (`ORDER-ORC`, `ORDER-TIMING-TQ1-1`).
 
 ```typescript
 // Selecting groups directly
@@ -297,39 +210,59 @@ if (pid?.node.type === "segment") {
 }
 
 // Navigation through groups to segments
-value(ast, "ORDER-ORC-1"); // ✅ Order control
-value(ast, "ORDER-TIMING-TQ1-1"); // ✅ Timing quantity
-
-// If both segment and group have same name, segment is prioritized
-// (This is rare in practice since groups use descriptive names like ORDER, PATIENT)
+value(ast, "ORDER-ORC-1"); // Order control
+value(ast, "ORDER-TIMING-TQ1-1"); // Timing quantity
 ```
 
-## Error Messages
+## Common recipes
 
-- Invalid formats throw with guidance, e.g. `"Invalid HL7 path format: \"PID-\""`
-- Out-of-range indexes complain, e.g. `"Field number must be ≥1, got: 0"`
-- Whitespace is rejected to avoid accidental typos
+### Patient demographics
 
-## Contributing
+```typescript
+const lastName = value(ast, "PID-5[1].1.1")?.value;
+const firstName = value(ast, "PID-5[1].2.1")?.value;
+const middleName = value(ast, "PID-5[1].3.1")?.value;
+const dob = value(ast, "PID-7[1].1.1")?.value;
+```
 
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
+### Observations
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+```typescript
+// Single observation
+const obsValue = value(ast, "OBX-5[1].1.1")?.value;
+const units = value(ast, "OBX-6[1].1.1")?.value;
+const refRange = value(ast, "OBX-7[1].1.1")?.value;
 
-## Code of Conduct
+// Multiple observations
+const allOBX = selectAll(ast, "OBX");
+for (const { node } of allOBX) {
+  const val = value(node, "OBX-5")?.value;
+  const u = value(node, "OBX-6")?.value;
+  console.log(`${val} ${u}`);
+}
+```
 
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
+### Validation
 
-## License
+```typescript
+if (!matches(ast, "MSH")) throw new Error("Missing message header");
+if (!matches(ast, "PID-3[1].1.1")) throw new Error("Missing patient ID");
 
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
+if (matches(ast, "OBX")) {
+  const observations = selectAll(ast, "OBX");
+  console.log(`Found ${observations.length} observations`);
+}
+```
 
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
+## Error messages
 
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+- Invalid formats throw with guidance, e.g. `"Invalid HL7 path format: \"PID-\""`.
+- Out-of-range indexes throw, e.g. `"Field number must be ≥1, got: 0"`.
+- Whitespace is rejected to catch accidental typos.
+
+## Part of Glion
+
+`@glion/util-query` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
+
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/util-semver/README.md
+++ b/packages/util-semver/README.md
@@ -1,31 +1,31 @@
 # @glion/util-semver
 
-A tiny, fast, and secure version utility for HL7v2-like version strings. Intentionally simplified for our ecosystem while maintaining excellent performance and type safety.
+Parser, comparators, and range matcher for HL7v2-style numeric version strings.
 
-## Features
+## What it does
 
-✨ **Simple & Elegant** - Clean API, no unnecessary complexity
-⚡ **High Performance** - O(n) algorithms, Range caching for hot paths
-🔒 **Secure** - ReDoS protection, integer overflow guards
-📘 **Type Safe** - Full TypeScript support with structured errors
-🪶 **Tiny** - ~6KB, zero dependencies
+Parses, compares, and matches HL7v2 versions like `2.5.1` or `2.3`. Supports the `=`, `<`, `<=`, `>`, `>=` comparators and AND-combined ranges (`">=2.0 <3.0"`), plus helpers for sorting, increment, diff, and finding max/min versions that satisfy a range. Intentionally narrower than full semver: no prerelease, build metadata, wildcards, or `^`/`~` operators. Versions are capped at int32 and input lengths are bounded to protect against malformed input.
 
-## Installation
+## Install
 
 ```bash
 npm install @glion/util-semver
 ```
 
-## Quick Start
+## Use
 
 ```typescript
 import {
   parse,
   clean,
+  valid,
   compare,
+  eq,
+  gt,
   satisfies,
   sort,
   maxSatisfying,
+  minSatisfying,
   increment,
   diff,
   Range,
@@ -37,11 +37,11 @@ clean("2"); // "2.0.0"
 valid("2.5.1"); // true
 
 // Compare versions
-compare("2.3.1", "2.4"); // -1 (less than)
+compare("2.3.1", "2.4"); // -1
 eq("2.5.0", "2.5"); // true
 gt("2.5.1", "2.5.0"); // true
 
-// Version ranges
+// Ranges
 satisfies("2.5.1", ">=2.0 <3.0"); // true
 satisfies("2.5.1", "2.5.1"); // true (exact match)
 
@@ -50,14 +50,14 @@ sort(["2.5", "2.3.1", "2.10"]); // ["2.3.1", "2.5", "2.10"]
 maxSatisfying(["2.3", "2.5", "3.0"], ">=2.0 <3.0"); // "2.5"
 minSatisfying(["2.3", "2.5", "3.0"], ">=2.0 <3.0"); // "2.3"
 
-// Version manipulation
+// Manipulation
 increment("2.5.1", "minor"); // "2.6.0"
 diff("2.5.1", "2.6.0"); // "minor"
 ```
 
-## API Reference
+## API
 
-### Parsing & Validation
+### Parsing and validation
 
 #### `parse(version: string): Hl7Version`
 
@@ -69,11 +69,11 @@ parse("2.3"); // { major: 2, minor: 3, patch: 0 }
 parse("2"); // { major: 2, minor: 0, patch: 0 }
 ```
 
-**Throws:** `VersionParseError` if invalid format
+Throws `VersionParseError` if the format is invalid.
 
 #### `clean(version: string): string`
 
-Converts a version to canonical format (major.minor.patch).
+Converts a version to canonical `major.minor.patch` format.
 
 ```typescript
 clean("2"); // "2.0.0"
@@ -81,7 +81,7 @@ clean("2.5"); // "2.5.0"
 clean(" 2.5 "); // "2.5.0"
 ```
 
-**Throws:** `VersionParseError` if invalid format
+Throws `VersionParseError` if the format is invalid.
 
 #### `valid(version: string): boolean`
 
@@ -105,13 +105,13 @@ compare("2.5.1", "2.5.1"); // 0  (a = b)
 compare("2.6", "2.5.9"); // 1  (a > b)
 ```
 
-#### Comparison Operators
+#### Comparison operators
 
-- `eq(a, b)` - Equal to
-- `lt(a, b)` - Less than
-- `lte(a, b)` - Less than or equal
-- `gt(a, b)` - Greater than
-- `gte(a, b)` - Greater than or equal
+- `eq(a, b)` — equal to
+- `lt(a, b)` — less than
+- `lte(a, b)` — less than or equal
+- `gt(a, b)` — greater than
+- `gte(a, b)` — greater than or equal
 
 ```typescript
 eq("2.5.0", "2.5"); // true
@@ -119,17 +119,11 @@ lt("2.3", "2.4"); // true
 gte("2.5.1", "2.5"); // true
 ```
 
-### Range Matching
+### Range matching
 
 #### `satisfies(version, range): boolean`
 
 Checks if a version satisfies a range expression.
-
-**Range Syntax:**
-
-- Operators: `=`, `<`, `<=`, `>`, `>=`
-- Multiple comparators: Space-separated (AND logic)
-- Default operator: `=` (exact match)
 
 ```typescript
 satisfies("2.5.1", ">=2.0 <3.0"); // true
@@ -137,17 +131,9 @@ satisfies("2.5.1", "2.5.1"); // true (exact match)
 satisfies("2.5.1", ">=2.6"); // false
 ```
 
-**Performance Tip:** Use `Range` objects for repeated checks:
+For repeated checks, use a `Range` object to avoid re-parsing:
 
 ```typescript
-// Slow: Parse range every time
-for (const version of versions) {
-  if (satisfies(version, ">=2.0 <3.0")) {
-    /* ... */
-  }
-}
-
-// Fast: Parse once, reuse many times
 const range = new Range(">=2.0 <3.0");
 for (const version of versions) {
   if (satisfies(version, range)) {
@@ -156,7 +142,7 @@ for (const version of versions) {
 }
 ```
 
-#### `Range` Class
+#### `Range` class
 
 Pre-parsed range for efficient reuse.
 
@@ -171,15 +157,15 @@ maxSatisfying(versions, range);
 minSatisfying(versions, range);
 ```
 
-### Collection Operations
+### Collection operations
 
 #### `sort(versions: string[]): string[]`
 
-Sorts versions in ascending order. Returns new array (does not mutate).
+Sorts versions in ascending order. Returns a new array; does not mutate.
 
 ```typescript
 sort(["2.5", "2.3.1", "2.10.0"]);
-// => ["2.3.1", "2.5", "2.10.0"]
+// ["2.3.1", "2.5", "2.10.0"]
 ```
 
 #### `maxSatisfying(versions, range): string | null`
@@ -187,11 +173,8 @@ sort(["2.5", "2.3.1", "2.10.0"]);
 Finds the highest version that satisfies a range.
 
 ```typescript
-maxSatisfying(["2.3.0", "2.5.1", "3.0.0"], ">=2.0 <3.0");
-// => "2.5.1"
-
-maxSatisfying(["2.3.0", "2.5.1"], ">=3.0");
-// => null (no matches)
+maxSatisfying(["2.3.0", "2.5.1", "3.0.0"], ">=2.0 <3.0"); // "2.5.1"
+maxSatisfying(["2.3.0", "2.5.1"], ">=3.0"); // null
 ```
 
 #### `minSatisfying(versions, range): string | null`
@@ -199,11 +182,10 @@ maxSatisfying(["2.3.0", "2.5.1"], ">=3.0");
 Finds the lowest version that satisfies a range.
 
 ```typescript
-minSatisfying(["2.3.0", "2.5.1", "3.0.0"], ">=2.0 <3.0");
-// => "2.3.0"
+minSatisfying(["2.3.0", "2.5.1", "3.0.0"], ">=2.0 <3.0"); // "2.3.0"
 ```
 
-### Version Manipulation
+### Version manipulation
 
 #### `increment(version, release): string`
 
@@ -223,12 +205,10 @@ Determines which component differs between versions.
 diff("2.5.1", "3.0.0"); // "major"
 diff("2.5.1", "2.6.0"); // "minor"
 diff("2.5.1", "2.5.2"); // "patch"
-diff("2.5.1", "2.5.1"); // null (equal)
+diff("2.5.1", "2.5.1"); // null
 ```
 
-## Error Handling
-
-All parsing/operation functions throw structured errors for invalid input:
+### Errors
 
 ```typescript
 import { VersionParseError, RangeParseError } from "@glion/util-semver";
@@ -239,7 +219,6 @@ try {
   if (e instanceof VersionParseError) {
     console.log(e.input); // "INVALID"
     console.log(e.reason); // "expected format: major.minor.patch..."
-    console.log(e.message); // Full formatted message
   }
 }
 
@@ -247,105 +226,36 @@ try {
   satisfies("2.5.1", "INVALID_RANGE");
 } catch (e) {
   if (e instanceof RangeParseError) {
-    console.log(e.token); // "INVALID_RANGE"
-    console.log(e.reason); // "expected format: [operator]version..."
+    console.log(e.token);
+    console.log(e.reason);
   }
 }
 ```
 
-**Validation functions never throw:**
+- `valid(version)` never throws — returns `false` for invalid input.
+- `parse()`, `clean()`, `compare()`, `satisfies()`, etc. throw on invalid input.
 
-- `valid(version)` - Returns `false` for invalid input
+## Version comparison rules
 
-**Operation functions throw on invalid input:**
+### Version format
 
-- `parse()`, `clean()`, `compare()`, `satisfies()`, etc.
+- Generic numeric versions: `major[.minor][.patch]`.
+- Missing components default to 0: `"2"` → `{ major: 2, minor: 0, patch: 0 }`.
+- Whitespace is trimmed: `" 2.5.1 "` → `"2.5.1"`.
+- No prerelease or build metadata.
+- No wildcards, hyphen ranges, or `^`/`~` operators.
 
-## Performance
+### Range syntax
 
-### Algorithm Complexity
+Operators:
 
-- `parse()`, `compare()`: O(1)
-- `sort()`: O(n log n)
-- `maxSatisfying()`, `minSatisfying()`: O(n) - optimized to avoid full sort
-- Range parsing: O(k) where k = number of comparators
+- `=` or omitted — exact match
+- `<` — less than
+- `<=` — less than or equal
+- `>` — greater than
+- `>=` — greater than or equal
 
-### Optimization Tips
-
-**1. Reuse Range objects**
-
-```typescript
-// ❌ Slow: Parse range on every call
-for (const version of manyVersions) {
-  if (satisfies(version, ">=2.0 <3.0")) {
-    /* ... */
-  }
-}
-
-// ✅ Fast: Parse once, reuse unlimited times
-const range = new Range(">=2.0 <3.0");
-for (const version of manyVersions) {
-  if (satisfies(version, range)) {
-    /* ... */
-  }
-}
-```
-
-**2. Use appropriate algorithms**
-
-```typescript
-// ❌ Unnecessary: Full sort just to find max
-const sorted = sort(versions);
-const max = sorted[sorted.length - 1];
-
-// ✅ Efficient: O(n) instead of O(n log n)
-const max = maxSatisfying(versions, ">=0.0.0");
-```
-
-## Security
-
-Built-in protections against common vulnerabilities:
-
-**ReDoS Protection:**
-
-- Maximum input length: 100 chars (versions), 1000 chars (ranges)
-- Throws `VersionParseError` or `RangeParseError` if exceeded
-
-**Integer Overflow Protection:**
-
-- Version components capped at 2³¹-1 (max safe int32)
-- Ensures cross-platform interoperability
-- Throws `VersionParseError` if exceeded
-
-**Input Sanitization:**
-
-- Comprehensive validation rejects malformed input early
-- Structured errors for debugging
-
-## Version Format
-
-- **Generic numeric versions:** `major[.minor][.patch]`
-- **Missing components default to 0:** `"2"` → `{ major: 2, minor: 0, patch: 0 }`
-- **Whitespace is trimmed:** `" 2.5.1 "` → `"2.5.1"`
-- **No prerelease/build metadata**
-- **No wildcards, hyphen ranges, or `^`/`~` operators**
-
-## Range Syntax
-
-**Operators:**
-
-- `=` or omitted - Exact match
-- `<` - Less than
-- `<=` - Less than or equal
-- `>` - Greater than
-- `>=` - Greater than or equal
-
-**Multiple comparators:**
-
-- Space-separated for AND logic: `">=2.3 <3.0"`
-- All comparators must be satisfied
-
-**Examples:**
+Multiple comparators are space-separated with AND semantics — all must be satisfied:
 
 ```typescript
 "2.5.1"; // Exact match
@@ -354,26 +264,14 @@ Built-in protections against common vulnerabilities:
 ">=2.3 <2.6 >2.4"; // Multiple AND conditions
 ```
 
-## Contributing
+### Input limits
 
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
+- Versions are capped at 100 characters; ranges at 1000 characters. Longer inputs throw `VersionParseError` or `RangeParseError`.
+- Version components are capped at 2³¹−1; overflow throws `VersionParseError`.
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+## Part of Glion
 
-## Code of Conduct
+`@glion/util-semver` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
-
-## License
-
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
-
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
-
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/util-timestamp/README.md
+++ b/packages/util-timestamp/README.md
@@ -1,22 +1,18 @@
 # @glion/util-timestamp
 
-An immutable, high-performance HL7v2 timestamp utility with precision tracking. Parses, formats, and converts HL7v2 TS (Time Stamp) values while preserving precision for lossless round-tripping.
+HL7v2 timestamp parser, formatter, and converter with precision tracking.
 
-## Features
+## What it does
 
-- **Precision tracking** - 7 levels from year to millisecond, never loses or adds detail
-- **Lossless round-trip** - `Timestamp.parse(str).toString() === str` for all valid inputs
-- **High performance** - No regex, no intermediate arrays, pre-computed lookup tables
-- **Type safe** - Full TypeScript support with const enums and union types
-- **Zero dependencies** - Pure computation, no runtime dependencies
+Parses, formats, and converts HL7v2 TS (Time Stamp) values across seven precision levels — year, month, day, hour, minute, second, millisecond — so that `Timestamp.parse(str).toString() === str` for any valid input. Timezone offsets are applied during parsing so `toDate()` returns the correct absolute moment, and reconstructed during formatting so the original local-time representation round-trips exactly regardless of the server's timezone. Pure computation, zero runtime dependencies.
 
-## Installation
+## Install
 
 ```bash
 npm install @glion/util-timestamp
 ```
 
-## Quick Start
+## Use
 
 ```typescript
 import { Timestamp, Precision } from "@glion/util-timestamp";
@@ -36,13 +32,13 @@ const now = Timestamp.now({ precision: "second", timezone: true });
 now.toString(); // "20260307143045+0000"
 ```
 
-## API Reference
+## API
 
 ### `Timestamp.parse(value: string): Timestamp`
 
 Parses an HL7v2 timestamp string into a `Timestamp` instance.
 
-Accepts the full HL7v2 TS format: `YYYY[MM[DD[HH[MM[SS[.S[S[S[S]]]]]]]]][+/-ZZZZ]`
+Accepts the full HL7v2 TS format: `YYYY[MM[DD[HH[MM[SS[.S[S[S[S]]]]]]]]][+/-ZZZZ]`.
 
 ```typescript
 Timestamp.parse("2026"); // year precision
@@ -56,7 +52,7 @@ Timestamp.parse("20260307143045-0500"); // with timezone offset
 Timestamp.parse("20260307143045.12+0000"); // fractional + timezone
 ```
 
-**Throws:** `TypeError` if the string is not a valid HL7v2 timestamp.
+Throws `TypeError` if the string is not a valid HL7v2 timestamp.
 
 ### `Timestamp.from(date: Date, options?: TimestampOptions): Timestamp`
 
@@ -71,7 +67,7 @@ Timestamp.from(date, { precision: "millisecond" }).toString(); // "2026030714304
 Timestamp.from(date, { timezone: true }).toString(); // "20260307143045+0000"
 ```
 
-**Throws:** `TypeError` if the `Date` is invalid (`NaN`).
+Throws `TypeError` if the `Date` is invalid (`NaN`).
 
 ### `Timestamp.now(options?: TimestampOptions): Timestamp`
 
@@ -84,13 +80,13 @@ Timestamp.now({ precision: "minute" }).toString(); // "202603071430"
 Timestamp.now({ timezone: true }).toString(); // "20260307143045+0000"
 ```
 
-### Instance Properties
+### Instance properties
 
 #### `precision: Precision`
 
 The precision level of the timestamp. One of: `"year"`, `"month"`, `"day"`, `"hour"`, `"minute"`, `"second"`, `"millisecond"`.
 
-### Instance Methods
+### Instance methods
 
 #### `toString(): string`
 
@@ -130,7 +126,18 @@ Precision.Second; // "second"      → YYYYMMDDHHmmss
 Precision.Millisecond; // "millisecond" → YYYYMMDDHHmmss.SSSS
 ```
 
-## Precision Tracking
+### Error handling
+
+All invalid input throws `TypeError` with a descriptive message:
+
+```typescript
+Timestamp.parse(""); // TypeError: Invalid HL7v2 timestamp: ""
+Timestamp.parse("not-a-timestamp"); // TypeError: Invalid HL7v2 timestamp: "not-a-timestamp"
+Timestamp.parse("20263"); // TypeError: Invalid HL7v2 timestamp: "20263"
+Timestamp.from(new Date("invalid")); // TypeError: Invalid Date provided to Timestamp.from
+```
+
+## Precision model
 
 Precision is a first-class concept. The timestamp remembers exactly how much detail was provided, so formatting never inflates or truncates:
 
@@ -147,42 +154,33 @@ Timestamp.from(date, { precision: "day" }).toString(); // "20260307"
 Timestamp.from(date, { precision: "minute" }).toString(); // "202603071430"
 ```
 
-## Timezone Management
+### Timezone handling
 
-Timezone information is embedded directly in the `Date` object — not stored as separate public metadata. This ensures that `toDate()` always returns the correct absolute moment, and `toString()` always reproduces the original timezone for lossless round-tripping.
-
-### Correct Absolute Moments
+Timezone information is embedded directly in the `Date` object — not stored as separate public metadata. This ensures `toDate()` always returns the correct absolute moment, and `toString()` always reproduces the original timezone for lossless round-tripping.
 
 When an HL7v2 timestamp includes a timezone offset (`+/-ZZZZ`), the offset is applied during parsing to construct a `Date` with the correct UTC instant:
 
 ```typescript
 // 14:30:45 in UTC-5 → Date stores 19:30:45 UTC
-const ts = Timestamp.parse("20260307143045-0500");
-ts.toDate().toISOString(); // "2026-03-07T19:30:45.000Z"
+Timestamp.parse("20260307143045-0500").toDate().toISOString();
+// "2026-03-07T19:30:45.000Z"
 
 // 14:30:45 in UTC+5:30 → Date stores 09:00:45 UTC
-const ts2 = Timestamp.parse("20260307143045+0530");
-ts2.toDate().toISOString(); // "2026-03-07T09:00:45.000Z"
+Timestamp.parse("20260307143045+0530").toDate().toISOString();
+// "2026-03-07T09:00:45.000Z"
 
 // Midnight in UTC+5:30 → previous day in UTC
-const ts3 = Timestamp.parse("20260101000000+0530");
-ts3.toDate().toISOString(); // "2025-12-31T18:30:00.000Z"
+Timestamp.parse("20260101000000+0530").toDate().toISOString();
+// "2025-12-31T18:30:00.000Z"
 ```
-
-### Lossless Round-Trip with Timezone
 
 Parsed timestamps with timezone offsets round-trip exactly, regardless of the server's timezone:
 
 ```typescript
-// On ANY server (UTC, EST, PST, IST):
 Timestamp.parse("20260307143045-0500").toString(); // "20260307143045-0500"
 Timestamp.parse("20260307143045+0530").toString(); // "20260307143045+0530"
 Timestamp.parse("20261231235959.999-0800").toString(); // "20261231235959.999-0800"
 ```
-
-The timezone offset is stored internally and used by `toString()` to reconstruct the original local time components from UTC. No public `timezoneOffset` property is exposed — this prevents the data integrity risk of consumers calling `toDate()` and forgetting to account for a separate offset.
-
-### Creating Timestamps with Timezone
 
 When using `from()` or `now()` with `{ timezone: true }`, the runtime's local timezone offset is captured at creation time:
 
@@ -191,8 +189,6 @@ const ts = Timestamp.from(new Date(), { timezone: true });
 ts.toString(); // "20260307143045-0500" (on a UTC-5 server)
 ```
 
-### Without Timezone
-
 Timestamps without a timezone offset are treated as local time — no UTC conversion is applied:
 
 ```typescript
@@ -200,7 +196,7 @@ const ts = Timestamp.parse("20260307143045");
 // Date is constructed with new Date(2026, 2, 7, 14, 30, 45) — local time
 ```
 
-### Precision Gate
+### Precision gate on timezone
 
 Timezone is only included at `"hour"` precision or finer. Coarser precisions (`"year"`, `"month"`, `"day"`) never carry a timezone suffix:
 
@@ -212,47 +208,9 @@ Timestamp.from(date, { precision: "hour", timezone: true }).toString();
 // "2026030714-0500" — timezone included
 ```
 
-## Performance
+## Part of Glion
 
-Optimized for high-throughput streaming processors handling 100K+ messages per second:
+`@glion/util-timestamp` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-- **No regex** — manual character-based parsing via `codePointAt` arithmetic
-- **No intermediate arrays** — direct string concatenation in `toString()`
-- **Pre-computed lookup table** — zero-padded strings for 0-99
-- **O(1) precision lookups** — `Map` instead of `Array.indexOf()`
-- **Zero allocations in hot paths** — no substring extraction or `Number()` conversions
-
-## Error Handling
-
-All invalid input throws `TypeError` with a descriptive message:
-
-```typescript
-Timestamp.parse(""); // TypeError: Invalid HL7v2 timestamp: ""
-Timestamp.parse("not-a-timestamp"); // TypeError: Invalid HL7v2 timestamp: "not-a-timestamp"
-Timestamp.parse("20263"); // TypeError: Invalid HL7v2 timestamp: "20263"
-Timestamp.from(new Date("invalid")); // TypeError: Invalid Date provided to Timestamp.from
-```
-
-## Contributing
-
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## Code of Conduct
-
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
-
-## License
-
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
-
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
-
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/util-visit/README.md
+++ b/packages/util-visit/README.md
@@ -1,32 +1,14 @@
 # @glion/util-visit
 
-## Introduction
+Visitor for traversing HL7v2 AST trees with ancestor context, depth, and HL7v2-aware sequence numbers.
 
-This package provides a lightweight, type-safe visitor pattern for traversing [HL7v2 AST][hl7v2-ast] trees. Built on top of the battle-tested [unist-util-visit-parents][], it adds HL7v2-specific context while delegating core traversal to a proven implementation.
+## What it does
 
-### What is this?
-
-`hl7v2-util-visit` enables you to walk through any HL7v2 AST tree — from the root message down to individual subcomponents — with full context about where you are in the hierarchy. The visitor pattern:
-
-- **Works from any starting node** (Root, Segment, Field, Component, etc.)
-- **Tracks ancestors** from traversal root to current node
-- **Provides visit info** (index, sequence, depth, metadata)
-- **Efficient O(n) traversal** — Pre-computed index map for O(1) lookups
-- **Battle-tested core** — Delegates traversal to `unist-util-visit-parents`
-
-### When should I use this?
-
-Use `hl7v2-util-visit` when you need to:
-
-- Validate HL7v2 message structure
-- Transform or annotate AST nodes
-- Extract specific fields with context
-- Analyze message patterns across the tree
-- Implement custom processing rules that need parent/ancestor awareness
+Walks an HL7v2 AST from any starting node — Root, Segment, Field, Component, or Subcomponent — calling a visitor function for each matching node. Each call receives the node, its ancestors (root-to-parent), and a `VisitInfo` record with index, HL7v2 sequence number, depth, and extracted metadata. Supports filtering by type string, property object, or predicate, and exposes `SKIP`/`EXIT` control actions. Delegates core traversal to `unist-util-visit-parents` and pre-computes sibling indices for O(1) lookups.
 
 ## Install
 
-```sh
+```bash
 npm install @glion/util-visit
 ```
 
@@ -42,8 +24,6 @@ const message = parse("MSH|^~\\&|...\rPID|...");
 visit(message, "segment", (node, ancestors, info) => {
   console.log(`Segment: ${info.metadata?.header} at depth ${info.depth}`);
 });
-// => Segment: MSH at depth 2
-// => Segment: PID at depth 2
 
 // Find fields with parent context
 visit(message, "field", (node, ancestors, info) => {
@@ -54,7 +34,7 @@ visit(message, "field", (node, ancestors, info) => {
 // Skip processing of sensitive segments
 visit(message, (node, ancestors, info) => {
   if (node.type === "segment" && info.metadata?.header === "NTE") {
-    return SKIP; // Skip NTE segment children
+    return SKIP;
   }
 });
 ```
@@ -69,37 +49,37 @@ Visit nodes in an HL7v2 AST tree.
 
 #### Parameters
 
-- **`tree`** (`Nodes`) — Tree to traverse (can be any node type, not just Root)
-- **`test`** (`string | Partial<Nodes> | Test`) — Optional filter:
-  - `string`: Match nodes by type (e.g., `'segment'`)
-  - `Partial<Nodes>`: Match nodes with matching properties (e.g., `{ name: 'PATIENT_GROUP' }`)
-  - `Test`: Custom function `(node, ancestors) => boolean`
-- **`visitor`** (`Visitor`) — Function called for each matching node
+- `tree` (`Nodes`) — Tree to traverse. Can be any node type, not just `Root`.
+- `test` (`string | Partial<Nodes> | Test`, optional) — Filter:
+  - `string` — Match nodes by type (e.g., `"segment"`).
+  - `Partial<Nodes>` — Match nodes with matching properties (e.g., `{ name: "PATIENT_GROUP" }`).
+  - `Test` — Custom function `(node, ancestors) => boolean`.
+- `visitor` (`Visitor`) — Function called for each matching node.
 
 #### Returns
 
-`void`
+`void`.
 
-#### Important: Test vs Visitor Functions
+#### Important: test vs visitor functions
 
 **If you pass a function as the second argument, it is always treated as a Visitor, never as a Test.**
 
 ```typescript
-// WRONG - testFn will be treated as a visitor, not a test
+// WRONG — testFn will be treated as a visitor, not a test
 visit(ast, (node) => node.type === 'segment', ...); // Missing visitor!
 
-// CORRECT - Explicit 3-argument form
+// CORRECT — Explicit 3-argument form
 visit(ast, (node) => node.type === 'segment', (node, ancestors, info) => {
   console.log('Visiting segment');
 });
 
-// CORRECT - Use string or object for simple tests
+// CORRECT — Use string or object for simple tests
 visit(ast, 'segment', (node, ancestors, info) => {
   console.log('Visiting segment');
 });
 ```
 
-#### Visitor Function
+#### Visitor function
 
 ```typescript
 type Visitor<T extends Nodes = Nodes> = (
@@ -111,17 +91,17 @@ type Visitor<T extends Nodes = Nodes> = (
 
 The visitor receives:
 
-- **`node`** — Current AST node
-- **`ancestors`** — Array of ancestor nodes from root to parent (not including current node)
-- **`info`** — Visit information with index, sequence, depth, and metadata
+- `node` — Current AST node.
+- `ancestors` — Array of ancestor nodes from root to parent (not including current node).
+- `info` — Visit information with index, sequence, depth, and metadata.
 
 The visitor can return:
 
-- `undefined` or `void` — Continue traversal normally
-- `SKIP` — Skip children of current node
-- `EXIT` — Stop traversal immediately
+- `undefined` or `void` — Continue traversal normally.
+- `SKIP` — Skip children of current node.
+- `EXIT` — Stop traversal immediately.
 
-### VisitInfo
+### `VisitInfo`
 
 ```typescript
 interface VisitInfo {
@@ -139,28 +119,27 @@ interface VisitInfo {
 }
 ```
 
-**Important**: `index` and `sequence` represent the node's **position in the tree**, not its position among filtered results. For example:
+`index` and `sequence` represent the node's **position in the tree**, not its position among filtered results:
 
 ```typescript
 // Structure: MSH segment with fields at positions 1, 2, 3, 4
 // Filter matches only field 3
-
 visit(
   ast,
   (n) => n.type === "field" && hasContent(n),
   (node, ancestors, info) => {
-    console.log(info.sequence); // => 3 (position in segment, not "1st match")
+    console.log(info.sequence); // 3 (position in segment, not "1st match")
   }
 );
 ```
 
 This is correct because HL7v2 paths like `PID.3` refer to tree positions, not filtered positions.
 
-### Automatic Metadata Extraction
+### Automatic metadata extraction
 
-The `metadata` field is populated automatically with common metadata:
+The `metadata` field is populated automatically:
 
-| Node Type | Metadata Key | Description                                 |
+| Node type | Metadata key | Description                                 |
 | --------- | ------------ | ------------------------------------------- |
 | `segment` | `header`     | Segment identifier (e.g., `"MSH"`, `"PID"`) |
 | `group`   | `name`       | Group name (e.g., `"PATIENT_GROUP"`)        |
@@ -185,7 +164,7 @@ import type {
 
 ## Examples
 
-### Filter by Node Type
+### Filter by node type
 
 ```typescript
 visit(ast, "segment", (node, ancestors, info) => {
@@ -193,7 +172,7 @@ visit(ast, "segment", (node, ancestors, info) => {
 });
 ```
 
-### Filter by Properties
+### Filter by properties
 
 ```typescript
 visit(ast, { name: "PATIENT_GROUP" }, (node, ancestors, info) => {
@@ -201,7 +180,7 @@ visit(ast, { name: "PATIENT_GROUP" }, (node, ancestors, info) => {
 });
 ```
 
-### Custom Test Function
+### Custom test function
 
 ```typescript
 // Visit fields in MSH segment only
@@ -217,21 +196,17 @@ visit(
 );
 ```
 
-### Access Parent and Ancestors
+### Access parent and ancestors
 
 ```typescript
 visit(ast, "component", (node, ancestors, info) => {
-  // Get immediate parent
   const parent = ancestors.at(-1);
-
-  // Find closest segment ancestor
   const segment = ancestors.findLast((n) => n.type === "segment");
-
   console.log(`Component at depth ${info.depth}`);
 });
 ```
 
-### Control Flow: Skip Children
+### Control flow: skip children
 
 ```typescript
 visit(ast, (node, ancestors, info) => {
@@ -241,13 +216,13 @@ visit(ast, (node, ancestors, info) => {
 });
 ```
 
-### Control Flow: Exit Early
+### Control flow: exit early
 
 ```typescript
-import { EXIT } from '@glion/util-visit';
+import { EXIT } from "@glion/util-visit";
 
 let found = false;
-visit(ast, 'field', (node, ancestors, info) => {
+visit(ast, "field", (node, ancestors, info) => {
   if (/* some condition */) {
     found = true;
     return EXIT; // Stop traversal completely
@@ -255,7 +230,7 @@ visit(ast, 'field', (node, ancestors, info) => {
 });
 ```
 
-### Start from Any Node
+### Start from any node
 
 ```typescript
 import { s, f, c } from "@glion/builder";
@@ -269,14 +244,13 @@ visit(segment, "field", (node, ancestors, info) => {
 });
 ```
 
-### Track Nesting Levels
+### Track nesting levels
 
 ```typescript
 visit(ast, (node, ancestors, info) => {
   const indent = "  ".repeat(info.depth - 1);
   console.log(`${indent}${node.type} [${info.sequence}]`);
 });
-// Output:
 // root [1]
 //   segment [1]
 //     segment-header [0]
@@ -285,11 +259,10 @@ visit(ast, (node, ancestors, info) => {
 //         component [1]
 ```
 
-### Group Hierarchy Navigation
+### Group hierarchy navigation
 
 ```typescript
 visit(ast, "segment", (node, ancestors, info) => {
-  // Get all parent groups
   const groups = ancestors
     .filter((n) => n.type === "group")
     .map((n) => (n as any).name)
@@ -297,12 +270,10 @@ visit(ast, "segment", (node, ancestors, info) => {
 
   console.log(`${info.metadata?.header} is in groups: ${groups.join(" > ")}`);
 });
-// => PID is in groups: PATIENT_GROUP
+// PID is in groups: PATIENT_GROUP
 ```
 
-## Real-World Use Cases
-
-### Validate Required Fields
+### Validate required fields
 
 ```typescript
 function validateRequiredFields(ast: Root): string[] {
@@ -312,12 +283,10 @@ function validateRequiredFields(ast: Root): string[] {
     const segment = node as Segment;
     const header = info.metadata?.header;
 
-    // MSH segment must have at least 12 fields
     if (header === "MSH" && segment.children.length < 12) {
-      errors.push(`MSH segment missing required fields`);
+      errors.push("MSH segment missing required fields");
     }
 
-    // PID segment must have patient ID (PID.3)
     if (header === "PID") {
       const patientId = segment.children[3];
       if (!patientId || patientId.children.length === 0) {
@@ -330,7 +299,7 @@ function validateRequiredFields(ast: Root): string[] {
 }
 ```
 
-### Extract Specific Data with Context
+### Extract data with context
 
 ```typescript
 interface PatientName {
@@ -350,7 +319,6 @@ function extractPatientNames(ast: Root): PatientName[] {
     if (nameField?.children[0]?.children[0]) {
       const nameComponent = nameField.children[0].children[0];
       const name = (nameComponent.children[0] as Subcomponent)?.value || "";
-
       const groupAncestor = ancestors.find((n) => n.type === "group");
 
       names.push({
@@ -365,46 +333,7 @@ function extractPatientNames(ast: Root): PatientName[] {
 }
 ```
 
-### Message Structure Analysis
-
-```typescript
-interface MessageStructure {
-  segmentCount: number;
-  groupCount: number;
-  maxDepth: number;
-  segmentTypes: Record<string, number>;
-}
-
-function analyzeStructure(ast: Root): MessageStructure {
-  const structure: MessageStructure = {
-    segmentCount: 0,
-    groupCount: 0,
-    maxDepth: 0,
-    segmentTypes: {},
-  };
-
-  visit(ast, (node, ancestors, info) => {
-    structure.maxDepth = Math.max(structure.maxDepth, info.depth);
-
-    if (node.type === "segment") {
-      structure.segmentCount++;
-      const header = info.metadata?.header as string;
-      if (header) {
-        structure.segmentTypes[header] =
-          (structure.segmentTypes[header] || 0) + 1;
-      }
-    }
-
-    if (node.type === "group") {
-      structure.groupCount++;
-    }
-  });
-
-  return structure;
-}
-```
-
-### Find First Match and Exit
+### Find first match and exit
 
 ```typescript
 function findFirstObservation(ast: Root, targetCode: string): string | null {
@@ -420,7 +349,7 @@ function findFirstObservation(ast: Root, targetCode: string): string | null {
     if (code === targetCode) {
       const valueField = segment.children[5];
       result = valueField?.children[0]?.children[0]?.children[0]?.value || null;
-      return EXIT; // Stop traversal
+      return EXIT;
     }
   });
 
@@ -428,59 +357,9 @@ function findFirstObservation(ast: Root, targetCode: string): string | null {
 }
 ```
 
-## Architecture
+## Part of Glion
 
-This library is a thin wrapper around [unist-util-visit-parents][] that adds HL7v2-specific features:
+`@glion/util-visit` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-1. **Core Traversal**: Delegates to `unist-util-visit-parents` (battle-tested with 50M+ weekly downloads)
-2. **Index Optimization**: Pre-computes node indices for O(1) lookups (avoids O(n²) `indexOf` calls)
-3. **HL7v2 Context**: Adds `VisitInfo` with sequence numbers, depth tracking, and metadata extraction
-4. **Domain Conventions**: Implements HL7v2-specific indexing (segment-header sequence = 0, fields = 1,2,3...)
-
-This design gives us:
-
-- ✅ Proven traversal logic (EXIT/SKIP handling, edge cases)
-- ✅ Mutation support (inherited from unist)
-- ✅ Reverse traversal support (pass `reverse: true` to underlying library)
-- ✅ Small codebase (~120 lines vs previous ~180 lines)
-- ✅ Ecosystem compatibility (works with other unist utilities)
-
-## Performance Characteristics
-
-- **O(n) traversal** — Single pass through all nodes
-- **O(n) index pre-computation** — One-time upfront cost
-- **O(1) index lookups** — Avoids O(n²) `indexOf()` anti-pattern
-- **O(d) ancestor construction** where d = depth (typically < 10 for HL7v2)
-- **Minimal allocations** — Metadata extracted once per node
-
-## Types
-
-```typescript
-export type {
-  VisitInfo, // { index, sequence, depth, metadata }
-  Visitor, // (node, ancestors, info) => VisitorResult
-  VisitorResult, // void | false | 'skip' | ActionTuple
-  Test, // string | Partial | predicate | null
-  Predicate, // (node, ancestors) => boolean
-} from "@glion/util-visit";
-```
-
-## Contributing
-
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
-
-## Code of Conduct
-
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
-
-## License
-
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
-
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). See the [LICENSE][github-license] file for details.
-
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
-[hl7v2-ast]: https://github.com/rethinkhealth/glion/tree/main/packages/hl7v2-ast
-[unist-util-visit-parents]: https://github.com/syntax-tree/unist-util-visit-parents
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,33 +1,54 @@
 # @glion/utils
 
-A utility package for working with HL7v2 messages, most commonly used within the `@glion/hl7v2` ecosystem — a unist-inspired collection of plugins and utilities designed to parse, transform, validate, and manipulate HL7v2 messages.
+Shared helpers for HL7v2 AST work — diagnostics reporting, length/byte measurement, and conformance checks.
 
-This package provides core utilities including:
+## What it does
 
-- Diagnostic reporting system for linters, validators, and transformers
-- Standard HL7v2 delimiters
-- AST node utility functions
-- Conformance validation utilities (cardinality, length, optionality)
+Provides the low-level utilities used across the Glion ecosystem: a `report()` function for emitting diagnostics onto a `VFile`, `getLength`/`getByteLength` for measuring any AST node without serializing it, and stateless `checkOptionality`/`checkCardinality`/`checkLength` conformance validators. Linters and transformers reach for this package to avoid reimplementing these primitives.
 
-## Installation
+## Install
 
 ```bash
 npm install @glion/utils
+```
+
+## Use
+
+```typescript
+import { report, getByteLength, checkCardinality } from "@glion/utils";
+import type { Diagnostic } from "@glion/utils";
+import { VFile } from "vfile";
+
+const rule: Diagnostic = {
+  type: "lint",
+  namespace: "field",
+  code: "required",
+  title: "Required Field Missing",
+  description: "A required field is missing from the segment.",
+  severity: "error",
+  message: (ctx) => `Field '${ctx.fieldPath}' is required`,
+};
+
+const file = new VFile();
+report(file, rule, { context: { fieldPath: "PID-5" }, node: segmentNode });
+
+const bytes = getByteLength(segmentNode);
+const result = checkCardinality(fieldNode, 1, 5);
 ```
 
 ## API
 
 ### `report(file, rule, options?)`
 
-Report a diagnostic to a VFile. This function is the standard way to report issues in the HL7v2 ecosystem.
+Reports a diagnostic to a VFile. This is the standard way to report issues across Glion linters, validators, and transformers.
 
 #### Parameters
 
-- `file` (`VFile | null | undefined`) - The VFile to report to
-- `rule` (`Diagnostic`) - The diagnostic rule definition
-- `options` (`ReportOptions`, optional)
-  - `node` (`Node`, optional) - The AST node related to the diagnostic
-  - `context` (`Record<string, unknown>`, optional) - Context data passed to the diagnostic's message function
+- `file` (`VFile | null | undefined`) — The VFile to report to.
+- `rule` (`Diagnostic`) — The diagnostic rule definition.
+- `options` (`ReportOptions`, optional):
+  - `node` (`Node`, optional) — The AST node related to the diagnostic.
+  - `context` (`Record<string, unknown>`, optional) — Context data passed to the diagnostic's `message` function.
 
 #### Example
 
@@ -36,7 +57,6 @@ import { report } from "@glion/utils";
 import type { Diagnostic } from "@glion/utils";
 import { VFile } from "vfile";
 
-// Define a diagnostic rule
 const requiredFieldRule: Diagnostic = {
   type: "lint",
   namespace: "field",
@@ -48,7 +68,6 @@ const requiredFieldRule: Diagnostic = {
   helpUrl: "https://example.com/docs/required-field",
 };
 
-// Report the diagnostic
 const file = new VFile();
 report(file, requiredFieldRule, {
   context: { fieldPath: "PID-5" },
@@ -58,25 +77,23 @@ report(file, requiredFieldRule, {
 
 ### `getByteLength(node)`
 
-Calculate the byte length of any HL7v2 AST node. This utility efficiently computes the total serialized length including all children and separators (assumed to be 1 byte each).
+Calculates the byte length of any HL7v2 AST node. Efficiently computes the total serialized length including all children and separators (assumed to be 1 byte each).
 
 #### Parameters
 
-- `node` (`Nodes | null | undefined`) - The AST node to measure
+- `node` (`Nodes | null | undefined`) — The AST node to measure.
 
 #### Returns
 
-`number` - The total byte length when the node is serialized
+`number` — The total byte length when the node is serialized.
 
 #### Algorithm
 
-- For literal nodes (Subcomponent, SegmentHeader): returns the byte length of the value using UTF-8 encoding (i.e., `Buffer.byteLength(value, 'utf8')`)
-- For parent nodes: recursively sums the byte length of all children plus 1 byte per separator between children
-- Handles all node types: Root, Segment, Group, Field, FieldRepetition, Component, Subcomponent
+- For literal nodes (Subcomponent, SegmentHeader): returns the byte length of the value using UTF-8 encoding (i.e., `Buffer.byteLength(value, 'utf8')`).
+- For parent nodes: recursively sums the byte length of all children plus 1 byte per separator between children.
+- Handles all node types: Root, Segment, Group, Field, FieldRepetition, Component, Subcomponent.
 
-#### Performance
-
-The function is optimized for performance with O(n) time complexity where n is the total number of nodes in the tree. It uses a simple recursive approach with minimal overhead.
+O(n) time complexity where n is the total number of nodes in the tree.
 
 #### Example
 
@@ -106,88 +123,42 @@ const field: Field = {
 const length = getByteLength(field); // Returns: 10
 ```
 
-#### Use Cases
-
-- Validating field or message size constraints
-- Memory allocation planning
-- Message size reporting and analytics
-- Performance optimization by avoiding full serialization
-
 ### `getLength(node)`
 
-Calculate the string length of any HL7v2 AST node. This utility efficiently computes the total serialized character length including all children and separators (assumed to be 1 character each).
+Calculates the string length of any HL7v2 AST node. Efficiently computes the total serialized character length including all children and separators (assumed to be 1 character each).
 
 #### Parameters
 
-- `node` (`Nodes | null | undefined`) - The AST node to measure
+- `node` (`Nodes | null | undefined`) — The AST node to measure.
 
 #### Returns
 
-`number` - The total string length when the node is serialized
+`number` — The total string length when the node is serialized.
 
 #### Algorithm
 
-- For literal nodes (Subcomponent, SegmentHeader): returns `value.length` (JavaScript string length)
-- For parent nodes: recursively sums the string length of all children plus 1 character per separator between children
-- Handles all node types: Root, Segment, Group, Field, FieldRepetition, Component, Subcomponent
+- For literal nodes (Subcomponent, SegmentHeader): returns `value.length` (JavaScript string length).
+- For parent nodes: recursively sums the string length of all children plus 1 character per separator between children.
+- Handles all node types: Root, Segment, Group, Field, FieldRepetition, Component, Subcomponent.
 
-#### Important Note
+#### Important note
 
 Returns JavaScript string length (UTF-16 code units). For UTF-8 byte length (e.g., for wire protocol or size constraints), use `getByteLength` instead. These values differ for characters outside the ASCII range.
 
-#### Performance
-
-The function is optimized for performance with O(n) time complexity where n is the total number of nodes in the tree. It uses a simple recursive approach with minimal overhead.
-
 #### Example
-
-```typescript
-import { getLength } from "@glion/utils";
-import type { Field } from "@glion/ast";
-
-const field: Field = {
-  type: "field",
-  children: [
-    {
-      type: "field-repetition",
-      children: [
-        {
-          type: "component",
-          children: [
-            { type: "subcomponent", value: "SMITH" },
-            { type: "subcomponent", value: "JOHN" },
-          ],
-        },
-      ],
-    },
-  ],
-};
-
-// Calculate: SMITH&JOHN = 5 + 1 + 4 = 10 characters
-const length = getLength(field); // Returns: 10
-```
-
-#### Use Cases
-
-- UI display and text formatting
-- Character-based validation rules
-- String manipulation operations
-- Quick length checks where byte-level precision is not required
-
-#### Comparison with `getByteLength`
 
 ```typescript
 import { getLength, getByteLength } from "@glion/utils";
 
 const subcomponent = { type: "subcomponent", value: "café" };
 
-getLength(subcomponent); // Returns: 4 (4 characters)
-getByteLength(subcomponent); // Returns: 5 (5 bytes in UTF-8: c-a-f-C3-A9)
+getLength(subcomponent); // 4 (4 characters)
+getByteLength(subcomponent); // 5 (5 bytes in UTF-8: c-a-f-C3-A9)
 ```
 
-### Conformance Utilities
+### Conformance utilities
 
-The package provides stateless, composable functions to validate HL7v2 AST nodes against constraints like optionality (usage), cardinality, and length.
+Stateless, composable functions to validate HL7v2 AST nodes against constraints like optionality (usage), cardinality, and length.
 
 #### `ValidationResult`
 
@@ -211,9 +182,9 @@ type ValidationResult =
 
 Checks if a node satisfies the optionality (usage) constraint.
 
-- **node**: `Nodes | undefined` - The AST node to check.
-- **optionality**: `string` - The usage code (e.g., 'R', 'O', 'X').
-- **Returns**: `ValidationResult`
+- `node` (`Nodes | undefined`) — The AST node to check.
+- `optionality` (`string`) — The usage code (e.g., `'R'`, `'O'`, `'X'`).
+- Returns `ValidationResult`.
 
 ```typescript
 import { checkOptionality } from "@glion/utils";
@@ -230,10 +201,10 @@ if (!result.ok) {
 
 Checks if a field has the correct number of repetitions.
 
-- **node**: `Field | undefined` - The field node to check.
-- **min**: `number` - Minimum repetitions.
-- **max**: `number | '*'` - Maximum repetitions.
-- **Returns**: `ValidationResult`
+- `node` (`Field | undefined`) — The field node to check.
+- `min` (`number`) — Minimum repetitions.
+- `max` (`number | '*'`) — Maximum repetitions.
+- Returns `ValidationResult`.
 
 ```typescript
 import { checkCardinality } from "@glion/utils";
@@ -246,10 +217,10 @@ const result = checkCardinality(myFieldNode, 1, 5);
 
 Checks if the content of a node falls within the minimum and maximum length.
 
-- **node**: `Nodes | undefined` - The node to check (length is calculated recursively).
-- **max**: `number` - Maximum length.
-- **min**: `number` (optional, default: 0) - Minimum length.
-- **Returns**: `ValidationResult`
+- `node` (`Nodes | undefined`) — The node to check (length is calculated recursively).
+- `max` (`number`) — Maximum length.
+- `min` (`number`, optional, default `0`) — Minimum length.
+- Returns `ValidationResult`.
 
 ```typescript
 import { checkLength } from "@glion/utils";
@@ -261,26 +232,9 @@ const result = checkLength(myNode, 10, 1);
 const result2 = checkLength(myNode, 10);
 ```
 
-## Contributing
+## Part of Glion
 
-We welcome contributions! Please see our [Contributing Guide][github-contributing] for more details.
+`@glion/utils` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## Code of Conduct
-
-To ensure a welcoming and positive environment, we have a [Code of Conduct][github-code-of-conduct] that all contributors and participants are expected to adhere to.
-
-## License
-
-Copyright 2025 Rethink Health, SUARL. All rights reserved.
-
-This program is licensed to you under the terms of the [MIT License](https://opensource.org/licenses/MIT). This program is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [LICENSE][github-license] file for details.
-
-[github-code-of-conduct]: https://github.com/rethinkhealth/glion/blob/main/CODE_OF_CONDUCT.md
-[github-license]: https://github.com/rethinkhealth/glion/blob/main/LICENSE
-[github-contributing]: https://github.com/rethinkhealth/glion/blob/main/CONTRIBUTING.md
+[Glion]: https://github.com/rethinkhealth/glion#readme
+[Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/turbo/generators/templates/README.md.hbs
+++ b/turbo/generators/templates/README.md.hbs
@@ -30,7 +30,7 @@
 
 # @glion/{{name}}
 
-> {{description}}
+{{description}}
 
 ## What it does
 
@@ -40,10 +40,8 @@
 ## Install
 
 ```bash
-pnpm add @glion/{{name}}
+npm install @glion/{{name}}
 ```
-
-> Using npm? `npm install @glion/{{name}}`
 
 ## Use
 


### PR DESCRIPTION
Phase 3 of 4. Completes the per-package README standardization by rewriting every remaining existing README to match the template locked in Phase 1.

**Stacked on [#597](https://github.com/rethinkhealth/glion/pull/597)** — this PR targets `feat/per-package-readme-phase2` so the diff shows only the 25 rewrites. When #597 merges to main, this PR auto-retargets to main.

## Ecosystem milestone

Combined with Phase 2, the full 41-package public ecosystem now passes `pnpm check:readmes` — **41 successful, 41 total, 2 private skipped**. Every `@glion/*` npm page has a compliant README.

## Summary by unit

**Unit 6 — 9 runtime + core rewrites**

| Package | Notable | Size |
|---|---|---|
| `mllp` | **Voice fix:** stripped 8 Hono-style references and the "Hono/Koa onion model" phrasing. Removed the embedded "Glion CLI" sub-section (now lives in `@glion/cli`). Full server/middleware/primitives API preserved. | 486 → ~290 lines |
| `hl7v2` | Expanded from 86 lines to template-sized; new `## Pipeline` section showing the default `parseHL7v2` composition. | 86 → ~180 lines |
| `builder` | **Voice fix:** renamed `## Philosophy` section to factual prose. | 140 → ~110 lines |
| `ack`, `mllp-ack`, `parser`, `ast`, `to-hl7v2`, `jsonify` | Structural conformance; API content preserved. | - |

**Unit 7 — 3 plugin rewrites** (`decode-escapes`, `encode-escapes`, `annotate-profile-fields`)
- Escape codecs: `## Behavior` sections with input/output tables for every escape sequence; inverse relationship cross-linked.
- `annotate-profile-fields`: `## What it annotates` with the full `FieldData` augmentation table preserved.

**Unit 8 — 7 linting rewrites**
- `preset-lint-recommended`: **voice fix** — removed the "ESLint's recommended but for HL7v2" analogy.
- 5 core lint rules: mirrored the Phase 2 profile-lint structural shape → coherent 14-rule family across the two presets.
- `lint-segment-header-length`: **correctness fix** — previous README documented options (`allow`, ASCII-uppercase check) the source doesn't implement. Now matches the actual length-only behaviour.
- `lint-profile-events-segments-order`: flattened validation/resolution error breakdown into `## What it checks` with verbatim message strings.

**Unit 9 — 6 utility + config rewrites** (all size reductions via pruning marketing prose, kept real API surface)

| Package | Before | After |
|---|---|---|
| `utils` | 286 | 240 |
| `util-visit` | 486 | 365 |
| `util-query` | 335 | 268 (**voice fix:** "Path Format & Design Philosophy" → "Path format") |
| `util-semver` | 379 | 277 |
| `util-timestamp` | 258 | 216 |
| `config` | 390 | 315 |

## Voice cleanup — zero residue across all 25

- `grep -i 'hono' packages/mllp/README.md` → 0
- `grep -i 'philosophy' packages/builder/README.md packages/util-query/README.md` → 0
- `grep -i 'eslint' packages/preset-lint-recommended/README.md` → 0
- Dropped `## Contributing` / `## Code of Conduct` / `## License` / `## Security` / `## Related` sections from every file — replaced by the canonical `## Part of Glion` footer.

## Execution

Dispatched 4 parallel subagents (one per unit). Unit 6's agent hit context cap after completing 6 of 9 files (voice fix on `builder` did land); I finished `mllp`, `to-hl7v2`, and `jsonify` inline, preserving and manually verifying the Hono-strip.

## Testing

- `pnpm check:readmes` → **41 successful, 41 total, 2 private skipped**.
- `pnpm check` → 0 warnings, 0 errors.
- Each of the 25 rewrites was verified individually via `pnpm turbo run check:readme --filter=@glion/<name>`.

## Follow-ups

- **Phase 4** — flip `continue-on-error: true` off the CI advisory step (tracked in [#595](https://github.com/rethinkhealth/glion/issues/595)); unblocks once both #597 and this PR merge.
- [#589](https://github.com/rethinkhealth/glion/issues/589) — separately correct the `@glion/profiles` `package.json` description.
- Generator template currently missing `publint` entry (noted during prior merge; small follow-up).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this PR changes documentation (25 README files) with no runtime or deployment impact. After merge, spot-check a handful of npm package pages (`@glion/mllp`, `@glion/util-visit`, `@glion/hl7v2`) to confirm the new READMEs render.

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>