### PR TITLE
fix(profiles): correct misleading package.json description

### DIFF
--- a/packages/profiles/package.json
+++ b/packages/profiles/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@glion/profiles",
   "version": "0.15.1",
-  "description": "hl7v2 plugin to parse hl7v2 messages",
+  "description": "HL7v2 version-specific profile definitions (fields, data types, tables, segments) with LRU-cached loading",
   "keywords": [
     "health",
     "healthcare",


### PR DESCRIPTION
Closes #589.

## The bug

`packages/profiles/package.json` has read `"description": "hl7v2 plugin to parse hl7v2 messages"` since before the `@rethinkhealth/*` → `@glion/*` rename. The description is wrong — `@glion/profiles` is not a parser. It contains the HL7v2 version-specific profile data (segments, fields, data types, tables, event structures, code systems) with LRU-cached loaders, consumed by the profile-based annotation plugins (`@glion/annotate-profile-*`) and the profile lint rules (`@glion/lint-profile-*`).

Before this fix, npm's package page and search results for `@glion/profiles` misrepresented what the package does.

## The fix

One-line change — replace the description with wording that matches the package's actual purpose:

```diff
-  "description": "hl7v2 plugin to parse hl7v2 messages",
+  "description": "HL7v2 version-specific profile definitions (fields, data types, tables, segments) with LRU-cached loading",
```

This matches the description already used in:

- The `@glion/profiles` README (landed in #597).
- The root README's Packages → Unified layer → Utilities catalog.
- The README tagline: "HL7v2 version-specific profile data — segments, fields, datatypes, and tables — with LRU-cached loaders."

## Testing

One-field edit; nothing to build or test. Verified the file is valid JSON (`node -e 'JSON.parse(require("fs").readFileSync("packages/profiles/package.json","utf8"))'` exits 0).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: package.json metadata change only, no runtime or build impact. After the next release of `@glion/profiles`, spot-check the npm package page to confirm the updated description shows.

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>