### PR TITLE
chore: changeset for post-0.15.2 cleanup + retrospective release-notes

### DIFF
--- a/.changeset/post-readme-arc-cleanup.md
+++ b/.changeset/post-readme-arc-cleanup.md
@@ -1,0 +1,11 @@
+---
+"@glion/hl7v2": patch
+---
+
+Workspace tooling and documentation cleanup following the README standardization arc (Phases 1–4, released in 0.15.2 alongside the publint packaging-hygiene fix). All public `@glion/*` packages now have template-compliant READMEs on npm, and CI enforces the template on every PR going forward.
+
+- **Generator template.** `turbo gen package` now scaffolds new packages with the `publint` script and devDep, so newly created packages automatically participate in the packaging-check CI step (#602).
+- **Contributor guidance.** `CLAUDE.md` refreshed with the current `@glion/*` package catalog and the `packages/` vs. `tools/` split introduced during the README standardization (#601).
+- **TSConfig base.** The shared `@glion/tsconfig` base no longer sets `composite`, eliminating stale `tsbuildinfo` issues when rebuilding after source edits (#603). Consumers that extend `@glion/tsconfig/library.json` for standard compilation are unaffected; consumers relying on TypeScript project-references may need to declare `composite` explicitly in their own `tsconfig.json`.
+
+No runtime API changes.


### PR DESCRIPTION
Adds a changeset covering the three PRs that merged after the 0.15.2 release (#594) with no accompanying changeset, plus a retrospective acknowledgement of the README standardization arc that shipped quietly in 0.15.2.

## Context

The 0.15.2 release fired automatically via the Changesets Action as soon as PR #593 landed the `packaging-hygiene.md` changeset — the `fixed: [["@glion/*", "@glion/cli"]]` lockstep config meant every `@glion/*` package bumped together. That carried the full README standardization arc (Phases 1–4 — #590, #592, #597, #598, #599, #600) onto npm at 0.15.2 as a side effect. The new READMEs are live on npm across all 41 packages.

The **changelog narrative** for 0.15.2 only described the `@glion/annotate-delimiters` packaging-hygiene fix. The README arc got no callout — a minor documentation debt.

Three additional PRs merged after #594:

| PR | What it does |
|---|---|
| [#601](https://github.com/rethinkhealth/glion/pull/601) | Refresh `CLAUDE.md` with current package catalog and `packages/` vs. `tools/` split |
| [#602](https://github.com/rethinkhealth/glion/pull/602) | Add `publint` script + devDep to the `turbo gen package` template |
| [#603](https://github.com/rethinkhealth/glion/pull/603) | Drop `composite` from the shared `@glion/tsconfig` base |

None of them have a changeset, so nothing on main is queued for the next release.

## The fix

A single patch-level changeset that:

1. Bundles the three post-#594 PRs as the queue for 0.15.3.
2. Retrospectively calls out the README standardization arc that shipped in 0.15.2, giving it a narrative home in the changelog history.
3. Flags the potential TSConfig behavior change for consumers relying on `composite` project references (they'll now need to declare it themselves).

Because of `fixed` lockstep, naming one package propagates the bump to all `@glion/*` siblings. The changeset names `@glion/hl7v2` as the narrative anchor.

## What happens on merge

1. This PR merges to main.
2. The Changesets Action fires and opens a new Version Packages PR titled `chore: update versions`, targeting 0.15.3 for every `@glion/*` package.
3. Review and merge that PR.
4. The Changesets Action's publish step runs `pnpm ci:publish`, uploading the 41 public packages to npm.

## Testing

- Changeset file syntax verified: frontmatter names `@glion/hl7v2` at `patch` level.
- No code changes in this PR — changeset-only.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this PR adds a single changeset file. Once the release fires, spot-check a handful of npm package pages (`@glion/hl7v2`, `@glion/profiles`, `@glion/mllp`, `@glion/cli`) to confirm 0.15.3 is live with the expected CHANGELOG.md additions.

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>