### PR TITLE
chore(tools): add publint to the turbo generator template

### DIFF
--- a/turbo/generators/templates/package.json.hbs
+++ b/turbo/generators/templates/package.json.hbs
@@ -34,7 +34,8 @@
     "check:readme": "glion-check-readme",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "publint": "publint --strict"
   },
   "devDependencies": {
     "@glion/check-readme": "workspace:*",
@@ -42,6 +43,7 @@
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^24.10.1",
     "@vitest/coverage-v8": "4.0.18",
+    "publint": "0.3.18",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "4.0.18"


### PR DESCRIPTION
Closes a silent drift introduced when publint landed as a per-package turbo task (#593). At that time, publint was added to every existing `packages/*/package.json` but **not** to `turbo/generators/templates/package.json.hbs`. As a result, any package scaffolded via `turbo gen package` since then ships without a `publint` script or devDep — meaning a new package could merge without running the packaging check.

## The fix

Two-line addition to the template, matching the convention across all existing public packages:

```diff
   "scripts": {
     "build": "tsup && tsc --emitDeclarationOnly",
     "check-types": "tsc --noEmit",
     "check:readme": "glion-check-readme",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "publint": "publint --strict"
   },
   "devDependencies": {
     "@glion/check-readme": "workspace:*",
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^24.10.1",
     "@vitest/coverage-v8": "4.0.18",
+    "publint": "0.3.18",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "4.0.18"
   },
```

## Verification

Scaffolded a throwaway package via `npx turbo gen package publint-template-verify "..."`. The generated `package.json` contained:

```
"publint": "publint --strict"
"publint": "0.3.18"
```

Throwaway package removed after verify. No changes to any shipped package.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: template-only change. Effect is observable the next time someone scaffolds a package via `turbo gen package`.

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>