### PR TITLE
feat(ci): add continuous preview releases with pkg.pr.new (#540)

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,6 +10,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   preview:
     name: Publish preview to pkg.pr.new

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,32 @@
+name: Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    name: Publish preview to pkg.pr.new
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm ci:install
+      - name: Build all packages
+        run: pnpm build
+      - name: Publish preview to pkg.pr.new
+        run: npx pkg-pr-new publish './packages/*' --compact --pnpm

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Build all packages
         run: pnpm build
       - name: Publish preview to pkg.pr.new
-        run: npx pkg-pr-new publish './packages/*' --compact --pnpm
+        run: pnpm exec pkg-pr-new publish './packages/*' --compact --pnpm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,8 +123,6 @@ Run `pnpm build && pnpm publint` locally before pushing. CI enforces the same ch
 
 Every PR and every commit on `main` publishes preview packages to [pkg.pr.new](https://pkg.pr.new) via `.github/workflows/preview.yml`. The pkg.pr.new bot posts install commands as a PR comment so reviewers and bug reporters can validate a change before it is released to npm. See [ADR 0016](./docs/adr/0016-continuous-preview-releases.md) for rationale.
 
-Operational note: the pkg.pr.new GitHub App must be installed on the repository for the workflow to succeed. This is a one-time repo-admin action outside the code.
-
 <!-- omit in toc -->
 
 ## Attribution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,14 @@ Run `pnpm build && pnpm publint` locally before pushing. CI enforces the same ch
 
 <!-- omit in toc -->
 
+## Preview Releases
+
+Every PR and every commit on `main` publishes preview packages to [pkg.pr.new](https://pkg.pr.new) via `.github/workflows/preview.yml`. The pkg.pr.new bot posts install commands as a PR comment so reviewers and bug reporters can validate a change before it is released to npm. See [ADR 0016](./docs/adr/0016-continuous-preview-releases.md) for rationale.
+
+Operational note: the pkg.pr.new GitHub App must be installed on the repository for the workflow to succeed. This is a one-time repo-admin action outside the code.
+
+<!-- omit in toc -->
+
 ## Attribution
 
 This guide is based on the **contributing-gen**. [Make your own](https://github.com/bttger/contributing-gen)!

--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ Glion is pre-1.0. APIs in published packages are stabilizing but may still chang
 
 _Packages were previously published under `@rethinkhealth/hl7v2-*` and were renamed to `@glion/*`. The unscoped `glion` command is published as `@glion/cli` pending npm name approval._
 
+### Preview releases
+
+Every pull request and every commit on `main` publishes preview packages to [pkg.pr.new](https://pkg.pr.new). Install an unreleased fix or feature by its commit SHA, without waiting for a Changesets release:
+
+```bash
+pnpm add https://pkg.pr.new/@glion/parser@<commit-sha>
+```
+
+Replace `@glion/parser` with any published `@glion/*` package. Preview URLs are surfaced as a bot comment on each open PR. See [ADR 0016](./docs/adr/0016-continuous-preview-releases.md) for rationale and scope.
+
 ## Contributing
 
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for more details.

--- a/docs/adr/0016-continuous-preview-releases.md
+++ b/docs/adr/0016-continuous-preview-releases.md
@@ -71,10 +71,12 @@ steps:
       cache: "pnpm"
   - run: pnpm ci:install
   - run: pnpm build
-  - run: npx pkg-pr-new publish './packages/*' --compact --pnpm
+  - run: pnpm exec pkg-pr-new publish './packages/*' --compact --pnpm
 ```
 
 No test or lint gate. CI already reports test/lint/publint status on the same PR next to the preview comment; duplicating those gates here would waste CI minutes and couple the preview path to signals it does not need.
+
+`pkg-pr-new` is pinned as an exact-version root devDependency, consistent with ADR 0015 section 3 — any tool that publishes artifacts on our behalf must be reproducible across runs and upgradeable via a reviewed PR rather than silently resolved by `npx` at runtime. The workflow invokes it via `pnpm exec` so every run uses the version in `pnpm-lock.yaml`.
 
 Flag rationale:
 
@@ -140,3 +142,4 @@ The pkg.pr.new GitHub App must be installed on `rethinkhealth/glion` before the 
 ## History
 
 - 2026-04-21: Proposed.
+- 2026-04-21: Pinned `pkg-pr-new` as an exact-version root devDependency and switched the workflow from `npx` to `pnpm exec` so the CLI version is reproducible across runs and governed by the same supply-chain hygiene as other build-shaping tools (ADR 0015 §3).

--- a/docs/adr/0016-continuous-preview-releases.md
+++ b/docs/adr/0016-continuous-preview-releases.md
@@ -1,0 +1,142 @@
+# ADR 0016: Continuous Preview Releases with pkg.pr.new
+
+## Status
+
+Proposed
+
+## Context
+
+Glion ships ~40 packages under the `@glion/*` scope via Changesets on merges to `main` (see ADR 0015 and `.github/workflows/release.yml`). This release cadence is the right default for consumers who want stable versions, but it creates a feedback gap for the people who need a build _before_ it reaches npm:
+
+- **Bug reporters.** A downstream integrator files an issue, a maintainer opens a fix PR, and the reporter now has to choose between (a) installing from a git URL, which does not trigger our build pipeline and ships raw TypeScript, (b) cloning the repo locally and `pnpm link`-ing, or (c) waiting for the next Changesets release. All three paths are high-friction, and (c) can be days away if the fix lands behind other unreleased changes.
+- **Cross-team reviewers.** When a PR changes AST shape, lint behavior, or plugin ordering, the most useful review signal is "did this break my integration?" — a question only answerable by running the candidate code against a real consumer project. Without preview packages, reviewers are limited to reading the diff and reasoning about impact.
+- **Internal consumers.** Other teams at rethinkhealth that depend on `@glion/*` cannot validate an unreleased fix before we publish it. Any bug we ship is already in their lockfiles before they know.
+
+The effect is that releases carry more risk than they should. We discover integration issues after npm publish instead of before, and the feedback loop from "fix proposed" to "fix verified" is measured in release cycles rather than commits.
+
+### Why not expand the existing release pipeline
+
+Four approaches were considered as alternatives to a separate preview system:
+
+1. **Pre-release tags on npm** (e.g. `@glion/parser@0.5.0-next.abc1234`). Works, but pollutes the real npm registry with one version per commit, requires managing dist-tags, and consumers end up installing artifacts that look like real releases. Also couples preview integrity to our npm scope's trust posture from ADR 0015 — a compromise of the preview path becomes a compromise of the release path.
+2. **Publish to a private npm registry.** Adds infrastructure (registry hosting, auth, lifecycle) for a use case that is inherently public-facing (external bug reporters need to install without a token).
+3. **Git-URL installs.** Already possible today. Does not build the package, so consumers get source TypeScript without the `exports` map, types, or bundled output. Fails the moment a consumer uses the package as its `exports` map declares.
+4. **`pnpm link` or workspace checkout.** Requires the consumer to clone Glion and maintain a local build. Not a viable workflow for external reporters.
+
+None of these solve the "install by commit SHA, verify, throw away" workflow that bug triage and PR review actually need.
+
+### Why pkg.pr.new
+
+[pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new) (from the StackBlitz team) publishes package tarballs to a separate registry keyed by commit SHA, with a URL format like `https://pkg.pr.new/@glion/parser@{sha}` that `pnpm add` accepts directly. It is purpose-built for this workflow. Specifically:
+
+- **Separate registry.** Preview artifacts never touch npm. The real release path in ADR 0015 is unaffected; there is no shared credential, no dist-tag entanglement, no risk of a preview being mistaken for a release.
+- **Commit-addressed, not version-addressed.** Consumers install `https://pkg.pr.new/@glion/parser@{sha}` — no version-bump negotiation, no dist-tag juggling. The SHA is the identity.
+- **Automatic PR comments.** On every PR, a comment appears with ready-to-paste install commands for each package that changed. This is the feature that makes the workflow usable: reviewers do not have to construct URLs by hand.
+- **Zero npm credentials.** Publishes are authorized via a GitHub App installation, not an `NPM_TOKEN`. There is no new secret to rotate, and a token exfiltration cannot cross over from previews into the real release path.
+- **No lifecycle management.** Preview packages expire on the pkg.pr.new side. We do not accumulate a graveyard of per-commit versions that we have to clean up.
+
+The trade-off is an external dependency (pkg.pr.new's service and the GitHub App) that is not under our control. This is acceptable because the preview channel is not on the critical path for anything: if pkg.pr.new is down, bug triage falls back to the pre-existing (slow) workflows. Releases continue to flow through ADR 0015's pipeline unaffected.
+
+## Decision
+
+Glion will publish preview packages on every PR and every push to `main` via pkg.pr.new, configured as a new standalone GitHub Actions workflow that is independent of both CI and the Changesets release pipeline.
+
+### 1. Workflow file: `.github/workflows/preview.yml`
+
+A new workflow, not an addition to `ci.yml` or `release.yml`:
+
+- **Separate from `ci.yml`** because preview publishing and CI signal have different semantics. A failed preview publish should not turn CI red; a failing test should not block a preview from reaching a bug reporter (it is still installable; the failure is visible via the CI status on the same PR).
+- **Separate from `release.yml`** because previews are explicitly _not_ releases. Mixing them increases the chance that a future change to one path accidentally affects the other, and obscures the boundary that ADR 0015 depends on.
+- **Single job**, single matrix leg (Node 22 on `ubuntu-latest`). Previews do not need a Node-version matrix — the published tarball is the same regardless of publisher Node version, and the e2e/matrix coverage already lives in `ci.yml`.
+
+### 2. Triggers
+
+- `pull_request` on `opened`, `synchronize`, `reopened` — republishes preview on each push to a PR branch.
+- `push` on `main` — gives every mainline commit a retrievable preview URL.
+- **Forks are not supported in v1.** Using `pull_request` (safe) rather than `pull_request_target` (runs trusted workflow against untrusted PR code) means PRs from forks do not receive a preview comment. Glion's contributor base today is small and primarily organizational; revisit when external contributions become routine.
+
+### 3. Published package scope
+
+`./packages/*` — all public workspace packages. pkg.pr.new auto-skips packages marked `"private": true`, and `tools/*` is outside the glob entirely. This makes the preview set identical to the release set, so "what pkg.pr.new publishes" and "what Changesets publishes" stay in sync by construction.
+
+### 4. Workflow steps
+
+```yaml
+steps:
+  - uses: actions/checkout@v5
+  - uses: pnpm/action-setup@v4
+  - uses: actions/setup-node@v4
+    with:
+      node-version: 22.x
+      cache: "pnpm"
+  - run: pnpm ci:install
+  - run: pnpm build
+  - run: npx pkg-pr-new publish './packages/*' --compact --pnpm
+```
+
+No test or lint gate. CI already reports test/lint/publint status on the same PR next to the preview comment; duplicating those gates here would waste CI minutes and couple the preview path to signals it does not need.
+
+Flag rationale:
+
+- `--compact` — uses the short URL form `https://pkg.pr.new/@glion/parser@{sha}` instead of the long `https://pkg.pr.new/rethinkhealth/glion/...`. Requires the GitHub App to be installed on the repo (enforced by pkg.pr.new).
+- `--pnpm` — packs tarballs via `pnpm publish` semantics, matching the real release tooling from ADR 0015 so preview and release artifacts have the same shape.
+
+### 5. Workflow permissions
+
+- `contents: read` — checkout.
+- `pull-requests: write` — required for the pkg.pr.new bot to post install-command comments on PRs.
+- **No** `id-token: write` — pkg.pr.new uses the GitHub App installation, not OIDC-to-npm. The release workflow's OIDC privileges are not extended to this workflow.
+
+### 6. Manual prerequisite
+
+The pkg.pr.new GitHub App must be installed on `rethinkhealth/glion` before the workflow will succeed. This is a one-time repo-admin action and cannot be scripted. The README and CONTRIBUTING docs will point to the preview URL pattern once the App is installed.
+
+### 7. Explicitly out of scope for v1
+
+- **StackBlitz playground templates.** The upstream issue (#540) marks this "optional" and no concrete consumer has asked. Adding later is a purely additive change and does not require revisiting this ADR.
+- **Preview publishing on forked PRs.** Covered above; not worth the `pull_request_target` security complexity today.
+- **Test/lint gating.** See section 4.
+
+## Consequences
+
+### Positive
+
+1. **Faster bug-fix feedback loops.** "Fix proposed → fix verified in consumer's environment" drops from release-cycle-length to single-commit-length. Bug reporters can install the fix the moment a PR is updated.
+2. **Better PR review signal.** Reviewers can install the candidate package into their own integration and run it against real data before approving, instead of reasoning about diff impact abstractly.
+3. **Release quality rises.** Because previews catch integration issues before merge, the npm releases produced by the Changesets pipeline are more likely to be known-good.
+4. **No blast radius into the release path.** Previews use a separate registry, separate credentials (GitHub App), and a separate workflow file. A failure or compromise in the preview path cannot propagate into npm publishing.
+5. **Preview set equals release set by construction.** Using the same `./packages/*` glob that Changesets publishes means we cannot accidentally preview something that will not release, or vice versa.
+
+### Negative
+
+1. **External service dependency.** pkg.pr.new is a third-party service run by the StackBlitz team. If it goes down, the preview workflow fails. This is acceptable because no release path depends on pkg.pr.new and the pre-existing bug-triage fallbacks (git URL, clone + link) still work.
+2. **Additional GitHub Actions minutes.** Every PR push and every merge to `main` now runs a build-and-publish cycle. Roughly one extra `pnpm build` per PR update. Mitigated by not running tests again (they run in `ci.yml`) and by pnpm's store cache.
+3. **GitHub App install is an operational dependency.** Setting up the repo requires a repo admin to install the pkg.pr.new GitHub App. This is a one-time cost but a non-code step that a fresh clone of the repo cannot reproduce.
+4. **No preview coverage for forked PRs.** External contributors cannot receive a preview link on their own PRs. Workaround is for a maintainer to push the branch to an internal fork; long-term fix is revisiting `pull_request_target`.
+
+### Neutral
+
+1. **Preview URLs are public.** Anyone who sees the commit SHA can install the preview. This is the whole point and is consistent with Glion being an open-source project, but it means secrets must never be committed (already enforced by ADR 0015 and the secret-scanning defaults on GitHub).
+2. **Preview packages do not carry provenance.** pkg.pr.new does not produce sigstore attestations. ADR 0015 section 2 targets provenance for npm releases only; previews are explicitly out of scope. A consumer who cares about provenance uses the npm release, not a preview.
+
+## Alternatives Considered
+
+- **npm pre-release tags (`-next.sha`, `-pr.123`).** Rejected. Pollutes the real registry with one version per commit, couples preview trust posture to release trust posture (ADR 0015), and requires dist-tag lifecycle management. Previews and releases should not share a blast radius.
+- **Private npm registry (Verdaccio, GitHub Packages).** Rejected. Adds infrastructure for a use case that must be externally reachable — bug reporters cannot authenticate to an internal registry.
+- **Git-URL installs (status quo).** Does not build the package; ships raw TypeScript without the `exports` map or types; fails for any consumer that imports via the `exports` entry points. Fine for "clone and hack" but not for "install and verify."
+- **`pull_request_target` for fork support.** Considered and rejected for v1. The security model requires us to carefully avoid running PR-controlled scripts, and the contributor base today does not justify the complexity. Revisit if external PRs become routine.
+- **Gate preview publishing on full CI passing.** Rejected. CI status is already visible on the PR; duplicating the gate here wastes minutes and makes the preview path fail for reasons unrelated to the package itself (e.g. a flaky e2e test). Consumers who care can check the PR's CI badge before installing.
+- **Append a preview step to `ci.yml`'s testing job.** Rejected. The testing job runs across a Node version matrix; the preview would be published three times per run. Carving out a separate job in `ci.yml` to avoid this is functionally identical to a separate workflow file but conflates concerns.
+- **Build a bespoke preview publisher.** Rejected. pkg.pr.new is a focused, maintained tool in the StackBlitz ecosystem (aligned with our tsdown/Rolldown choice). Building our own would require operating a registry, a PR-comment bot, and a retention policy — all for zero differentiation.
+
+## References
+
+- Upstream issue: [#540 — feat(ci): add continuous preview releases with pkg.pr.new](https://github.com/rethinkhealth/glion/issues/540)
+- [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new) — upstream tool
+- ADR 0015 — `docs/adr/0015-secure-publishing.md` — release-path trust posture, which this ADR is explicitly decoupled from
+- `.github/workflows/release.yml` — Changesets release pipeline (unchanged by this ADR)
+- `.github/workflows/ci.yml` — test/lint/publint/e2e pipeline (unchanged by this ADR)
+
+## History
+
+- 2026-04-21: Proposed.

--- a/docs/superpowers/plans/2026-04-21-pkg-pr-new-preview-releases.md
+++ b/docs/superpowers/plans/2026-04-21-pkg-pr-new-preview-releases.md
@@ -1,0 +1,339 @@
+# pkg.pr.new Preview Releases Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a GitHub Actions workflow that publishes preview packages to pkg.pr.new on every PR and every push to `main`, and document the feature for consumers and contributors.
+
+**Architecture:** A new, standalone workflow file (`.github/workflows/preview.yml`) runs independently of `ci.yml` and `release.yml`. It installs dependencies, builds all workspace packages via turbo, then runs `npx pkg-pr-new publish './packages/*' --compact --pnpm`. The workflow uses the `pull-requests: write` permission so pkg.pr.new can post install-command comments on PRs. No npm credentials are involved — auth is handled by the pkg.pr.new GitHub App (installed manually on the repo as a one-time step). Documentation touches `README.md` (consumer-facing install snippet) and `CONTRIBUTING.md` (cross-ref to ADR 0016).
+
+**Tech Stack:** GitHub Actions, pnpm, turbo, pkg.pr.new (CLI + GitHub App).
+
+**Spec reference:** `docs/adr/0016-continuous-preview-releases.md`.
+
+---
+
+## File Structure
+
+- **Create:** `.github/workflows/preview.yml` — the preview publishing workflow. Single-purpose file; responsibility is "run on PR/main, build, publish preview". No other logic.
+- **Modify:** `README.md` — add a short "Preview releases" subsection under `## Status` explaining how to install per-commit previews. Consumer-facing.
+- **Modify:** `CONTRIBUTING.md` — add a "Preview Releases" section that links to ADR 0016 and notes the manual GitHub App prerequisite. Contributor-facing.
+
+Each file has one audience and one responsibility. No cross-file coupling.
+
+---
+
+## Task 1: Add the preview publishing workflow
+
+**Files:**
+
+- Create: `.github/workflows/preview.yml`
+
+- [ ] **Step 1: Create the workflow file**
+
+Create `.github/workflows/preview.yml` with the following content:
+
+```yaml
+name: Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    name: Publish preview to pkg.pr.new
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm ci:install
+      - name: Build all packages
+        run: pnpm build
+      - name: Publish preview to pkg.pr.new
+        run: npx pkg-pr-new publish './packages/*' --compact --pnpm
+```
+
+Design notes (do not include these as comments in the file — leave the file clean):
+
+- `name: Preview` — short, consistent with `name: CI` and `name: Changesets`.
+- `pull_request` triggers cover `opened`, `synchronize`, `reopened` — matches `ci.yml`'s PR coverage.
+- `push` on `main` gives every mainline commit a retrievable preview URL.
+- `permissions` block is minimal: `contents: read` (checkout) + `pull-requests: write` (PR comment). No `id-token: write` — pkg.pr.new uses the GitHub App, not OIDC.
+- `pnpm/action-setup@v4` and `actions/setup-node@v4` with Node 22 match `ci.yml` conventions.
+- `pnpm ci:install` uses the existing alias (`pnpm install --no-frozen-lockfile`) consistent with other workflows.
+- `pnpm build` runs turbo, which handles package build order.
+- `./packages/*` glob — pkg.pr.new auto-skips `"private": true` packages; `tools/*` is outside the glob.
+- `--compact` — short URL form (requires GitHub App installed on the repo).
+- `--pnpm` — pack tarballs via pnpm semantics to match real release tooling.
+
+- [ ] **Step 2: Verify the YAML parses**
+
+Run:
+
+```bash
+node -e "require('yaml')" 2>/dev/null || npm view yaml version >/dev/null
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/preview.yml'))" && echo OK
+```
+
+Expected: `OK` printed. If Python is not available, fall back to:
+
+```bash
+node -e "const fs=require('fs'); const y=require('js-yaml'); y.load(fs.readFileSync('.github/workflows/preview.yml','utf8')); console.log('OK')"
+```
+
+If neither is available, open the file and eyeball it against the snippet above — indentation of `with:` blocks and list items (`- uses:`, `- name:`) matters.
+
+- [ ] **Step 3: Lint the file with the project linter**
+
+Run:
+
+```bash
+pnpm check
+```
+
+Expected: no errors reported for `.github/workflows/preview.yml`. (Ultracite/Biome does not lint YAML by default, so this step just confirms the workflow file does not trip any repo-wide check such as file-size or encoding rules.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/preview.yml
+git commit -m "feat(ci): publish preview packages via pkg.pr.new on PRs and main
+
+Adds a standalone Preview workflow that builds all workspace packages
+and publishes a per-commit preview to pkg.pr.new. Independent from
+ci.yml (different failure semantics) and release.yml (previews are
+not releases). See ADR 0016 for rationale.
+
+Refs #540"
+```
+
+---
+
+## Task 2: Document preview installs in README.md
+
+**Files:**
+
+- Modify: `README.md` (insert new subsection under `## Status`)
+
+- [ ] **Step 1: Locate the `## Status` section**
+
+Open `README.md` and find the `## Status` heading (currently near line 144). The existing content is:
+
+```markdown
+## Status
+
+Glion is pre-1.0. APIs in published packages are stabilizing but may still change in minor releases. We recommend pinning exact versions in production applications.
+
+_Packages were previously published under `@rethinkhealth/hl7v2-*` and were renamed to `@glion/*`. The unscoped `glion` command is published as `@glion/cli` pending npm name approval._
+```
+
+- [ ] **Step 2: Append a `### Preview releases` subsection**
+
+Insert the following subsection immediately after the italicized migration note in `## Status`, before the `## Contributing` heading:
+
+````markdown
+### Preview releases
+
+Every pull request and every commit on `main` publishes preview packages to [pkg.pr.new](https://pkg.pr.new). Install an unreleased fix or feature by its commit SHA, without waiting for a Changesets release:
+
+\```bash
+pnpm add https://pkg.pr.new/@glion/parser@<commit-sha>
+\```
+
+Replace `@glion/parser` with any published `@glion/*` package. Preview URLs are surfaced as a bot comment on each open PR. See [ADR 0016](./docs/adr/0016-continuous-preview-releases.md) for rationale and scope.
+````
+
+(In the actual edit, strip the `\` before each backtick fence — they are escaped here only because this plan document embeds Markdown-in-Markdown.)
+
+- [ ] **Step 3: Verify the README renders**
+
+Run:
+
+```bash
+node -e "const fs=require('fs'); const s=fs.readFileSync('README.md','utf8'); if(!s.includes('### Preview releases')) process.exit(1); if(!s.includes('pkg.pr.new/@glion/parser')) process.exit(2); console.log('OK')"
+```
+
+Expected: `OK`.
+
+- [ ] **Step 4: Lint**
+
+Run:
+
+```bash
+pnpm check
+```
+
+Expected: no new errors introduced by the README edit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): document pkg.pr.new preview installs
+
+Adds a Preview releases subsection under Status explaining how to
+install per-commit previews and linking to ADR 0016.
+
+Refs #540"
+```
+
+---
+
+## Task 3: Document preview workflow in CONTRIBUTING.md
+
+**Files:**
+
+- Modify: `CONTRIBUTING.md` (append a new section next to `## Packaging Checks`)
+
+- [ ] **Step 1: Locate the `## Packaging Checks` section**
+
+Open `CONTRIBUTING.md` and find the `## Packaging Checks` heading (currently around line 116). The existing content is:
+
+```markdown
+<!-- omit in toc -->
+
+## Packaging Checks
+
+Run `pnpm build && pnpm publint` locally before pushing. CI enforces the same check. See [ADR 0015](./docs/adr/0015-secure-publishing.md) for rationale.
+
+<!-- omit in toc -->
+
+## Attribution
+```
+
+- [ ] **Step 2: Insert a `## Preview Releases` section**
+
+Insert the following section between `## Packaging Checks` and `## Attribution`:
+
+```markdown
+<!-- omit in toc -->
+
+## Preview Releases
+
+Every PR and every commit on `main` publishes preview packages to [pkg.pr.new](https://pkg.pr.new) via `.github/workflows/preview.yml`. The pkg.pr.new bot posts install commands as a PR comment so reviewers and bug reporters can validate a change before it is released to npm. See [ADR 0016](./docs/adr/0016-continuous-preview-releases.md) for rationale.
+
+Operational note: the pkg.pr.new GitHub App must be installed on the repository for the workflow to succeed. This is a one-time repo-admin action outside the code.
+```
+
+(Retain the trailing blank line so the subsequent `<!-- omit in toc -->` marker stays separated.)
+
+- [ ] **Step 3: Verify the CONTRIBUTING edit**
+
+Run:
+
+```bash
+node -e "const fs=require('fs'); const s=fs.readFileSync('CONTRIBUTING.md','utf8'); if(!s.includes('## Preview Releases')) process.exit(1); if(!s.includes('ADR 0016')) process.exit(2); console.log('OK')"
+```
+
+Expected: `OK`.
+
+- [ ] **Step 4: Lint**
+
+Run:
+
+```bash
+pnpm check
+```
+
+Expected: no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -m "docs(contributing): document pkg.pr.new preview workflow
+
+Notes the Preview workflow, the PR bot comment, and the one-time
+GitHub App install prerequisite. Links to ADR 0016.
+
+Refs #540"
+```
+
+---
+
+## Task 4: Open the PR with the manual prerequisite called out
+
+**Files:** none (this is a PR-description task, not a code task).
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin worktree-fix-540
+```
+
+- [ ] **Step 2: Open the PR**
+
+Open a PR against `main` with the title:
+
+```
+feat(ci): add continuous preview releases with pkg.pr.new (#540)
+```
+
+Use this PR body (replace the worktree branch name if needed):
+
+```markdown
+## Summary
+
+- Closes #540 by adding a Preview GitHub Actions workflow that publishes per-commit preview packages to [pkg.pr.new](https://pkg.pr.new).
+- Adds ADR 0016 documenting the rationale, decision, tradeoffs, and alternatives considered.
+- Documents preview installs in README and the preview workflow in CONTRIBUTING.
+
+## Manual prerequisite — repo admin action required
+
+The pkg.pr.new GitHub App must be installed on `rethinkhealth/glion` before the workflow will succeed. This is a one-time action:
+
+1. Visit https://github.com/apps/pkg-pr-new and click **Install**.
+2. Scope the install to the `rethinkhealth/glion` repository.
+3. After install, the next workflow run will publish and comment on its own PR.
+
+## Test plan
+
+- [ ] Merge is blocked until the GitHub App is installed (the workflow will fail without it; that is expected).
+- [ ] After App install, pushing a commit to this PR triggers the `Preview` workflow.
+- [ ] The workflow completes successfully (green check on `Preview / Publish preview to pkg.pr.new`).
+- [ ] A comment from the pkg.pr.new bot appears on the PR listing `@glion/*` install URLs.
+- [ ] Verify `pnpm add https://pkg.pr.new/@glion/parser@<commit-sha>` installs and imports in a scratch project.
+- [ ] Merge to `main` triggers the workflow again and publishes a preview keyed on the merge commit SHA.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+- [ ] **Step 3: Verify the PR exists**
+
+```bash
+gh pr view --json url,title,state
+```
+
+Expected: JSON output with `"state": "OPEN"` and the title set.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage** — every section of ADR 0016 is implemented:
+
+- §1 Workflow file — Task 1.
+- §2 Triggers (`pull_request` types + `push` main) — Task 1, Step 1.
+- §3 Package scope (`./packages/*`) — Task 1, Step 1.
+- §4 Workflow steps (checkout / pnpm / Node 22 / install / build / `npx pkg-pr-new publish ... --compact --pnpm`) — Task 1, Step 1.
+- §5 Permissions (`contents: read`, `pull-requests: write`, no `id-token: write`) — Task 1, Step 1.
+- §6 Manual GitHub App prerequisite — Task 3 (CONTRIBUTING note) + Task 4 (PR description).
+- §7 Out-of-scope items (StackBlitz templates, fork support, test gating) — intentionally absent from the plan.
+
+**Placeholder scan** — no TBDs, no "add appropriate X", no "similar to above". All code blocks contain the literal content the engineer will paste.
+
+**Type consistency** — only YAML keys and CLI flags are referenced. `--compact`, `--pnpm`, and the `./packages/*` glob are used identically in the ADR and the plan.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "only-allow": "^1.2.2",
     "oxfmt": "^0.44.0",
     "oxlint": "1.51.0",
+    "pkg-pr-new": "0.0.66",
     "rimraf": "^6.1.3",
     "turbo": "^2.9.6",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       oxlint:
         specifier: 1.51.0
         version: 1.51.0
+      pkg-pr-new:
+        specifier: 0.0.66
+        version: 0.0.66
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -2404,6 +2407,18 @@ importers:
 
 packages:
 
+  '@actions/core@3.0.1':
+    resolution: {integrity: sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==}
+
+  '@actions/exec@3.0.0':
+    resolution: {integrity: sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==}
+
+  '@actions/http-client@4.0.1':
+    resolution: {integrity: sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==}
+
+  '@actions/io@3.0.2':
+    resolution: {integrity: sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==}
+
   '@alcalzone/ansi-tokenize@0.1.3':
     resolution: {integrity: sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==}
     engines: {node: '>=14.13.1'}
@@ -2716,6 +2731,10 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jsdevtools/ez-spawn@3.0.4':
+    resolution: {integrity: sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==}
+    engines: {node: '>=10'}
+
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
@@ -2739,6 +2758,62 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@octokit/action@6.1.0':
+    resolution: {integrity: sha512-lo+nHx8kAV86bxvOVOI3vFjX3gXPd/L7guAUbvs3pUvnR2KC+R7yjBkA1uACt4gYhs4LcWP3AXSGQzsbeN2XXw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/auth-action@4.1.0':
+    resolution: {integrity: sha512-m+3t7K46IYyMk7Bl6/lF4Rv09GqDZjYmNg8IWycJ2Fa3YE3DE7vQcV6G2hUPmR9NDqenefNJwVtlisMjzymPiQ==}
+    engines: {node: '>= 18'}
+
+  '@octokit/auth-token@4.0.0':
+    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/core@5.2.2':
+    resolution: {integrity: sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==}
+    engines: {node: '>= 18'}
+
+  '@octokit/endpoint@9.0.6':
+    resolution: {integrity: sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/graphql@7.1.1':
+    resolution: {integrity: sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==}
+    engines: {node: '>= 18'}
+
+  '@octokit/openapi-types@20.0.0':
+    resolution: {integrity: sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==}
+
+  '@octokit/openapi-types@24.2.0':
+    resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
+
+  '@octokit/plugin-paginate-rest@9.2.2':
+    resolution: {integrity: sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+
+  '@octokit/plugin-rest-endpoint-methods@10.4.1':
+    resolution: {integrity: sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+
+  '@octokit/request-error@5.1.1':
+    resolution: {integrity: sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==}
+    engines: {node: '>= 18'}
+
+  '@octokit/request@8.4.1':
+    resolution: {integrity: sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/types@12.6.0':
+    resolution: {integrity: sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==}
+
+  '@octokit/types@13.10.0':
+    resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
 
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
@@ -3515,6 +3590,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  before-after-hook@2.2.3:
+    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -3550,6 +3628,9 @@ packages:
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
+
+  call-me-maybe@1.0.2:
+    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -3654,6 +3735,10 @@ packages:
       supports-color:
         optional: true
 
+  decode-uri-component@0.4.1:
+    resolution: {integrity: sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==}
+    engines: {node: '>=14.16'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -3664,6 +3749,9 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  deprecation@2.3.1:
+    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -3805,6 +3893,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  filter-obj@5.1.0:
+    resolution: {integrity: sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==}
+    engines: {node: '>=14.16'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -4009,6 +4101,10 @@ packages:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
 
+  isbinaryfile@5.0.7:
+    resolution: {integrity: sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==}
+    engines: {node: '>= 18.0.0'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -4192,6 +4288,9 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
@@ -4321,6 +4420,10 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  pkg-pr-new@0.0.66:
+    resolution: {integrity: sha512-t+rZ2DY9Bp7v2NSFZciqChb6DGPdo9YhQeuW/GSdMsUx634gnqe+baJq2ZQgVtXaIxUbnPPBmtFJb6qnQ0uVUA==}
+    hasBin: true
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -4376,8 +4479,20 @@ packages:
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
 
+  query-registry@3.0.1:
+    resolution: {integrity: sha512-M9RxRITi2mHMVPU5zysNjctUT8bAPx6ltEXo/ir9+qmiM47Y7f0Ir3+OxUO5OjYAWdicBQRew7RtHtqUXydqlg==}
+    engines: {node: '>=20'}
+
+  query-string@9.3.1:
+    resolution: {integrity: sha512-5fBfMOcDi5SA9qj5jZhWAcTtDfKF5WFdd2uD9nVNlbxVv1baq65aALy6qofpNEGELHvisjjasxQp7BlM9gvMzw==}
+    engines: {node: '>=18'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-lru@7.3.0:
+    resolution: {integrity: sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==}
+    engines: {node: '>=18'}
 
   react-reconciler@0.29.2:
     resolution: {integrity: sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==}
@@ -4523,6 +4638,10 @@ packages:
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
+
+  split-on-first@3.0.0:
+    resolution: {integrity: sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==}
+    engines: {node: '>=12'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -4729,9 +4848,17 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
+
   turbo@2.9.6:
     resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
     hasBin: true
+
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
 
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
@@ -4759,6 +4886,10 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@6.25.0:
+    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+    engines: {node: '>=18.17'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -4789,6 +4920,9 @@ packages:
     resolution: {integrity: sha512-bnzuF8b6d47WubA4a5yLqFbuZz/v/NS6eRwUIdOaDmsqzwTlyv8yS1g3M7ISdtBQrigPD3qKK87Cu7zhEfCF3A==}
     deprecated: Use @types/unist instead
 
+  universal-user-agent@6.0.1:
+    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -4802,6 +4936,14 @@ packages:
     peerDependenciesMeta:
       synckit:
         optional: true
+
+  url-join@5.0.0:
+    resolution: {integrity: sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  validate-npm-package-name@5.0.1:
+    resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -4950,6 +5092,9 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
@@ -4978,6 +5123,10 @@ packages:
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
+  zod-package-json@1.2.0:
+    resolution: {integrity: sha512-tamtgPM3MkP+obfO2dLr/G+nYoYkpJKmuHdYEy6IXRKfLybruoJ5NUj0lM0LxwOpC9PpoGLbll1ecoeyj43Wsg==}
+    engines: {node: '>=20'}
+
   zod-to-json-schema@3.25.0:
     resolution: {integrity: sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==}
     peerDependencies:
@@ -4987,6 +5136,22 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@actions/core@3.0.1':
+    dependencies:
+      '@actions/exec': 3.0.0
+      '@actions/http-client': 4.0.1
+
+  '@actions/exec@3.0.0':
+    dependencies:
+      '@actions/io': 3.0.2
+
+  '@actions/http-client@4.0.1':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 6.25.0
+
+  '@actions/io@3.0.2': {}
 
   '@alcalzone/ansi-tokenize@0.1.3':
     dependencies:
@@ -5324,6 +5489,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jsdevtools/ez-spawn@3.0.4':
+    dependencies:
+      call-me-maybe: 1.0.2
+      cross-spawn: 7.0.6
+      string-argv: 0.3.2
+      type-detect: 4.1.0
+
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -5358,6 +5530,78 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@octokit/action@6.1.0':
+    dependencies:
+      '@octokit/auth-action': 4.1.0
+      '@octokit/core': 5.2.2
+      '@octokit/plugin-paginate-rest': 9.2.2(@octokit/core@5.2.2)
+      '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.2)
+      '@octokit/types': 12.6.0
+      undici: 6.25.0
+
+  '@octokit/auth-action@4.1.0':
+    dependencies:
+      '@octokit/auth-token': 4.0.0
+      '@octokit/types': 13.10.0
+
+  '@octokit/auth-token@4.0.0': {}
+
+  '@octokit/core@5.2.2':
+    dependencies:
+      '@octokit/auth-token': 4.0.0
+      '@octokit/graphql': 7.1.1
+      '@octokit/request': 8.4.1
+      '@octokit/request-error': 5.1.1
+      '@octokit/types': 13.10.0
+      before-after-hook: 2.2.3
+      universal-user-agent: 6.0.1
+
+  '@octokit/endpoint@9.0.6':
+    dependencies:
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/graphql@7.1.1':
+    dependencies:
+      '@octokit/request': 8.4.1
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/openapi-types@20.0.0': {}
+
+  '@octokit/openapi-types@24.2.0': {}
+
+  '@octokit/plugin-paginate-rest@9.2.2(@octokit/core@5.2.2)':
+    dependencies:
+      '@octokit/core': 5.2.2
+      '@octokit/types': 12.6.0
+
+  '@octokit/plugin-rest-endpoint-methods@10.4.1(@octokit/core@5.2.2)':
+    dependencies:
+      '@octokit/core': 5.2.2
+      '@octokit/types': 12.6.0
+
+  '@octokit/request-error@5.1.1':
+    dependencies:
+      '@octokit/types': 13.10.0
+      deprecation: 2.3.1
+      once: 1.4.0
+
+  '@octokit/request@8.4.1':
+    dependencies:
+      '@octokit/endpoint': 9.0.6
+      '@octokit/request-error': 5.1.1
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/types@12.6.0':
+    dependencies:
+      '@octokit/openapi-types': 20.0.0
+
+  '@octokit/types@13.10.0':
+    dependencies:
+      '@octokit/openapi-types': 24.2.0
 
   '@oxc-project/types@0.122.0': {}
 
@@ -5891,6 +6135,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  before-after-hook@2.2.3: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -5922,6 +6168,8 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-me-maybe@1.0.2: {}
 
   callsites@3.1.0: {}
 
@@ -6010,11 +6258,15 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-uri-component@0.4.1: {}
+
   deepmerge@4.3.1: {}
 
   defu@6.1.4: {}
 
   delayed-stream@1.0.0: {}
+
+  deprecation@2.3.1: {}
 
   dequal@2.0.3: {}
 
@@ -6165,6 +6417,8 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  filter-obj@5.1.0: {}
 
   find-up@4.1.0:
     dependencies:
@@ -6369,6 +6623,8 @@ snapshots:
 
   is-windows@1.0.2: {}
 
+  isbinaryfile@5.0.7: {}
+
   isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
@@ -6539,6 +6795,10 @@ snapshots:
 
   obug@2.1.1: {}
 
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
@@ -6675,6 +6935,17 @@ snapshots:
 
   pirates@4.0.7: {}
 
+  pkg-pr-new@0.0.66:
+    dependencies:
+      '@actions/core': 3.0.1
+      '@jsdevtools/ez-spawn': 3.0.4
+      '@octokit/action': 6.1.0
+      ignore: 5.3.2
+      isbinaryfile: 5.0.7
+      pkg-types: 1.3.1
+      query-registry: 3.0.1
+      tinyglobby: 0.2.15
+
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
@@ -6719,7 +6990,24 @@ snapshots:
 
   quansync@1.0.0: {}
 
+  query-registry@3.0.1:
+    dependencies:
+      query-string: 9.3.1
+      quick-lru: 7.3.0
+      url-join: 5.0.0
+      validate-npm-package-name: 5.0.1
+      zod: 3.25.76
+      zod-package-json: 1.2.0
+
+  query-string@9.3.1:
+    dependencies:
+      decode-uri-component: 0.4.1
+      filter-obj: 5.1.0
+      split-on-first: 3.0.0
+
   queue-microtask@1.2.3: {}
+
+  quick-lru@7.3.0: {}
 
   react-reconciler@0.29.2(react@18.3.1):
     dependencies:
@@ -6915,6 +7203,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  split-on-first@3.0.0: {}
 
   sprintf-js@1.0.3: {}
 
@@ -7112,6 +7402,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tunnel@0.0.6: {}
+
   turbo@2.9.6:
     optionalDependencies:
       '@turbo/darwin-64': 2.9.6
@@ -7120,6 +7412,8 @@ snapshots:
       '@turbo/linux-arm64': 2.9.6
       '@turbo/windows-64': 2.9.6
       '@turbo/windows-arm64': 2.9.6
+
+  type-detect@4.1.0: {}
 
   type-fest@4.41.0:
     optional: true
@@ -7146,6 +7440,8 @@ snapshots:
       quansync: 1.0.0
 
   undici-types@7.18.2: {}
+
+  undici@6.25.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -7191,6 +7487,8 @@ snapshots:
 
   unist@0.0.1: {}
 
+  universal-user-agent@6.0.1: {}
+
   universalify@0.1.2: {}
 
   unrun@0.2.34(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
@@ -7199,6 +7497,10 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  url-join@5.0.0: {}
+
+  validate-npm-package-name@5.0.1: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -7322,6 +7624,8 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
+  wrappy@1.0.2: {}
+
   ws@8.20.0:
     optional: true
 
@@ -7333,6 +7637,10 @@ snapshots:
 
   yoga-layout@3.2.1:
     optional: true
+
+  zod-package-json@1.2.0:
+    dependencies:
+      zod: 3.25.76
 
   zod-to-json-schema@3.25.0(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
## Summary

- Closes #540 by adding a Preview GitHub Actions workflow that publishes per-commit preview packages to [pkg.pr.new](https://pkg.pr.new).
- Adds [ADR 0016](./docs/adr/0016-continuous-preview-releases.md) documenting the rationale, decision, tradeoffs, and alternatives considered.
- Documents preview installs in README and the preview workflow in CONTRIBUTING.

## Manual prerequisite — repo admin action required

The pkg.pr.new GitHub App must be installed on `rethinkhealth/glion` before the workflow will succeed. This is a one-time action:

1. Visit https://github.com/apps/pkg-pr-new and click **Install**.
2. Scope the install to the `rethinkhealth/glion` repository.
3. After install, the next workflow run will publish and comment on its own PR.

## Intentional design choices called out during review

- **`npx pkg-pr-new` is unpinned.** Matches the form specified in issue #540 and in ADR 0016. Treated the same way every pkg.pr.new adopter does — consider pinning or adding as a devDependency in a follow-up if supply-chain hygiene warrants it.
- **Forks are not supported in v1.** Uses \`pull_request\` (not \`pull_request_target\`) so forked PRs don't receive a preview comment. Revisit if external contributions become routine (see ADR 0016 §7).
- **No test/lint gate on the preview workflow.** \`ci.yml\` already reports that status on the same PR; gating here would duplicate work and couple preview availability to unrelated CI signals (see ADR 0016 §4).
- **Concurrency cancels stale PR builds but never main-branch builds**, so every mainline commit still produces a preview URL.

## Test plan

- [x] Merge is blocked until the GitHub App is installed (the workflow will fail without it; that is expected).
- [x] After App install, pushing a commit to this PR triggers the \`Preview\` workflow.
- [x] The workflow completes successfully (green check on \`Preview / Publish preview to pkg.pr.new\`).
- [x] A comment from the pkg.pr.new bot appears on the PR listing \`@glion/*\` install URLs.
- [x] Verify \`pnpm add https://pkg.pr.new/@glion/parser@<commit-sha>\` installs and imports in a scratch project.
- [ ] Merge to \`main\` triggers the workflow again and publishes a preview keyed on the merge commit SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)