### PR TITLE
fix(tsconfig): stop skipping declaration emit on rebuild

### DIFF
--- a/packages/profiles/tsconfig.build.json
+++ b/packages/profiles/tsconfig.build.json
@@ -1,13 +1,8 @@
 {
   "extends": "@glion/tsconfig/library.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "strictNullChecks": true,
-    "composite": false,
     "noResolve": true,
-    "types": ["node"],
-    "skipLibCheck": true
+    "types": ["node"]
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist", "src/profiles/v*", "src/profiles/utg"]
+  "exclude": ["src/profiles/v*", "src/profiles/utg"]
 }

--- a/tools/tsconfig/library.json
+++ b/tools/tsconfig/library.json
@@ -3,7 +3,6 @@
   "display": "Monorepo",
   "extends": "./base.json",
   "compilerOptions": {
-    "composite": true,
     "declaration": true,
     "declarationMap": true
   }


### PR DESCRIPTION
## Problem

`pnpm publint` on `@glion/cli` failed with `pkg.exports["."].types is ./dist/run.d.ts but the file does not exist`. Root cause: `composite: true` in `tools/tsconfig/library.json` made `tsc` cache incremental state in `tsconfig.build.tsbuildinfo` at the package root — outside `dist/`. So `rm -rf dist && pnpm build` left the cache intact, tsc saw the project as up-to-date, and emitted zero declarations. Any publint run after a partial clean would fail.

Reproduced across multiple packages (glion, mllp, parser) — a systemic latent bug, not a glion-specific one.

## Fix

Drop `composite: true` from the shared `library.json`. No package uses TypeScript project references (`tsc -b` / `"references"`), so composite was buying nothing; Turbo already handles cross-package caching at the task level. Cold `tsc --emitDeclarationOnly` for a single package is ~1s, so the incremental cache wasn't saving real time either.

Secondary: trimmed `packages/profiles/tsconfig.build.json` down to just the fields that actually diverge from the inherited base (`noResolve`, `types: ["node"]`, and the `v*`/`utg` excludes). The removed fields — `outDir`, `strictNullChecks`, `skipLibCheck`, `composite: false`, `include: ["src"]`, redundant `exclude` entries — all match the base or are no-ops.

## Verification

- `turbo run build --force` — 41/41 packages build cold.
- `turbo run publint` — 82/82 pass.
- `rm -rf dist && pnpm build` across glion/mllp/parser — all `.d.ts` files emit each time.
- No `.tsbuildinfo` files are regenerated anywhere.
- `turbo run check-types --force --continue` — 42/43 pass (one pre-existing `check-readme` failure on `main`, unrelated).