### PR TITLE
docs(packages): align package READMEs with documentation framework

### DIFF
--- a/packages/annotate-profile-fields/README.md
+++ b/packages/annotate-profile-fields/README.md
@@ -4,7 +4,7 @@ Unified plugin to annotate HL7v2 field nodes with profile metadata.
 
 ## What it does
 
-Enriches every `field` node in a parsed HL7v2 tree with metadata drawn from the HL7v2 specification profile — field name, datatype, required/repeatable flags, maximum length, and table reference — so the AST becomes self-describing. The plugin reads the message version from MSH-12, loads the matching field definitions from `@glion/profiles`, and spreads the profile properties onto `field.data`. Unknown segments (Z-segments) and unsupported versions are silently skipped.
+Enriches every `field` node in a parsed HL7v2 tree with metadata drawn from the HL7v2 specification profile — field name, datatype, required/repeatable flags, maximum length, and table reference — so the AST becomes self-describing. The plugin reads the resolved `ProfileContext` from `file.data.profile` (populated by `@glion/annotate-profile-context`) and spreads each matching profile entry onto `field.data`. Unknown segments (Z-segments) and unsupported versions are silently skipped.
 
 ## Install
 
@@ -15,17 +15,20 @@ npm install @glion/annotate-profile-fields
 ## Use
 
 ```ts
+import { hl7v2AnnotateProfileContext } from "@glion/annotate-profile-context";
 import { hl7v2AnnotateProfileFields } from "@glion/annotate-profile-fields";
 import { hl7v2Parser } from "@glion/parser";
 import { unified } from "unified";
 
-const processor = unified().use(hl7v2Parser).use(hl7v2AnnotateProfileFields);
+const processor = unified()
+  .use(hl7v2Parser)
+  .use(hl7v2AnnotateProfileContext)
+  .use(hl7v2AnnotateProfileFields);
 
 const message =
   "MSH|^~\\&|SENDER||RECEIVER||20241201||ADT^A01^ADT_A01|MSG123|P|2.5\rPID|1||12345||Doe^John";
 
-const tree = processor.parse(message);
-await processor.run(tree);
+const file = await processor.process(message);
 
 // Field nodes now carry profile metadata on field.data
 // e.g., PID-3: { id: "PID-3", name: "Patient Identifier List", required: true, repeatable: true, datatype: "CX", ... }
@@ -37,15 +40,19 @@ This package exports the named constant `hl7v2AnnotateProfileFields`. The defaul
 
 ### `unified().use(hl7v2AnnotateProfileFields)`
 
-Annotate Field nodes with profile metadata. The plugin:
+A `unified` plugin that annotates `field` nodes with profile metadata. The plugin reads the resolved `ProfileContext` from `file.data.profile` (populated by `@glion/annotate-profile-context`) and, for each `field` node, looks up the field definition by segment name and sequence index, then spreads the matching profile properties onto `field.data`.
 
-1. Reads the HL7v2 version from MSH-12.
-2. Loads field definitions for all segments in the message from `@glion/profiles`.
-3. Visits each Field node and spreads the matching profile properties onto `field.data`.
+```ts
+import type { Root } from "@glion/ast";
+import type { Plugin } from "unified";
 
-###### Returns
+export const hl7v2AnnotateProfileFields: Plugin<[], Root, Root>;
+export default hl7v2AnnotateProfileFields;
+```
 
-Async transformer (`async function (Root) => Root`).
+**Returns**
+
+The same `Root` tree, mutated in place. When `file.data.profile` is absent, the tree is returned unchanged.
 
 ## What it annotates
 

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -24,8 +24,6 @@ function firstSegment(tree: Root): Segment | undefined {
 }
 ```
 
-Use these types whenever you write a plugin, visitor, or helper that operates on the HL7v2 AST — they are the contract shared by every package in the ecosystem.
-
 ## API
 
 The package exports interface declarations only. There is no runtime JavaScript.
@@ -42,7 +40,7 @@ The package exports interface declarations only. There is no runtime JavaScript.
 
 Every node may also carry a `position` property (`{ start, end }` with `line`, `column`, and `offset`) following the `unist` spec.
 
-## Node types
+## Node hierarchy
 
 The AST mirrors the full HL7v2 delimiter hierarchy:
 
@@ -83,37 +81,33 @@ interface Root <: Parent {
 
 interface Segment <: Parent {
   type: 'segment'
-  name?: string
+  name: string
   children: [Field]
 }
 
 interface Group <: Parent {
   type: 'group'
   name: string
-  children: [Segment]
+  children: [Segment | Group]
 }
 
 interface Field <: Parent {
   type: 'field'
-  index: number
   children: [FieldRepetition]
 }
 
 interface FieldRepetition <: Parent {
   type: 'field-repetition'
-  index?: number
   children: [Component]
 }
 
 interface Component <: Parent {
   type: 'component'
-  index: number
   children: [Subcomponent]
 }
 
 interface Subcomponent <: Literal {
   type: 'subcomponent'
-  index: number
   value: string
 }
 ```

--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -1,10 +1,10 @@
 # @glion/builder
 
-Tiny, typed helpers for assembling HL7v2 ASTs by hand.
+Typed helpers for assembling HL7v2 ASTs by hand.
 
 ## What it does
 
-`@glion/builder` provides five short functions (`m`, `s`, `f`, `r`, `c`) that wrap [`unist-builder`](https://github.com/syntax-tree/unist-builder) and return nodes typed from [`@glion/ast`](../ast/). You build trees with a few function calls instead of nesting `u('node-type', ...)` boilerplate by hand, and the output is the same shape a parser would produce — so any Glion consumer (serializers, linters, annotators) can read it back. The builder is intentionally small: no hidden serialization, no format guessing, no HL7v2 semantics. You decide what the tree looks like; the helpers just reduce the typing.
+`@glion/builder` provides six short functions (`m`, `g`, `s`, `f`, `r`, `c`) that wrap [`unist-builder`](https://github.com/syntax-tree/unist-builder) and return nodes typed from [`@glion/ast`](../ast/). The output matches the shape produced by `@glion/parser`, so any Glion consumer (serializers, linters, annotators) can read it back. The helpers carry no HL7v2 semantics: trees are constructed exactly as written.
 
 ## Install
 
@@ -18,12 +18,9 @@ npm install @glion/builder
 import { c, f, m, s } from "@glion/builder";
 
 const tree = m(
+  s("MSH", f("^~\\&")),
   s(
-    f("MSH"), // include the segment header explicitly
-    f("^~\\&")
-  ),
-  s(
-    f("PID"),
+    "PID",
     f(), // empty field
     f([
       c(["123456", "DOE", "JOHN"]), // arrays and individual args are interchangeable
@@ -32,7 +29,7 @@ const tree = m(
 );
 ```
 
-`tree` is a `Root` node containing two segments (`MSH`, `PID`). Pass it to `@glion/to-hl7v2` to serialize, to `@glion/jsonify` to jsonify, or to any `unist` visitor to inspect it.
+`tree` is a `Root` node containing two segments (`MSH`, `PID`). It is consumable by `@glion/to-hl7v2` (for serialization), `@glion/jsonify` (for JSON), or any `unist` visitor.
 
 ## API
 
@@ -40,57 +37,56 @@ const tree = m(
 
 Build a `Root` (message) node.
 
-- No arguments → empty root.
-- Pass any number of `RootContent` nodes (segments, fragments); they are appended in order.
-- Arguments are used as-is. Pass concrete AST nodes rather than nested arrays.
+- No arguments produce an empty root.
+- Any number of `RootContent` nodes (segments, groups) are appended in order.
 
-### `s(...fields: Field[]): Segment`
+### `g(name: string, ...children: (Segment | Group)[]): Group`
+
+Build a `Group` node.
+
+- `name` is the group name (e.g. `"PATIENT"`, `"ORDER"`).
+- Children are appended in the order provided. Groups can nest.
+
+### `s(name: string, ...fields: Field[]): Segment`
 
 Build a `Segment` node.
 
-- No arguments → empty segment.
-- Include the header field yourself, typically `f('PID')`, as the first argument.
-- Fields are appended in the order provided; the helper does not auto-flatten.
+- `name` is the three-character segment identifier (e.g. `"MSH"`, `"PID"`).
+- Fields are appended in the order provided.
 
 ### `f(...values: Array<string | Component | FieldRepetition | Array<string | Component | FieldRepetition>>): Field`
 
 Build a `Field` node.
 
-- No arguments → empty field with a single empty repetition.
+- No arguments produce an empty field.
 - Strings become components with a single subcomponent containing the value.
 - `Component` instances are added directly.
-- `FieldRepetition` instances are preserved so you can control repetitions explicitly.
-- Arrays are flattened one level, letting you mix individual values and grouped lists.
-- Sequences of strings/components are grouped into a single repetition unless a `FieldRepetition` is introduced explicitly.
+- `FieldRepetition` instances are preserved so repetitions can be controlled explicitly.
+- Arrays are flattened one level, mixing individual values and grouped lists.
+- Sequences of strings and components are grouped into a single repetition unless a `FieldRepetition` is introduced explicitly.
 
 ### `r(...components: Array<string | Component | Array<string | Component>>): FieldRepetition`
 
 Build a `FieldRepetition` node.
 
-- No arguments → repetition with an empty component.
+- No arguments produce a repetition with an empty component.
 - Strings become components with a single subcomponent containing the value.
-- Components are inserted as-is.
-- Arrays are flattened one level for convenience.
+- `Component` instances are inserted as-is.
+- Arrays are flattened one level.
 
 ### `c(...values: Array<string | string[]>): Component`
 
 Build a `Component` node.
 
-- No arguments → component with an empty subcomponent.
+- No arguments produce a component with an empty subcomponent.
 - Strings become subcomponents.
-- Arrays are flattened one level, so `c('DOE', ['JOHN', 'Q'])` works.
+- Arrays are flattened one level, so `c('DOE', ['JOHN', 'Q'])` produces three subcomponents.
 
-For advanced scenarios — multiple repetitions per field, custom metadata, node reuse — drop down to `unist-builder` (`u`) directly and mix those nodes with the helpers above.
-
-## Design
-
-- **Explicit.** You build the same AST shape you would by hand. There is no hidden serialization logic or format guessing.
-- **Composable.** Each helper is a thin wrapper over `unist-builder`, so raw nodes from `u()` and other utilities can be mixed freely.
-- **Minimal.** A small surface means fewer abstractions to learn and less room for divergent interpretations of the HL7v2 model.
+Compatible with `unist-builder`'s `u()` helper — raw `unist` nodes mix freely with the helpers above.
 
 ### Experimental: empty mode
 
-The builder respects the `emptyMode` experimental setting from `@glion/config`. When `emptyMode: "empty"` is configured in your `.hl7v2rc.json`, empty fields, repetitions, and components use empty `children` arrays instead of the legacy full structure:
+The builder honours the `emptyMode` experimental setting from `@glion/config`. When `emptyMode: "empty"` is configured in `.hl7v2rc.json`, empty fields, repetitions, and components produce empty `children` arrays instead of the legacy full structure:
 
 ```ts
 // Legacy mode (default):

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -14,7 +14,7 @@ npm install @glion/config
 
 ## Use
 
-Create a `.hl7v2rc.json` file in your project:
+A `.hl7v2rc.json` at the project root:
 
 ```json
 {
@@ -36,7 +36,7 @@ Create a `.hl7v2rc.json` file in your project:
 }
 ```
 
-Then load the configuration:
+Loaded by:
 
 ```typescript
 import { loadConfig } from "@glion/config";
@@ -50,7 +50,7 @@ console.log(settings.experimental.emptyMode); // "empty"
 
 ### `loadConfig(searchFrom?)`
 
-Loads and validates HL7v2 configuration synchronously. Recommended for CLI tools and startup code.
+Loads and validates HL7v2 configuration synchronously.
 
 ```typescript
 import { loadConfig } from "@glion/config";
@@ -65,13 +65,13 @@ const config2 = loadConfig("/path/to/project");
 const { settings } = loadConfig();
 ```
 
-- Parameters: `searchFrom` (optional) — Directory to start searching from (defaults to cwd).
+- Parameters: `searchFrom` (optional) — directory to start searching from (defaults to cwd).
 - Returns: `HL7v2Config` — object containing `plugins` and `settings`.
-- Throws: `ConfigurationError` if configuration is invalid.
+- Throws: `ConfigurationError` when configuration is invalid.
 
 ### `loadConfigAsync(searchFrom?)`
 
-Loads and validates HL7v2 configuration asynchronously. Use when you need non-blocking I/O or are in an async context.
+Loads and validates HL7v2 configuration asynchronously. Returns a `Promise`.
 
 ```typescript
 import { loadConfigAsync } from "@glion/config";
@@ -80,13 +80,13 @@ const config = await loadConfigAsync();
 const { settings } = await loadConfigAsync();
 ```
 
-- Parameters: `searchFrom` (optional) — Directory to start searching from (defaults to cwd).
+- Parameters: `searchFrom` (optional) — directory to start searching from (defaults to cwd).
 - Returns: `Promise<HL7v2Config>`.
-- Throws: `ConfigurationError` if configuration is invalid.
+- Throws: `ConfigurationError` when configuration is invalid.
 
 ### `defineConfig(config)`
 
-Type-safe helper for authoring configuration files. Provides IDE autocomplete with no runtime overhead (identity function for type inference).
+Identity helper for authoring configuration files in TypeScript or JavaScript. Returns the input unchanged; the type signature drives IDE autocomplete.
 
 ```typescript
 // hl7v2.config.ts
@@ -133,7 +133,7 @@ type HL7v2Settings = {
 
 ### `settings.delimiters`
 
-Configure custom delimiters for HL7v2 message parsing. Each delimiter must be exactly one character.
+Custom delimiters for HL7v2 message parsing. Each delimiter must be exactly one character.
 
 | Key            | Default | Description            |
 | -------------- | ------- | ---------------------- |
@@ -144,7 +144,7 @@ Configure custom delimiters for HL7v2 message parsing. Each delimiter must be ex
 | `escape`       | `\\`    | Escape character       |
 | `segment`      | `\r`    | Segment terminator     |
 
-Example — using custom delimiters for a non-standard system:
+Custom delimiters:
 
 ```json
 {
@@ -166,7 +166,7 @@ Controls how empty fields and components are represented in the AST.
 | `"legacy"` (default) | Empty fields create full structure (Field → Rep → Comp → Sub with `value: ""`). |
 | `"empty"`            | Empty fields have no children (Field with `children: []`).                      |
 
-Experimental — will become the default in v0.6.0.
+Experimental. Scheduled to become the default in v0.6.0.
 
 ### `plugins`
 
@@ -280,8 +280,8 @@ export default {
 The parser reads settings from the unified processor:
 
 ```typescript
-import { unified } from "unified";
 import { parseHL7v2 } from "@glion/hl7v2";
+import { unified } from "unified";
 
 const processor = unified()
   .use(parseHL7v2)
@@ -293,11 +293,11 @@ const processor = unified()
 const tree = processor.parse("MSH|^~\\&|...");
 ```
 
-When using the CLI, settings are loaded from configuration files automatically.
+The CLI loads settings from configuration files automatically.
 
 ### IDE support
 
-For autocomplete and validation, add the `$schema` field to your JSON configuration:
+The `$schema` field enables autocomplete and validation in JSON configuration:
 
 ```json
 {
@@ -305,7 +305,9 @@ For autocomplete and validation, add the `$schema` field to your JSON configurat
 }
 ```
 
-This package only validates configuration and does not execute arbitrary code from config files, except JS/MJS/TS config files which are explicitly imported. Ensure you trust the source of your configuration files.
+## Security
+
+The package validates configuration and does not execute arbitrary code, with one exception: JS, MJS, and TS configuration files are imported by `cosmiconfig` and run their top-level code on load.
 
 ## Part of Glion
 

--- a/packages/decode-escapes/README.md
+++ b/packages/decode-escapes/README.md
@@ -51,15 +51,15 @@ After this plugin runs:
 
 ### `unified().use(hl7v2DecodeEscapes[, options])`
 
-Decode HL7v2 escape sequences in literal nodes.
+A `unified` plugin that decodes HL7v2 escape sequences in literal nodes.
 
-###### Parameters
+**Parameters**
 
-- `options.delimiters` (optional) — Override delimiters. If omitted, the plugin reads them from `Root.data.delimiters` (set by the parser). Defaults to the HL7 standard (`| ^ ~ & \`).
+- `options.delimiters` (optional) — partial `Delimiters` override. When omitted, the plugin reads `file.data.delimiters` (set by `@glion/annotate-delimiters`). Falls back to the HL7 defaults (`| ^ ~ & \`).
 
-###### Returns
+**Returns**
 
-Nothing (`undefined`). Mutates the AST in-place.
+`undefined`. Mutates the tree in place.
 
 ## Behavior
 
@@ -79,9 +79,9 @@ Each escape sequence is decoded as follows:
 | `\H\`     | stripped (highlight-on marker, no output)      |
 | `\N\`     | stripped (normal-text marker, no output)       |
 
-Delimiter resolution order: `Root.data.delimiters` (preferred, set by the parser) → `options.delimiters` → HL7 defaults.
+Delimiter resolution order: `options.delimiters` → `file.data.delimiters` (set by `@glion/annotate-delimiters`) → HL7 defaults.
 
-The plugin only transforms AST nodes and does not execute code. The inverse operation is provided by [`@glion/encode-escapes`](https://github.com/rethinkhealth/glion/tree/main/packages/encode-escapes).
+The inverse operation is [`@glion/encode-escapes`](https://github.com/rethinkhealth/glion/tree/main/packages/encode-escapes).
 
 ## Part of Glion
 

--- a/packages/encode-escapes/README.md
+++ b/packages/encode-escapes/README.md
@@ -48,15 +48,17 @@ After this plugin runs:
 
 ### `unified().use(hl7v2EncodeEscapes[, options])`
 
-Encode special characters as HL7v2 escape sequences in literal nodes.
+A `unified` plugin that encodes delimiter and control characters as HL7v2 escape sequences in literal nodes.
 
-###### Parameters
+**Parameters**
 
-- `options.delimiters` (optional) — Override delimiters. If omitted, the plugin reads them from `Root.data.delimiters` (set by the parser). Defaults to the HL7 standard (`| ^ ~ & \`).
+- `options.delimiters` (optional) — partial `Delimiters` override. When omitted, the plugin reads `file.data.delimiters` (set by `@glion/annotate-delimiters`). Falls back to the HL7 defaults (`| ^ ~ & \`).
 
-###### Returns
+**Returns**
 
-Nothing (`undefined`). Mutates the AST in-place.
+`undefined`. Mutates the tree in place.
+
+MSH-1 and MSH-2 are skipped: they define the delimiters and must not themselves be escaped.
 
 ## Behavior
 
@@ -71,21 +73,21 @@ The plugin visits every `subcomponent` node and rewrites `node.value`, substitut
 | `\`   | `\E\` (escape character)       |
 | `\r`  | `\.br\` (line break directive) |
 
-Delimiter resolution order: `Root.data.delimiters` (preferred, set by the parser) → `options.delimiters` → HL7 defaults.
+Delimiter resolution order: `options.delimiters` → `file.data.delimiters` (set by `@glion/annotate-delimiters`) → HL7 defaults.
 
-This is the inverse of [`@glion/decode-escapes`](https://github.com/rethinkhealth/glion/tree/main/packages/decode-escapes):
+## Round-tripping
+
+Encoding then decoding round-trips to the original values when both plugins use the same delimiter set. See [`@glion/decode-escapes`](https://github.com/rethinkhealth/glion/tree/main/packages/decode-escapes).
 
 ```js
 import { hl7v2DecodeEscapes } from "@glion/decode-escapes";
 import { hl7v2EncodeEscapes } from "@glion/encode-escapes";
+import { unified } from "unified";
 
-// encode → decode round-trip
 const encoded = await unified().use(hl7v2EncodeEscapes).run(tree);
 const decoded = await unified().use(hl7v2DecodeEscapes).run(encoded);
 // decoded values === original values
 ```
-
-The plugin only transforms AST nodes and does not execute code.
 
 ## Part of Glion
 

--- a/packages/glion/README.md
+++ b/packages/glion/README.md
@@ -4,7 +4,7 @@ The `glion` command — development and production runtime for Glion MLLP applic
 
 ## What it does
 
-`@glion/cli` provides the `glion` binary that runs Glion applications. A single-file MLLP app exported as `export default new Mllp()` becomes a running server with `glion dev` (for development with live reload and a terminal UI) or `glion start` (for production with graceful shutdown and structured logs). The CLI reads configuration from a `glion.config.ts` file when present or infers defaults when not.
+`@glion/cli` provides the `glion` binary that runs Glion applications. A single-file MLLP app exported as `export default new Mllp()` runs as a server with `glion dev` (live reload and a terminal UI) or `glion start` (production: graceful shutdown and JSON-line logs). The CLI reads configuration from a `glion.config.ts` file when present and falls back to a conventional entry path otherwise.
 
 ## Install
 
@@ -13,8 +13,6 @@ npm install @glion/cli
 ```
 
 ## Use
-
-Define your app in a single file:
 
 ```ts
 // glion.app.ts
@@ -29,8 +27,6 @@ export default new Mllp()
   .on("ORU^R01", handleResult);
 ```
 
-Add the two scripts to `package.json`:
-
 ```json
 {
   "scripts": {
@@ -40,7 +36,7 @@ Add the two scripts to `package.json`:
 }
 ```
 
-Run `npm run dev` during development. Run `npm start` in production.
+`npm run dev` runs the dev server. `npm start` runs the production server.
 
 ## API
 
@@ -61,16 +57,20 @@ export default defineConfig({
 
 ### `GlionConfig`
 
-Type exported from `@glion/cli/config`:
+Type exported from `@glion/cli/config`. Paths resolve against the directory of the config file.
 
-| Field             | Type                            | Description                                                          |
-| ----------------- | ------------------------------- | -------------------------------------------------------------------- |
-| `entry`           | `string`                        | Path to the app file. Defaults to `./glion.app.ts` when unspecified. |
-| `port`            | `number`                        | Port to listen on. Defaults to `2575` (the MLLP standard).           |
-| `hostname`        | `string`                        | Interface to bind. Defaults to `0.0.0.0`.                            |
-| `tls`             | `{ cert: string; key: string }` | Enable MLLP over TLS.                                                |
-| `watch`           | `string[]`                      | Additional paths the dev watcher should reload on.                   |
-| `gracefulCloseMs` | `number`                        | Drain timeout for `glion start`. Defaults to `5000`.                 |
+| Field                   | Type                                                                           | Description                                                                                         |
+| ----------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `entry`                 | `string`                                                                       | Path to the app file. Required.                                                                     |
+| `port`                  | `number`                                                                       | TCP port to listen on. `0` selects an OS-assigned ephemeral port. Defaults to `2575`.               |
+| `hostname`              | `string`                                                                       | Interface to bind. Defaults to `127.0.0.1` for `glion dev` and `0.0.0.0` for `glion start`.         |
+| `tls`                   | `{ cert: string; key: string; ca?: string; passphrase?: string }`              | Enable MLLP over TLS.                                                                               |
+| `watch`                 | `string[]`                                                                     | Paths the dev watcher reloads on. Defaults to `[dirname(entry)]`.                                   |
+| `gracefulCloseMs`       | `number`                                                                       | Drain timeout for `glion start` in milliseconds. Defaults to `5000`.                                |
+| `keepAlive`             | `boolean`                                                                      | Enable TCP keep-alive on accepted sockets.                                                          |
+| `keepAliveInitialDelay` | `number`                                                                       | Initial delay in milliseconds before keep-alive probes are sent.                                    |
+| `socketTimeout`         | `number`                                                                       | Per-socket idle timeout in milliseconds.                                                            |
+| `logging`               | `boolean \| LogLevel \| { dir?: string; maxFiles?: number; level?: LogLevel }` | Off when omitted. `true` enables file logging with defaults; an object overrides individual fields. |
 
 ## Commands
 
@@ -84,7 +84,7 @@ Runs the app in production. Emits JSON-line events to stdout for log aggregators
 
 ### Zero-config mode
 
-Both commands work without a `glion.config.ts` when the app file is at `./glion.app.ts` at the project root. The TUI shows a `zero-config` badge to indicate no config was loaded. Create a `glion.config.ts` when you need custom ports, TLS, or additional watch paths.
+Both commands run without a `glion.config.ts` when the app file is at `./glion.app.ts` at the project root. The TUI shows a `zero-config` badge when no config was loaded.
 
 ### Cross-runtime invocation
 

--- a/packages/hl7v2/README.md
+++ b/packages/hl7v2/README.md
@@ -4,7 +4,7 @@ Pre-configured `unified` processor that parses, annotates, decodes, lints, and s
 
 ## What it does
 
-`@glion/hl7v2` exports `parseHL7v2`, a frozen `unified` processor assembled from the Glion plugin set. Feeding it an HL7v2 string returns a `VFile` whose `result` is the JSON serialization, whose `tree` is the transformed AST, and whose `messages` list holds every lint diagnostic gathered along the way. Use it when you want the full pipeline; reach for individual plugins when you need a different composition.
+`@glion/hl7v2` exports `parseHL7v2`, a frozen `unified` processor assembled from the Glion plugin set. Calling `parseHL7v2.process(input)` on an HL7v2 string returns a `VFile` whose `result` is the JSON serialization, whose `tree` is the transformed AST, and whose `messages` list holds every lint diagnostic gathered along the way.
 
 ## Install
 
@@ -25,7 +25,7 @@ console.log(file.messages); // lint diagnostics (warnings + errors)
 console.log(String(file)); // JSON output
 ```
 
-The processor is frozen. To extend it, call `.use(...)` on a fresh `unified()` instance composed of the plugins you need.
+The processor is frozen; further `.use(...)` calls throw. Extension happens by composing a fresh `unified()` instance from the underlying plugins.
 
 ## API
 
@@ -85,20 +85,17 @@ export const parseHL7v2 = unified()
 | `hl7v2PresetLintProfileRecommended` | `@glion/preset-lint-profile-recommended` | Applies profile-aware lint rules (field definitions, datatypes, table values).               |
 | `hl7v2Jsonify`                      | `@glion/jsonify`                         | Compiles the transformed tree to the simplified JSON representation.                         |
 
-To build your own pipeline, import the plugins directly and compose them on a fresh `unified()` instance.
-
-## Custom pipelines
+Each plugin is independently importable. A custom pipeline composes any subset of them on a fresh `unified()` instance:
 
 ```ts
 import { unified } from "unified";
 import { hl7v2Parser } from "@glion/parser";
 import { hl7v2ToHl7v2 } from "@glion/to-hl7v2";
 
-// Parse-and-reserialize (round-trip)
 const roundtrip = unified().use(hl7v2Parser).use(hl7v2ToHl7v2).freeze();
 ```
 
-Any `unified` plugin that operates on the `@glion/ast` tree can be slotted in — custom lints, annotators, transformers, or alternative compilers like `@glion/to-hl7v2`.
+Any `unified` plugin that operates on the `@glion/ast` tree composes with the Glion plugin set — custom lints, annotators, transformers, or alternative compilers such as `@glion/to-hl7v2`.
 
 ## Part of Glion
 

--- a/packages/jsonify/README.md
+++ b/packages/jsonify/README.md
@@ -1,10 +1,10 @@
 # @glion/jsonify
 
-Serialize an HL7v2 AST into a compact, structured JSON document.
+Compile an HL7v2 AST into a JSON-friendly structure.
 
 ## What it does
 
-`@glion/jsonify` takes an HL7v2 AST — typically produced by `@glion/parser` — and emits a JSON representation that strips `unist` metadata (position, raw, type discriminators) and keeps only the meaningful HL7v2 shape: segment names, field indexes, values, and children. The result is a clean payload for downstream APIs, message queues, and analytics stores that want structured HL7v2 without the parser's internal tree representation.
+`@glion/jsonify` takes an HL7v2 AST — typically produced by `@glion/parser` — and emits a JSON representation that strips `unist` metadata (position, type discriminators, raw text) and keeps the meaningful HL7v2 shape: segment names, field positions, repetitions, components, and subcomponents. The result is a plain array of segment and group objects suitable for downstream APIs, message queues, and analytics pipelines.
 
 ## Install
 
@@ -15,65 +15,87 @@ npm install @glion/jsonify
 ## Use
 
 ```ts
-import { hl7v2Parser } from "@glion/parser";
 import { hl7v2Jsonify } from "@glion/jsonify";
+import { hl7v2Parser } from "@glion/parser";
 import { unified } from "unified";
 
 const msg = `MSH|^~\\&|HIS|RIH|EKG|EKG|200202150930||ADT^A01|MSG00001|P|2.4\rPID|||555-44-4444||DOE^JOHN`;
 
 const file = await unified().use(hl7v2Parser).use(hl7v2Jsonify).process(msg);
 
-console.log(String(file));
+console.log(file.result);
 ```
 
 Yields:
 
 ```json
-{
-  "type": "Message",
-  "children": [
-    {
-      "type": "Segment",
-      "name": "MSH",
-      "children": [
-        { "type": "Field", "name": "MSH-1", "value": "|" },
-        { "type": "Field", "name": "MSH-2", "value": "^~\\&" }
-      ]
-    },
-    {
-      "type": "Segment",
-      "name": "PID",
-      "children": [
-        { "type": "Field", "name": "PID-3", "value": "555-44-4444" },
-        { "type": "Field", "name": "PID-5", "value": "DOE^JOHN" }
-      ]
-    }
-  ]
-}
+[
+  {
+    "segment": "MSH",
+    "fields": [
+      "|",
+      "^~\\&",
+      "HIS",
+      "RIH",
+      "EKG",
+      "EKG",
+      "200202150930",
+      "",
+      ["ADT", "A01"],
+      "MSG00001",
+      "P",
+      "2.4"
+    ]
+  },
+  {
+    "segment": "PID",
+    "fields": ["", "", "555-44-4444", "", ["DOE", "JOHN"]]
+  }
+]
 ```
 
 ## API
 
 ### `unified().use(hl7v2Jsonify)`
 
-Register the plugin as the compiler of a `unified` processor. The processor's `process()` call returns a file whose stringified contents is the JSON document. No options.
+Registers the plugin as the compiler of a `unified` processor. Sets `file.result` to an `Hl7v2JsonResult` value (a plain array of segment and group objects). Takes no options.
+
+### `toJsonRuntime(tree)`
+
+Standalone runtime that converts an HL7v2 AST node to its JSON representation.
+
+- `tree` (`Nodes`) — the root node to convert.
+- Returns: `Hl7v2JsonResult`.
+
+```ts
+import { toJsonRuntime } from "@glion/jsonify";
+
+const json = toJsonRuntime(rootNode);
+```
 
 ## JSON shape
 
-Every node in the output has the following shape:
-
 ```ts
-interface HL7v2JsonNode {
-  type: string; // "Message", "Segment", "Field", "Component", ...
-  name?: string; // segment name (e.g. "MSH") or field id (e.g. "PID-3")
-  index?: number; // positional index where relevant
-  value?: string; // leaf value for Field / Component / Subcomponent
-  delimiter?: string; // delimiter character when it is meaningful to preserve
-  children?: HL7v2JsonNode[]; // recursive shape for composite nodes
+type Hl7v2JsonResult = (SegmentJson | GroupJson)[];
+
+interface SegmentJson {
+  segment: string;
+  fields: (FieldJson | FieldJson[])[];
 }
+
+interface GroupJson {
+  group: string;
+  children: (SegmentJson | GroupJson)[];
+}
+
+type FieldJson = string | string[];
 ```
 
-Only the fields relevant to a given node appear in the output — `Field` nodes carry `name` and `value`, composite nodes carry `name` and `children`, and so on.
+Field values collapse to their simplest form:
+
+- A field with a single component containing a single subcomponent becomes a `string`.
+- A field with multiple components or subcomponents becomes a nested array (`string[]` or `string[][]`).
+- A field with multiple repetitions becomes an array, one entry per repetition.
 
 ## Part of Glion
 

--- a/packages/lint-max-message-size/README.md
+++ b/packages/lint-max-message-size/README.md
@@ -2,9 +2,17 @@
 
 Lint rule that flags HL7v2 messages exceeding a maximum byte size or segment count.
 
+|                      |                                      |
+| -------------------- | ------------------------------------ |
+| **Recommended**      | ❌                                   |
+| **Profile-aware**    | ❌                                   |
+| **Default severity** | `warning`                            |
+| **Requires**         | `@glion/parser`                      |
+| **Since**            | `@glion/lint-max-message-size@0.2.8` |
+
 ## What it does
 
-Measures the UTF-8 byte length of the source message and, optionally, the number of segment nodes in the tree. Reports a warning when the message is larger than `maxBytes` (default 10,000,000) or when `maxSegments` is set and the tree contains more segments than allowed. Intended to protect downstream systems from oversized payloads that would cause resource or protocol limits to be hit.
+Measures the UTF-8 byte length of the source message and, optionally, the number of segment nodes in the tree. Reports a warning when the message is larger than `maxBytes` (default `10_000_000`) or when `maxSegments` is set and the tree contains more segments than allowed. Oversized payloads exceed downstream resource and protocol limits.
 
 ## Install
 
@@ -67,19 +75,19 @@ PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
 
 ### Invalid
 
-A message whose UTF-8 size exceeds `maxBytes`:
+A message whose UTF-8 size exceeds `maxBytes` (here `maxBytes: 1`):
 
 ```
-Message size 2,000,000 bytes exceeds 1,000,000 bytes limit — trim payload or raise "maxBytes"
+Message size 9 bytes exceeds 1 byte limit — trim payload or raise "maxBytes"
 ```
 
-A tree with more segments than `maxSegments`:
+A tree with more segments than `maxSegments` (here `maxSegments: 1`):
 
 ```
-Message contains 150 segments (limit 100 segments) — reduce segment count or raise "maxSegments"
+Message contains 3 segments (limit 1 segment) — reduce segment count or raise "maxSegments"
 ```
 
-Byte and segment counts are interpolated with pluralization. Both checks are independent — if the message violates both thresholds, two messages are reported.
+Byte and segment counts are interpolated with pluralization (`1 byte` / `9 bytes`, `1 segment` / `3 segments`). The two checks are independent — a message violating both thresholds produces two messages.
 
 ## Part of Glion
 

--- a/packages/lint-message-version/README.md
+++ b/packages/lint-message-version/README.md
@@ -2,9 +2,17 @@
 
 Lint rule that checks an HL7v2 message's `MSH-12` version satisfies a semver range expression.
 
+|                      |                                             |
+| -------------------- | ------------------------------------------- |
+| **Recommended**      | ✅ part of `@glion/preset-lint-recommended` |
+| **Profile-aware**    | ❌                                          |
+| **Default severity** | `warning`                                   |
+| **Requires**         | `@glion/parser`                             |
+| **Since**            | `@glion/lint-message-version@0.2.22`        |
+
 ## What it does
 
-Reads `MSH-12.1` from the tree and evaluates it against the configured `expression` using `@glion/util-semver`. Reports a message when `MSH-12` is missing or empty, when the value is not a valid semver-like version, or when it falls outside the allowed range. The default expression (`"<3.0.0 >=2.3"`) accepts HL7v2 versions 2.3 through 2.9 and excludes future v3 values.
+Reads `MSH-12.1` from the tree and evaluates it against the configured `expression` using `@glion/util-semver`. Reports a message when `MSH-12` is missing or empty, when the value is not a valid semver-like version, or when it falls outside the allowed range. The default expression `"<3.0.0 >=2.3"` accepts HL7v2 versions 2.3 through 2.9 and excludes future v3 values.
 
 ## Install
 
@@ -90,7 +98,7 @@ Required MSH-12 (version) field is missing or empty
 `MSH-12` contains a value that cannot be parsed as semver:
 
 ```
-MSH-12 (version) field value 'abc' is not valid
+MSH-12 (version) field value 'foo' is not valid
 ```
 
 Both the offending value and the configured expression are interpolated into the message. The rule reports at most one message per tree and exits as soon as the first problem is detected.

--- a/packages/lint-no-trailing-empty-field/README.md
+++ b/packages/lint-no-trailing-empty-field/README.md
@@ -2,9 +2,17 @@
 
 Lint rule that flags HL7v2 segments ending with one or more empty trailing fields.
 
+|                      |                                              |
+| -------------------- | -------------------------------------------- |
+| **Recommended**      | ✅ part of `@glion/preset-lint-recommended`  |
+| **Profile-aware**    | ❌                                           |
+| **Default severity** | `warning`                                    |
+| **Requires**         | `@glion/parser`                              |
+| **Since**            | `@glion/lint-no-trailing-empty-field@0.2.10` |
+
 ## What it does
 
-For each segment, finds the index of the last non-empty field and reports a warning if any empty fields appear after it. Trailing empty fields come from stray field separators (`|`) at the end of a segment and should be stripped — some strict receivers reject such segments, and downstream tools may misinterpret the empty positions.
+For each segment, finds the index of the last non-empty field and reports a warning when any empty fields appear after it. Trailing empty fields come from stray field separators (`|`) at the end of a segment. Strict receivers reject such segments, and downstream tools can misinterpret the empty positions.
 
 ## Install
 

--- a/packages/lint-profile-events-segments-order/README.md
+++ b/packages/lint-profile-events-segments-order/README.md
@@ -1,10 +1,18 @@
 # @glion/lint-profile-events-segments-order
 
-Lint rule that validates HL7v2 segment order against the message structure defined by the profile.
+Validate HL7v2 segment order against the message structure defined by the profile.
+
+|                      |                                                     |
+| -------------------- | --------------------------------------------------- |
+| **Recommended**      | ❌                                                  |
+| **Profile-aware**    | ✅ part of `@glion/preset-lint-profile-recommended` |
+| **Default severity** | `warning`                                           |
+| **Requires**         | `@glion/parser`                                     |
+| **Since**            | `@glion/lint-profile-events-segments-order@0.6.0`   |
 
 ## What it does
 
-Walks the parsed tree segment-by-segment, feeding each segment name into a DFA (Deterministic Finite Automaton) built from the message structure definition in `@glion/profiles`. Reports one message for the first segment that is not valid at its position, or for a message that ends before reaching an accepting state. When no explicit `definition` is given, the rule resolves one from `tree.data.messageInfo` or directly from `MSH-9.3` and `MSH-12`.
+Walks the parsed tree segment-by-segment, feeding each segment name into a DFA (Deterministic Finite Automaton) built from the message structure definition in `@glion/profiles`. Reports one message for the first segment that is not valid at its position, or for a message that ends before reaching an accepting state. When no explicit `definition` option is provided, the rule resolves one from `MSH-9.3` (or `MSH-9.1` + `MSH-9.2` via the event map) and `MSH-12.1`. When resolution fails, the rule exits silently.
 
 ## Install
 
@@ -15,8 +23,6 @@ npm install @glion/lint-profile-events-segments-order
 ## Use
 
 ```ts
-import { hl7v2AnnotateMessage } from "@glion/annotate-message";
-import { hl7v2AnnotateMessageStructure } from "@glion/annotate-message-structure";
 import { hl7v2Parser } from "@glion/parser";
 import hl7v2LintSegmentOrder from "@glion/lint-profile-events-segments-order";
 import { unified } from "unified";
@@ -24,37 +30,41 @@ import { reporter } from "vfile-reporter";
 
 const message = [
   "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
-  "EVN|A01|20250601120000",
   "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
 ].join("\r");
 
 const file = await unified()
   .use(hl7v2Parser)
-  .use(hl7v2AnnotateMessage)
-  .use(hl7v2AnnotateMessageStructure)
   .use(hl7v2LintSegmentOrder)
   .process(message);
 
 console.error(reporter([file]));
 ```
 
-With an explicit DFA definition (skips automatic resolution):
+## Options
+
+| Option       | Type         | Default     | Description                                                                                                         |
+| ------------ | ------------ | ----------- | ------------------------------------------------------------------------------------------------------------------- |
+| `definition` | `Definition` | `undefined` | Pre-loaded DFA definition. When provided, the rule uses it directly and skips automatic resolution from MSH fields. |
 
 ```ts
 import { profiles } from "@glion/profiles";
+import { hl7v2Parser } from "@glion/parser";
 import hl7v2LintSegmentOrder from "@glion/lint-profile-events-segments-order";
 import { unified } from "unified";
 
 const definition = await profiles.events.load("2.5", "ADT_A01");
 
-const processor = unified().use(hl7v2LintSegmentOrder, { definition });
+const processor = unified()
+  .use(hl7v2Parser)
+  .use(hl7v2LintSegmentOrder, { definition });
 ```
 
 ## API
 
 ### `unified().use(hl7v2LintSegmentOrder[, options])`
 
-A `unified` lint rule plugin.
+A `unified` lint rule plugin. Visits each `segment` node, drives a DFA built from the resolved (or supplied) message structure, and emits one diagnostic at the first invalid transition or one diagnostic at the end of the message when the DFA has not reached an accepting state.
 
 ```ts
 import type { Plugin } from "unified";
@@ -62,11 +72,6 @@ import type { Root } from "@glion/ast";
 import type { Definition } from "@glion/profiles";
 
 export interface SegmentOrderOptions {
-  /**
-   * Pre-loaded DFA definition for the message structure. When provided, the
-   * rule uses it directly and skips automatic resolution from tree metadata
-   * or MSH fields.
-   */
   definition?: Definition;
 }
 
@@ -74,11 +79,11 @@ declare const hl7v2LintSegmentOrder: Plugin<[SegmentOrderOptions?], Root>;
 export default hl7v2LintSegmentOrder;
 ```
 
-All messages use `ruleId: "segment-order"` and `source: "hl7v2-lint"`. The rule stops at the first error because a rejected DFA transition leaves the automaton in an undefined state, and subsequent errors would be misleading.
+Messages use `ruleId: "segment-order"` and `source: "hl7v2-lint"`. The rule stops at the first error because a rejected DFA transition leaves the automaton in an undefined state.
 
 ## What it checks
 
-Segments must appear in an order that the message structure DFA accepts, and the message must end in an accepting state. The rule also surfaces two resolution errors that prevent validation from running.
+Segments must appear in an order that the message structure DFA accepts, and the message must end in an accepting state. Three diagnostic shapes are emitted: an unexpected segment, a premature end, and an empty segment name.
 
 ### Valid
 
@@ -88,10 +93,9 @@ An `ADT_A01` message whose segments follow the structure defined for v2.5:
 MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
 EVN|A01|20250601120000
 PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
-PV1|1|I|WARD^101^1
 ```
 
-### Invalid — unexpected segment
+### Invalid
 
 `PID` appears before `EVN` in an `ADT_A01`:
 
@@ -106,49 +110,26 @@ Reported message:
 Unexpected segment 'PID'. Expected: EVN, SFT
 ```
 
-The offending segment name and the set of segments the DFA expected at that position are interpolated.
+The offending segment name and the comma-separated set of segments the DFA expected at that position are interpolated.
 
-### Invalid — message ended prematurely
-
-All segments were consumed but the DFA did not reach an accepting state:
+A message that ends before satisfying the DFA reports:
 
 ```
 Message ended prematurely. Expected: PV1, PV2
 ```
 
-The list is the set of segments that would have satisfied the accepting state from the current position. Only reported when no other validation error was emitted.
+The list is the set of segments that would have advanced the DFA toward an accepting state. This diagnostic is only emitted when no other validation error fired.
 
-### Invalid — empty segment name
-
-A `segment` node in the AST has an empty or undefined `name`:
+A `segment` node with an empty or undefined `name` reports:
 
 ```
 Segment has empty segment name at this position
 ```
 
-Indicates a malformed tree.
-
-### Resolution — missing metadata
-
-Neither `tree.data.messageInfo` nor the MSH fields yield the version and message structure:
-
-```
-Cannot validate segment order: missing version (MSH-12) or message structure (MSH-9.3)
-```
-
-### Resolution — profile not found
-
-The version and structure were resolved, but no matching profile definition exists:
-
-```
-Cannot validate segment order: no profile found for ZZZ_Z99 (v2.5)
-```
-
-Resolution errors cause validation to be skipped entirely.
-
 ## Part of Glion
 
-`@glion/lint-profile-events-segments-order` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-events-segments-order` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-extra-components/README.md
+++ b/packages/lint-profile-extra-components/README.md
@@ -1,10 +1,18 @@
 # @glion/lint-profile-extra-components
 
-Lint rule to warn when a composite field contains more components than its datatype profile defines.
+Warn when a composite field contains more components than its datatype profile defines.
+
+|                      |                                                     |
+| -------------------- | --------------------------------------------------- |
+| **Recommended**      | ❌                                                  |
+| **Profile-aware**    | ✅ part of `@glion/preset-lint-profile-recommended` |
+| **Default severity** | `warning`                                           |
+| **Requires**         | `@glion/parser`, `@glion/annotate-profile-context`  |
+| **Since**            | `@glion/lint-profile-extra-components@0.12.0`       |
 
 ## What it does
 
-Flags fields whose repetitions contain more components than the datatype's profile allows. For composite datatypes, the maximum is the highest sequence key in the datatype definition; for primitive datatypes the maximum is 1 (the value itself). The rule reads profile context attached by `@glion/annotate-profile-context`. Empty fields, fields on unknown segments, and fields whose datatype definition is missing are silently skipped.
+Reads `file.data.profile` populated by `@glion/annotate-profile-context`. For each non-empty field, it resolves the datatype definition: for primitive datatypes the maximum is 1 (the value itself); for composite datatypes it is the highest sequence key in `dtDef.componentsBySequence`. Each component at a position greater than that maximum produces one message per offending repetition. Empty fields, fields on segments without a known profile (for example Z-segments), and fields whose datatype definition is missing are silently skipped.
 
 ## Install
 
@@ -22,7 +30,7 @@ import { unified } from "unified";
 import { reporter } from "vfile-reporter";
 
 const message = [
-  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.7.1",
   "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
 ].join("\r");
 
@@ -39,9 +47,7 @@ console.error(reporter([file]));
 
 ### `unified().use(hl7v2LintExtraComponents)`
 
-A `unified` lint rule plugin. Takes no options.
-
-Reads `file.data.profile`. For each non-empty field it resolves the datatype definition. For primitives the allowed component count is 1; for composites it is the highest key in `dtDef.componentsBySequence`. Every component at a position greater than that max produces one message per offending repetition.
+A `unified` lint rule plugin. Takes no options. Visits each `field` node, looks up its profile from `file.data.profile`, and reports one message per component past the datatype maximum in each repetition.
 
 ```ts
 import type { Plugin } from "unified";
@@ -51,39 +57,40 @@ declare const hl7v2LintExtraComponents: Plugin<[], Root>;
 export default hl7v2LintExtraComponents;
 ```
 
+Messages use `ruleId: "extra-components"` and `source: "hl7v2-lint"`.
+
 ## What it checks
 
-This rule flags `^`-delimited components past the profile's defined range for a datatype. `PID-8` (Administrative Sex) is a primitive field in v2.5, so it allows exactly one component.
+Each `^`-delimited component past the profile's defined range for the field's datatype is flagged. For primitives the maximum is 1; for composites it is the highest sequence number defined for the datatype at the message's HL7v2 version.
 
 ### Valid
 
-`PID-8` has a single component (`F`), which matches the primitive limit:
+`MSH-9` (datatype `MSG`) carries exactly the three components defined for v2.7.1:
 
 ```hl7
-MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
-PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20241201||ADT^A01^ADT_A01|MSG001|P|2.7.1
 ```
 
 ### Invalid
 
-`PID-8` has two components (`F^EXTRA`), which exceeds the v2.5 primitive limit of 1:
+`MSH-9` carries five components, two beyond the v2.7.1 `MSG` maximum of 3:
 
 ```hl7
-MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
-PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F^EXTRA
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20241201||ADT^A01^ADT_A01^EXTRA1^EXTRA2|MSG001|P|2.7.1
 ```
 
 Reported message:
 
 ```
-Component PID-8.2 is beyond the defined components for IS (max: 1 in v2.5)
+Component MSH-9.4 is beyond the defined components for MSG (max: 3 in v2.7.1)
 ```
 
-The datatype code (for example `IS`, `CX`, `XPN`) comes from the field's profile. For composite datatypes the same rule applies — a `CX` field in v2.5 defines up to 10 components, so a value carrying an 11th is reported against that datatype.
+The segment name, sequence, component number, datatype code, defined maximum, and HL7v2 version are interpolated from the offending node and the profile context. One message is emitted per extra component per repetition.
 
 ## Part of Glion
 
-`@glion/lint-profile-extra-components` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-extra-components` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-extra-fields/README.md
+++ b/packages/lint-profile-extra-fields/README.md
@@ -1,10 +1,18 @@
 # @glion/lint-profile-extra-fields
 
-Lint rule that warns when a segment contains fields beyond the maximum sequence defined in its profile.
+Warn when a segment contains fields beyond the maximum sequence defined in its profile.
+
+|                      |                                                     |
+| -------------------- | --------------------------------------------------- |
+| **Recommended**      | ❌                                                  |
+| **Profile-aware**    | ✅ part of `@glion/preset-lint-profile-recommended` |
+| **Default severity** | `warning`                                           |
+| **Requires**         | `@glion/parser`, `@glion/annotate-profile-context`  |
+| **Since**            | `@glion/lint-profile-extra-fields@0.12.0`           |
 
 ## What it does
 
-Flags fields whose sequence number exceeds the highest field position defined in the HL7v2 profile for that segment at the message's version. The rule reads profile context attached by `@glion/annotate-profile-context`, computes the maximum defined sequence per segment, and reports each field past that boundary. Segments without a known profile (for example Z-segments) are silently skipped.
+Reads `file.data.profile` populated by `@glion/annotate-profile-context`. For each segment with a known profile, it computes the maximum sequence number declared in `fieldDef.bySequence` and reports each field whose sequence exceeds that maximum. Segments without a known profile (for example Z-segments) are silently skipped.
 
 ## Install
 
@@ -22,7 +30,7 @@ import { unified } from "unified";
 import { reporter } from "vfile-reporter";
 
 const message = [
-  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5.1",
   "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
 ].join("\r");
 
@@ -39,9 +47,7 @@ console.error(reporter([file]));
 
 ### `unified().use(hl7v2LintExtraFields)`
 
-A `unified` lint rule plugin. Takes no options.
-
-Reads `file.data.profile`. For each segment it looks up the field definition set and takes the largest key (a 1-based HL7 sequence number) as the maximum. It then walks the segment's fields and reports each field whose sequence is greater than that maximum.
+A `unified` lint rule plugin. Takes no options. Visits each `segment` node, looks up its profile from `file.data.profile`, and reports one message per field whose 1-based sequence number is greater than the highest defined sequence.
 
 ```ts
 import type { Plugin } from "unified";
@@ -51,39 +57,42 @@ declare const hl7v2LintExtraFields: Plugin<[], Root>;
 export default hl7v2LintExtraFields;
 ```
 
+Messages use `ruleId: "extra-fields"` and `source: "hl7v2-lint"`.
+
 ## What it checks
 
-This rule flags fields past the defined range for a segment. `MSH` in v2.5 ends at `MSH-21`, so any field at sequence 22 or higher is unexpected for that segment and version.
+Each field whose sequence number exceeds the highest sequence defined for its segment in the HL7v2 profile is flagged. In v2.5.1, `PID` defines fields up to `PID-39`, so any `PID-40` or higher is reported.
 
 ### Valid
 
-`MSH` stops at `MSH-12` (Version ID) and all fields are within the v2.5 definition:
+`PID` stops at `PID-3` and all fields are within the v2.5.1 definition:
 
 ```hl7
-MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
-PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20241201||ADT^A01^ADT_A01|MSG001|P|2.5.1
+PID|1||ID123
 ```
 
 ### Invalid
 
-`MSH` carries a field at sequence 22, which is past the v2.5 maximum of `MSH-21`:
+`PID` carries fields at sequences 40 and 41, two past the v2.5.1 maximum of `PID-39`:
 
 ```hl7
-MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5||||||||||EXTRA
-PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20241201||ADT^A01^ADT_A01|MSG001|P|2.5.1
+PID|val1|val2|val3|val4|val5|val6|val7|val8|val9|val10|val11|val12|val13|val14|val15|val16|val17|val18|val19|val20|val21|val22|val23|val24|val25|val26|val27|val28|val29|val30|val31|val32|val33|val34|val35|val36|val37|val38|val39|val40|val41
 ```
 
 Reported message:
 
 ```
-Field MSH-22 is beyond the defined fields for MSH (max: 21 in v2.5)
+Field PID-40 is beyond the defined fields for PID (max: 39 in v2.5.1)
 ```
 
-The reported max comes from the profile's highest sequence number and the version is taken from the annotated profile context. One message is reported per extra field.
+The segment name, offending sequence, defined maximum, and HL7v2 version are interpolated. One message is emitted per extra field.
 
 ## Part of Glion
 
-`@glion/lint-profile-extra-fields` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-extra-fields` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-field-max-length/README.md
+++ b/packages/lint-profile-field-max-length/README.md
@@ -1,10 +1,18 @@
 # @glion/lint-profile-field-max-length
 
-Lint rule to validate field value lengths against HL7v2 profile maxLength.
+Validate field value lengths against HL7v2 profile `maxLength`.
+
+|                      |                                                     |
+| -------------------- | --------------------------------------------------- |
+| **Recommended**      | ❌                                                  |
+| **Profile-aware**    | ✅ part of `@glion/preset-lint-profile-recommended` |
+| **Default severity** | `warning`                                           |
+| **Requires**         | `@glion/parser`, `@glion/annotate-profile-context`  |
+| **Since**            | `@glion/lint-profile-field-max-length@0.6.0`        |
 
 ## What it does
 
-Flags field values that exceed the `maxLength` declared in the HL7v2 profile for the message's version. Length is computed by recursively summing the string lengths of all subcomponent values in a repetition, so delimiters (`^`, `&`, `~`) are not counted. The rule reads profile context attached by `@glion/annotate-profile-context` and reports once per offending repetition. Fields without a declared `maxLength`, empty fields, and Z-segments are skipped.
+Reads `file.data.profile` populated by `@glion/annotate-profile-context`. For each non-empty field whose profile declares a `maxLength`, the rule computes each repetition's content length with `getLength()` from `@glion/utils` (a recursive sum of subcomponent string lengths, so delimiters are not counted) and reports the repetitions over the limit. Fields without `maxLength` in the profile, empty fields, and segments without a known profile (for example Z-segments) are silently skipped.
 
 ## Install
 
@@ -39,9 +47,7 @@ console.error(reporter([file]));
 
 ### `unified().use(hl7v2LintFieldMaxLength)`
 
-A `unified` lint rule plugin. Takes no options.
-
-Reads `file.data.profile`. For each segment in the tree it walks its fields, looks up the profile entry by sequence, and — if a `maxLength` is declared — compares it against `getLength()` from `@glion/utils` for every repetition. Each repetition over the limit produces one message.
+A `unified` lint rule plugin. Takes no options. Visits each `segment` node, then each `field` node within it; for fields whose profile defines `maxLength`, it compares `getLength(repetition)` against the limit for every repetition.
 
 ```ts
 import type { Plugin } from "unified";
@@ -51,39 +57,42 @@ declare const hl7v2LintFieldMaxLength: Plugin<[], Root>;
 export default hl7v2LintFieldMaxLength;
 ```
 
+Messages use `ruleId: "field-max-length"` and `source: "hl7v2-lint"`.
+
 ## What it checks
 
-This rule flags fields whose measured content length is greater than the `maxLength` declared for that field in the HL7v2 profile. In v2.5, `MSH-10` (Message Control ID) has `maxLength: 20`.
+Each repetition whose measured content length is greater than the `maxLength` declared for its field in the HL7v2 profile is flagged. In v2.5, `PID-1` (Set ID — PID) has `maxLength: 4`.
 
 ### Valid
 
-`MSH-10` carries a 9-character Message Control ID, well within the v2.5 limit of 20:
+`PID-1` carries `1234`, exactly the v2.5 limit of 4 characters:
 
 ```hl7
-MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
-PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20241201||ADT^A01^ADT_A01|MSG001|P|2.5
+PID|1234
 ```
 
 ### Invalid
 
-`MSH-10` is 28 characters long, exceeding the v2.5 limit of 20:
+`PID-1` is 5 characters long, exceeding the v2.5 limit of 4:
 
 ```hl7
-MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG0000000000000000000000001|P|2.5
-PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20241201||ADT^A01^ADT_A01|MSG001|P|2.5
+PID|12345
 ```
 
 Reported message:
 
 ```
-Field MSH-10 exceeds max length of 20 (actual: 28)
+Field PID-1 exceeds max length of 4 (actual: 5)
 ```
 
-One message is produced per offending repetition. Delimiters are not included in the measured length — a composite value like `DOE^JANE` counts as 7 characters, not 8.
+The segment name, sequence, declared maximum, and measured length are interpolated. One message is emitted per offending repetition. Delimiters are not included in the measured length — a composite value like `DOE^JANE` counts as 7 characters.
 
 ## Part of Glion
 
-`@glion/lint-profile-field-max-length` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-field-max-length` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-field-repetition/README.md
+++ b/packages/lint-profile-field-repetition/README.md
@@ -1,10 +1,18 @@
 # @glion/lint-profile-field-repetition
 
-Lint rule that flags non-repeatable fields with multiple repetitions.
+Flag non-repeatable fields with multiple repetitions.
+
+|                      |                                                     |
+| -------------------- | --------------------------------------------------- |
+| **Recommended**      | ❌                                                  |
+| **Profile-aware**    | ✅ part of `@glion/preset-lint-profile-recommended` |
+| **Default severity** | `warning`                                           |
+| **Requires**         | `@glion/parser`, `@glion/annotate-profile-context`  |
+| **Since**            | `@glion/lint-profile-field-repetition@0.6.0`        |
 
 ## What it does
 
-Flags fields that contain more than one repetition (delimited by `~`) when the HL7v2 profile for the message's version declares `repeatable: false` for that field. The rule reads profile context attached by `@glion/annotate-profile-context`. A single repetition is always valid regardless of the `repeatable` flag; only 2+ repetitions on a non-repeatable field are reported. Segments without a known profile are silently skipped.
+Reads `file.data.profile` populated by `@glion/annotate-profile-context`. For each field under a segment with a known profile, it looks up the field profile by sequence; when `repeatable: false` and the AST contains more than one repetition, the rule emits one message for that field. A single repetition is always valid regardless of the `repeatable` flag. Segments without a known profile (for example Z-segments) are silently skipped.
 
 ## Install
 
@@ -39,9 +47,7 @@ console.error(reporter([file]));
 
 ### `unified().use(hl7v2LintFieldRepetition)`
 
-A `unified` lint rule plugin. Takes no options.
-
-Reads `file.data.profile`. For each field under a segment with a known profile it looks up the field entry by sequence. If the field's profile sets `repeatable: false` and the AST has more than one repetition, the rule emits one message for that field.
+A `unified` lint rule plugin. Takes no options. Visits each `segment` node, then each `field` node within it; when the field profile sets `repeatable: false` and the field has 2 or more repetitions, the rule emits one diagnostic for that field.
 
 ```ts
 import type { Plugin } from "unified";
@@ -51,39 +57,42 @@ declare const hl7v2LintFieldRepetition: Plugin<[], Root>;
 export default hl7v2LintFieldRepetition;
 ```
 
+Messages use `ruleId: "field-repetition"` and `source: "hl7v2-lint"`.
+
 ## What it checks
 
-This rule flags fields with multiple `~`-delimited repetitions when the profile marks the field as non-repeatable. For example, `PID-7` (Date of Birth) is not repeatable in v2.5.
+Each field with two or more `~`-delimited repetitions when the profile marks it as non-repeatable is flagged. In v2.5, `PID-1` (Set ID — PID) is non-repeatable.
 
 ### Valid
 
-`PID-7` carries a single Date of Birth:
+`PID-1` carries a single value:
 
 ```hl7
-MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
-PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20241201||ADT^A01^ADT_A01|MSG001|P|2.5
+PID|1
 ```
 
 ### Invalid
 
-`PID-7` carries two `~`-separated values, which violates the v2.5 profile for the `PID-7` field:
+`PID-1` carries two `~`-separated values, violating the v2.5 profile for that field:
 
 ```hl7
-MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
-PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101~19800102|F
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20241201||ADT^A01^ADT_A01|MSG001|P|2.5
+PID|1~2
 ```
 
 Reported message:
 
 ```
-Field PID-7 (Date/Time of Birth) is not repeatable but has 2 repetitions
+Field PID-1 (Set ID - PID) is not repeatable but has 2 repetitions
 ```
 
-When the field name is available in the profile it appears in parentheses after the position. The reported count equals the number of repetitions present in the field.
+The segment name, sequence, optional profile name (parenthesised when present), and repetition count are interpolated. The parenthesised name is omitted when the field profile does not provide one.
 
 ## Part of Glion
 
-`@glion/lint-profile-field-repetition` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-field-repetition` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-required-components/README.md
+++ b/packages/lint-profile-required-components/README.md
@@ -1,10 +1,18 @@
 # @glion/lint-profile-required-components
 
-Lint rule to validate required components in composite datatype fields.
+Validate required components in composite datatype fields.
+
+|                      |                                                     |
+| -------------------- | --------------------------------------------------- |
+| **Recommended**      | ❌                                                  |
+| **Profile-aware**    | ✅ part of `@glion/preset-lint-profile-recommended` |
+| **Default severity** | `warning`                                           |
+| **Requires**         | `@glion/parser`, `@glion/annotate-profile-context`  |
+| **Since**            | `@glion/lint-profile-required-components@0.6.0`     |
 
 ## What it does
 
-Flags composite fields whose required components (as declared by the datatype profile for the message's version) are missing or empty in any repetition. The rule reads profile context attached by `@glion/annotate-profile-context`, resolves each field's datatype, and checks the required components on every repetition. Empty fields, primitive datatypes, and segments without a known profile are skipped.
+Reads `file.data.profile` populated by `@glion/annotate-profile-context`. For each non-empty field whose datatype is composite and has at least one required component, the rule iterates `dtDef.requiredSequences` for every repetition and reports each component whose first subcomponent value is missing or empty. Empty fields, primitive datatypes, and segments without a known profile (for example Z-segments) are silently skipped — the empty-field case belongs to `@glion/lint-profile-required-fields`.
 
 ## Install
 
@@ -22,7 +30,7 @@ import { unified } from "unified";
 import { reporter } from "vfile-reporter";
 
 const message = [
-  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5",
+  "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.7.1",
   "PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F",
 ].join("\r");
 
@@ -39,9 +47,7 @@ console.error(reporter([file]));
 
 ### `unified().use(hl7v2LintRequiredComponents)`
 
-A `unified` lint rule plugin. Takes no options.
-
-Reads `file.data.profile`. For each non-empty field, resolves the datatype definition from the field profile and iterates `dtDef.requiredSequences`. For every field repetition, checks that each required component is present with a non-empty first subcomponent value.
+A `unified` lint rule plugin. Takes no options. Visits each `field` node, resolves its datatype definition through `file.data.profile`, and emits one diagnostic per missing required component per repetition.
 
 ```ts
 import type { Plugin } from "unified";
@@ -51,39 +57,40 @@ declare const hl7v2LintRequiredComponents: Plugin<[], Root>;
 export default hl7v2LintRequiredComponents;
 ```
 
+Messages use `ruleId: "required-components"` and `source: "hl7v2-lint"`.
+
 ## What it checks
 
-This rule flags missing required components on composite fields. The classic case is `MSH-9` (Message Type), where the `MSG` datatype requires the message code (`.1`) and trigger event (`.2`) components.
+Each required component on a composite field whose first subcomponent value is absent or empty is flagged. In v2.7.1 the `MSG` datatype on `MSH-9` (Message Type) requires the message code (`.1`), trigger event (`.2`), and message structure (`.3`) components.
 
 ### Valid
 
-`MSH-9` carries message code, trigger event, and message structure:
+`MSH-9` carries all three required `MSG` components:
 
 ```hl7
-MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
-PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20241201||ADT^A01^ADT_A01|MSG001|P|2.7.1
 ```
 
 ### Invalid
 
-`MSH-9.2` (Trigger Event) is empty, which violates the `MSG` datatype profile in v2.5:
+`MSH-9` is missing component 3 (Message Structure):
 
 ```hl7
-MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^|MSG00001|P|2.5
-PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20241201||ADT^A01|MSG001|P|2.7.1
 ```
 
 Reported message:
 
 ```
-Required component MSH-9.2 (Trigger Event) is missing or empty
+Required component MSH-9.3 (Message Structure) is missing or empty
 ```
 
-When the component name is available in the datatype profile it appears in parentheses. One message is reported per missing required component per repetition.
+The segment name, sequence, component number, and optional component name (parenthesised when the datatype profile provides one) are interpolated. The parenthesised name is omitted when the component profile does not carry one.
 
 ## Part of Glion
 
-`@glion/lint-profile-required-components` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-required-components` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-required-fields/README.md
+++ b/packages/lint-profile-required-fields/README.md
@@ -1,10 +1,18 @@
 # @glion/lint-profile-required-fields
 
-Lint rule to validate required fields per HL7v2 profile.
+Validate required fields per HL7v2 profile.
+
+|                      |                                                     |
+| -------------------- | --------------------------------------------------- |
+| **Recommended**      | ❌                                                  |
+| **Profile-aware**    | ✅ part of `@glion/preset-lint-profile-recommended` |
+| **Default severity** | `warning`                                           |
+| **Requires**         | `@glion/parser`, `@glion/annotate-profile-context`  |
+| **Since**            | `@glion/lint-profile-required-fields@0.6.0`         |
 
 ## What it does
 
-Flags segments whose required fields (as declared by the HL7v2 profile for the message's version) are missing or empty. The rule reads profile context attached to the file by `@glion/annotate-profile-context` and reports one message per missing required field. Segments without a known profile (for example Z-segments like `ZPD`) are silently skipped.
+Reads `file.data.profile` populated by `@glion/annotate-profile-context`. For each segment with a known profile, the rule iterates `fieldDef.requiredSequences` and reports one message per required field that is missing from the segment or empty in the AST. Segments without a known profile (for example Z-segments like `ZPD`) are silently skipped.
 
 ## Install
 
@@ -39,9 +47,7 @@ console.error(reporter([file]));
 
 ### `unified().use(hl7v2LintRequiredFields)`
 
-A `unified` lint rule plugin. Takes no options.
-
-The plugin reads `file.data.profile` (populated by `@glion/annotate-profile-context`). If no profile context is present the rule exits silently. For each segment, it iterates `fieldDef.requiredSequences` and checks that the corresponding field at that 1-based position is present and non-empty.
+A `unified` lint rule plugin. Takes no options. Visits each `segment` node, looks up its profile from `file.data.profile`, and emits one diagnostic per required field whose corresponding 1-based position is absent or empty.
 
 ```ts
 import type { Plugin } from "unified";
@@ -51,26 +57,28 @@ declare const hl7v2LintRequiredFields: Plugin<[], Root>;
 export default hl7v2LintRequiredFields;
 ```
 
+Messages use `ruleId: "required-fields"` and `source: "hl7v2-lint"`.
+
 ## What it checks
 
-This rule flags fields declared `required: true` in the HL7v2 profile for the message's version when those fields are missing or empty on the corresponding segment.
+Each field declared `required: true` in the HL7v2 profile for the message's version is flagged when missing or empty on the corresponding segment. In v2.5, `PID-3` (Patient Identifier List) is required.
 
 ### Valid
 
-`PID-3` (Patient Identifier List) and `PID-5` (Patient Name) are required in v2.5 and both are populated:
+`PID-3` and `PID-5` are required in v2.5 and both are populated:
 
 ```hl7
-MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
-PID|1||PATID1234^^^HOSP^MR||DOE^JANE||19800101|F
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20241201||ADT^A01^ADT_A01|MSG001|P|2.5
+PID|1||12345||Doe^John
 ```
 
 ### Invalid
 
-`PID-3` is empty, which violates the v2.5 profile for the `PID` segment:
+`PID-3` is empty, violating the v2.5 profile for the `PID` segment:
 
 ```hl7
-MSH|^~\&|SENDER|FAC|RECV|RFAC|20250601120000||ADT^A01^ADT_A01|MSG00001|P|2.5
-PID|1||||DOE^JANE||19800101|F
+MSH|^~\&|SENDER|FAC|RECV|RFAC|20241201||ADT^A01^ADT_A01|MSG001|P|2.5
+PID|1||||Doe
 ```
 
 Reported message:
@@ -79,11 +87,12 @@ Reported message:
 Required field PID-3 (Patient Identifier List) is missing or empty
 ```
 
-When the profile attaches a field name, it appears in parentheses after the position. Segments shorter than the highest required sequence produce one message per missing required field.
+The segment name, sequence, and optional profile name (parenthesised when present) are interpolated. The parenthesised name is omitted when the field profile does not provide one. Segments shorter than the highest required sequence produce one message per missing required field.
 
 ## Part of Glion
 
-`@glion/lint-profile-required-fields` is part of **[Glion]**, the application framework for HL7v2. See the [Glion README] for the full package catalog and architecture.
+`@glion/lint-profile-required-fields` is part of **[Glion]**, the application framework for HL7v2.
+See the [Glion README] for the full package catalog and architecture.
 
 [Glion]: https://github.com/rethinkhealth/glion#readme
 [Glion README]: https://github.com/rethinkhealth/glion#readme

--- a/packages/lint-profile-table-values/README.md
+++ b/packages/lint-profile-table-values/README.md
@@ -2,6 +2,14 @@
 
 Lint rule to validate coded field values against HL7v2 tables.
 
+|                      |                                                     |
+| -------------------- | --------------------------------------------------- |
+| **Recommended**      | ❌                                                  |
+| **Profile-aware**    | ✅ part of `@glion/preset-lint-profile-recommended` |
+| **Default severity** | `warning`                                           |
+| **Requires**         | `@glion/parser`, `@glion/annotate-profile-context`  |
+| **Since**            | `@glion/lint-profile-table-values@0.6.0`            |
+
 ## What it does
 
 Flags coded field values that are not present in the HL7-defined table referenced by the field's profile. The rule reads profile context attached by `@glion/annotate-profile-context`, resolves the table by id (stripping the `HL7` prefix, so `HL70001` looks up table `0001`), and checks the first component value of each repetition against the table's code set. Only `hl7`-type tables are validated; user-defined tables, empty fields, and Z-segments are skipped.

--- a/packages/lint-required-message-header/README.md
+++ b/packages/lint-required-message-header/README.md
@@ -2,9 +2,17 @@
 
 Lint rule that requires the message header segment (`MSH`) to be the first segment of an HL7v2 message.
 
+|                      |                                             |
+| -------------------- | ------------------------------------------- |
+| **Recommended**      | ✅ part of `@glion/preset-lint-recommended` |
+| **Profile-aware**    | ❌                                          |
+| **Default severity** | `error`                                     |
+| **Requires**         | `@glion/parser`                             |
+| **Since**            | `@glion/lint-required-message-header@0.2.8` |
+
 ## What it does
 
-Walks the parsed tree and checks that the first `segment` node is named `MSH`. If a different segment appears first, the rule reports one fail message naming the offending segment and stops. HL7v2 messages must begin with `MSH` because it carries the metadata required for routing and interpretation.
+Walks the parsed tree and checks that the first `segment` node is named `MSH`. When a different segment appears first, the rule calls `file.fail(...)` with a fatal diagnostic naming the offending segment and stops. HL7v2 messages begin with `MSH` because it carries the metadata required for routing and interpretation.
 
 ## Install
 

--- a/packages/lint-segment-header-length/README.md
+++ b/packages/lint-segment-header-length/README.md
@@ -2,9 +2,17 @@
 
 Lint rule that flags HL7v2 segment headers whose name is not exactly three characters.
 
+|                      |                                             |
+| -------------------- | ------------------------------------------- |
+| **Recommended**      | ✅ part of `@glion/preset-lint-recommended` |
+| **Profile-aware**    | ❌                                          |
+| **Default severity** | `warning`                                   |
+| **Requires**         | `@glion/parser`                             |
+| **Since**            | `@glion/lint-segment-header-length@0.2.8`   |
+
 ## What it does
 
-Visits every `segment` node and checks that `node.name.length === 3`. HL7v2 segments are identified by a three-character code (`MSH`, `PID`, `OBX`, `ZAD`). Lengths other than three usually indicate a typo (`PID1`, `MS`, `Obx`), malformed input, or a miscoded private extension.
+Visits every `segment` node and checks that `node.name.length === 3`. HL7v2 segments are identified by a three-character code (`MSH`, `PID`, `OBX`, `ZAD`). Lengths other than three indicate a typo (`PID1`, `MS`, `Obx`), malformed input, or a miscoded private extension.
 
 ## Install
 

--- a/packages/mllp-ack/README.md
+++ b/packages/mllp-ack/README.md
@@ -4,7 +4,7 @@ MLLP middleware that generates HL7v2 acknowledgments automatically from handler 
 
 ## What it does
 
-`@glion/mllp-ack` exports `ackMiddleware()`, a middleware for `@glion/mllp` that wraps your route handlers and produces an ACK/NAK response for every accepted message. When a handler returns without throwing, the middleware emits an AA (or a configurable success code such as CA for commit-level acknowledgments). When a handler throws an `AckException` from `@glion/ack`, the middleware translates it into the matching AE/AR/CE/CR response with an ERR segment. Plain `Error` values become `ApplicationInternalError` (AE, error code 207), so routes that forget to handle a failure still produce a valid NAK instead of silence.
+`@glion/mllp-ack` exports `ackMiddleware()`, a middleware for `@glion/mllp` that wraps route handlers and produces an ACK/NAK response for every accepted message. When a handler returns without throwing, the middleware emits an AA (or a configured success code such as CA for commit-level acknowledgments). When a handler throws an `AckException` from `@glion/ack`, the middleware translates it into the matching AE/AR/CE/CR response with an ERR segment. Plain `Error` values become `ApplicationInternalError` (AE, error code 207), so handlers that do not catch a failure still produce a valid NAK.
 
 ## Install
 
@@ -124,7 +124,7 @@ If `ctx.res` was already set by a handler and nothing threw, the middleware leav
 
 ### `ctx.ast` vs `ctx.tree()`
 
-The middleware reads `ctx.ast` — the raw parsed tree — rather than `await ctx.tree()`. `acknowledge()` only needs the MSH header fields (MSH-3 through MSH-12), which are already present in the pre-transform tree. Avoiding `ctx.tree()` means the transform pipeline (escape decoding, annotations, lint) is not triggered for ACK construction, so the middleware adds zero async overhead. If you write custom ACK middleware, follow the same pattern.
+The middleware reads `ctx.ast` — the raw parsed tree — rather than `await ctx.tree()`. `acknowledge()` only needs the MSH header fields (MSH-3 through MSH-12), which are already present in the pre-transform tree. Avoiding `ctx.tree()` means the transform pipeline (escape decoding, annotations, lint) is not triggered for ACK construction, so the middleware adds zero async overhead.
 
 ### Interaction with `onError`
 

--- a/packages/mllp/README.md
+++ b/packages/mllp/README.md
@@ -4,7 +4,7 @@ Transport-agnostic MLLP engine and middleware-driven MLLP server for HL7v2 messa
 
 ## What it does
 
-`@glion/mllp` provides everything you need to send and receive HL7v2 messages over MLLP/TCP: frame encoding and decoding primitives, streaming TransformStreams for chunked TCP, and an `Mllp` class with pattern-based routing, composable middleware, and first-class `unified` processor integration. The server is transport-agnostic at its core and ships with a `serve()` helper for Node.js and Bun.
+`@glion/mllp` provides primitives for sending and receiving HL7v2 messages over MLLP/TCP: frame encoding and decoding, streaming `TransformStream`s for chunked TCP, and an `Mllp` class with pattern-based routing, composable middleware, and a `unified` processor as the parse stage. The engine is transport-agnostic; the package ships a `serve()` helper at `@glion/mllp/node` that binds it to a Node.js or Bun TCP server.
 
 ## Install
 
@@ -37,13 +37,13 @@ const app = new Mllp()
 const server = serve(app, { port: 2575 });
 ```
 
-To run the app with live reload during development and a production start command, use the `@glion/cli` package — it provides the `glion dev` / `glion start` binary and configuration loader. This README focuses on the server primitives themselves.
+The `@glion/cli` package wraps an `Mllp` instance with `glion dev` (live reload) and `glion start` (production lifecycle). This README covers the server primitives only.
 
 ## API
 
 ### `Mllp`
 
-The server class. Built with a fluent chainable API:
+The server class. Methods return the instance for chaining.
 
 | Method                      | Description                                                                 |
 | --------------------------- | --------------------------------------------------------------------------- |
@@ -55,7 +55,7 @@ The server class. Built with a fluent chainable API:
 
 ### `serve(app, options)` — from `@glion/mllp/node`
 
-Start a Node.js or Bun TCP server that dispatches incoming MLLP frames through the `Mllp` instance.
+Starts a Node.js or Bun TCP server that dispatches incoming MLLP frames through the `Mllp` instance.
 
 - `port` (`number`) — TCP port to listen on.
 - `hostname` (`string`, optional) — interface to bind. Defaults to all interfaces.
@@ -65,9 +65,9 @@ Start a Node.js or Bun TCP server that dispatches incoming MLLP frames through t
 
 | Function                        | Description                                            |
 | ------------------------------- | ------------------------------------------------------ |
-| `encode(message)`               | Encode a message string into an MLLP frame.            |
-| `decode(frame)`                 | Decode a single MLLP frame to its message.             |
-| `encodeMultiple(messages)`      | Encode an array of messages in one pass.               |
+| `encode(message)`               | Encodes a message string into an MLLP frame.           |
+| `decode(frame)`                 | Decodes a single MLLP frame to its message.            |
+| `encodeMultiple(messages)`      | Encodes an array of messages in one pass.              |
 | `createDecoderStream(options?)` | TransformStream for streaming decode from chunked TCP. |
 
 ### Types
@@ -87,7 +87,7 @@ Start a Node.js or Bun TCP server that dispatches incoming MLLP frames through t
 
 ## Routing
 
-Register routes by message type, trigger event, or pattern:
+Routes match by message type, trigger event, or pattern:
 
 ```ts
 app.on("ADT^A01", handler); // exact match
@@ -97,7 +97,7 @@ app.on("ADT", handler); // any ADT (same as ADT^*)
 app.on("*", handler); // catch-all
 ```
 
-Routes are matched first-match-wins — register specific routes before catch-alls.
+Routes match first-match-wins. Specific routes take precedence only when registered before catch-alls.
 
 ## Middleware
 
@@ -127,7 +127,7 @@ app.use(async (ctx) => {
 
 ## Context
 
-Available in every middleware and handler. The pipeline is lazy: only the parse step runs eagerly; transforms and compilation are deferred until accessed.
+Available in every middleware and handler. The pipeline is lazy: only the parse step runs eagerly; transforms and compilation are deferred until accessed. `ctx.ast` returns the raw parsed AST synchronously and is sufficient for routing fields, MSH reads, and ACK construction. `await ctx.tree()` triggers the transform pipeline (escape decoding, annotations, lint) and returns the transformed AST. `await ctx.result()` triggers transform plus compile. Both async methods cache their result after first call.
 
 ### Sync properties
 
@@ -143,86 +143,18 @@ Available in every middleware and handler. The pipeline is lazy: only the parse 
 | `ctx.controlId`        | MSH-10 message control ID.                              |
 | `ctx.ast`              | Raw parsed AST — pre-transform, straight from the wire. |
 | `ctx.file`             | VFile (diagnostics accumulate after `tree()`).          |
-| `ctx.set(key, value)`  | Store a variable.                                       |
-| `ctx.get(key)`         | Retrieve a variable.                                    |
+| `ctx.set(key, value)`  | Stores a variable.                                      |
+| `ctx.get(key)`         | Retrieves a variable.                                   |
 | `ctx.var`              | Read-only snapshot of all variables.                    |
 
 ### Async methods
 
-| Method               | Triggers                | Description                                           |
-| -------------------- | ----------------------- | ----------------------------------------------------- |
-| `await ctx.tree()`   | `run()` (transform)     | Transformed AST — escape decoding, annotations, lint. |
-| `await ctx.result()` | `run()` + `stringify()` | Compiled output (e.g. JSON from `hl7v2Jsonify`).      |
+| Method               | Triggers                | Description                                                       |
+| -------------------- | ----------------------- | ----------------------------------------------------------------- |
+| `await ctx.tree()`   | `run()` (transform)     | Returns the transformed AST — escape decoding, annotations, lint. |
+| `await ctx.result()` | `run()` + `stringify()` | Returns the compiled output (e.g. JSON from `hl7v2Jsonify`).      |
 
-Both are cached — subsequent calls return the same value instantly.
-
-### `ctx.ast` vs `await ctx.tree()`
-
-Use `ctx.ast` when you only need the raw message structure — reading MSH fields, building ACK/NAK responses, route filter functions, or middleware that doesn't need escape-decoded values:
-
-```ts
-// Fast — no pipeline cost.
-app.use((ctx, next) => {
-  console.log(`Received ${ctx.messageType}^${ctx.triggerEvent}`);
-  return next();
-});
-```
-
-Use `await ctx.tree()` when you need the fully processed tree — business logic that reads decoded field values, or handlers that inspect annotations or resolved message structures:
-
-```ts
-// Triggers transform pipeline on first call.
-app.on("ADT^A01", async (ctx) => {
-  const tree = await ctx.tree();
-  // tree has escape sequences decoded, message structure resolved, etc.
-  return { raw: "..." };
-});
-```
-
-Use `await ctx.result()` when you need the compiled output:
-
-```ts
-app.on("ORU^R01", async (ctx) => {
-  const json = await ctx.result(); // triggers transform + compile
-  await saveToDatabase(json);
-  return { raw: "..." };
-});
-```
-
-### Writing middleware — prefer `ctx.ast`
-
-Most middleware only needs routing fields or raw MSH data — both available synchronously from `ctx.ast`. Reach for `await ctx.tree()` only when you genuinely need the transformed tree.
-
-```ts
-// Good — sync, fast, no pipeline cost.
-function authMiddleware(): Middleware {
-  return (ctx, next) => {
-    if (!isAuthorized(ctx.connection.remoteAddress)) {
-      return { raw: buildNak(ctx.ast, "Unauthorized") };
-    }
-    return next();
-  };
-}
-
-// Good — ACK middleware reads MSH fields from the pre-transform tree.
-function ackMiddleware(): Middleware {
-  return async (ctx, next) => {
-    await next();
-    ctx.res = { raw: toHl7v2(acknowledge(ctx.ast)) };
-  };
-}
-
-// Only when needed — triggers transform pipeline.
-function validationMiddleware(): Middleware {
-  return async (ctx, next) => {
-    const tree = await ctx.tree();
-    if (!isValid(tree)) {
-      return { raw: buildNak(ctx.ast, "Invalid") };
-    }
-    return next();
-  };
-}
-```
+Both are cached — subsequent calls return the same value.
 
 ## Error handling
 
@@ -233,11 +165,11 @@ app.onError(async (err, ctx) => {
 });
 ```
 
-Without an error handler, errors are absorbed and no response is sent. The sending system will time out and retry per standard MLLP behaviour. See the [design notes](#design-notes) below for the rationale.
+Without an error handler, no response is sent; the sending system times out and retries per standard MLLP behavior.
 
 ## TLS
 
-TLS is supported via `serve()` options:
+TLS is configured through `serve()` options:
 
 ```ts
 import fs from "node:fs";
@@ -288,32 +220,6 @@ tcpSocket.readable.pipeThrough(decoder).pipeTo(
   })
 );
 ```
-
-## Design notes
-
-### Why no default error response?
-
-HL7v2 has no universal error-response format. An ACK/NAK is version-dependent, varies by message type, and requires access to the inbound MSH segment to construct correctly. Building that into the core would couple the routing engine to HL7v2 message construction — the wrong layer of abstraction.
-
-Instead, the `Mllp` engine is middleware-first:
-
-- **Default behaviour** — no response is sent; the sending system times out and retries, which is valid MLLP behaviour.
-- **Logging** — add a logger middleware to make errors observable.
-- **ACK/NAK** — add an acknowledgment middleware to translate errors into proper NAK responses. `@glion/mllp-ack` provides this out of the box.
-- **Custom error responses** — use `app.onError()` for application-specific handling.
-
-```ts
-const app = new Mllp().parser(parseHL7v2);
-
-app.use(logger()); // observability — provided by middleware
-app.use(ackMiddleware()); // error → NAK translation — @glion/mllp-ack
-
-app.on("ADT^A01", handler);
-```
-
-### Why no built-in logging?
-
-The core has zero `console.log` or `console.error` calls. Logging is an opt-in middleware concern, giving you full control over format, destination, and verbosity without the core making assumptions about your observability stack.
 
 ## Part of Glion
 

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -4,7 +4,7 @@
 
 ## What it does
 
-`@glion/parser` is a low-level parser that turns raw HL7v2 messages into a `unist`-compatible syntax tree following the [`@glion/ast`](../ast/) spec. It runs as a `unified` parser plugin — feeding its output into any downstream `unified` processor — and auto-detects delimiters from MSH-1 and MSH-2 so non-standard delimiter sets work without configuration. Most applications should use [`@glion/hl7v2`](../hl7v2/), which bundles this parser with the standard transform and compile stages; reach for `@glion/parser` when you are building a custom pipeline.
+`@glion/parser` turns raw HL7v2 text into a `unist`-compatible syntax tree following the [`@glion/ast`](../ast/) spec. It runs as a `unified` parser plugin and auto-detects delimiters from MSH-1 and MSH-2, so non-standard delimiter sets parse without configuration. [`@glion/hl7v2`](../hl7v2/) bundles this parser with the default transform and compile stages.
 
 ## Install
 
@@ -29,60 +29,32 @@ console.log(tree);
 
 ### `unified().use(hl7v2Parser[, options])`
 
-Register the parser as the reader for a `unified` processor. The parser reads from the input string and produces a `Root` AST; it never mutates its input.
+Registers the parser as the reader for a `unified` processor. The parser reads from the input string and produces a `Root` AST; it does not mutate its input.
+
+### `parseHL7v2(input, options?, settings?)`
+
+Standalone parser. Returns a `Root` AST. `options` accepts `ParseOptions` (preprocessing); `settings` accepts `HL7v2Settings` from [`@glion/config`](../config/) and supplies delimiters and feature flags.
 
 ### Options
 
-| Option                   | Type                  | Description                                                                              |
-| ------------------------ | --------------------- | ---------------------------------------------------------------------------------------- |
-| `delimiters`             | `Partial<Delimiters>` | Override one or more delimiters. The parser merges with MSH-derived values and defaults. |
-| `experimental.emptyMode` | `"empty-array"`       | Opt in to the empty-array representation of empty fields (see below).                    |
+| Option       | Type                 | Description                                                                                                    |
+| ------------ | -------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `preprocess` | `PreprocessorStep[]` | Replaces the default preprocessor chain. The default chain runs delimiter detection from MSH-1/MSH-2 on input. |
 
-The default delimiters are `|` (field), `^` (component), `~` (repetition), `&` (subcomponent), `\` (escape), and `\r` (segment).
-
-### Custom delimiters
-
-```ts
-import { unified } from "unified";
-import { hl7v2Parser } from "@glion/parser";
-
-// Override only the segment delimiter
-const tree = unified()
-  .use(hl7v2Parser, { delimiters: { segment: "\n" } })
-  .parse(message);
-
-// Override multiple delimiters
-const customTree = unified()
-  .use(hl7v2Parser, {
-    delimiters: { field: "$", component: "%", segment: "\n" },
-  })
-  .parse(customMessage);
-```
-
-Options accept a partial `Delimiters` object, so only the characters you want to override need to be provided.
+Delimiters and empty-mode are configured via `HL7v2Settings` from [`@glion/config`](../config/), not via plugin options. The default delimiters are `|` (field), `^` (component), `~` (repetition), `&` (subcomponent), `\` (escape), and `\r` (segment).
 
 ## Parsing model
 
-- **Pull-based tokenizer.** Single pass, minimal object allocations — suitable for high-throughput ingestion.
-- **Delimiter auto-detection.** MSH-1 and MSH-2 are read before the rest of the message is tokenized so custom delimiter sets are honored without configuration.
-- **`unist`-compatible output.** Nodes follow the `@glion/ast` spec and integrate with `unist-util-visit`, `unist-builder`, and the wider Glion plugin ecosystem.
-- **Streaming-friendly.** The pull-based design is ready for streaming ingestion even though the current public API takes a complete string.
+- **Pull-based tokenizer.** Single pass with minimal object allocations.
+- **Delimiter auto-detection.** MSH-1 and MSH-2 are read before the rest of the message is tokenized; custom delimiter sets are honored without configuration.
+- **`unist`-compatible output.** Nodes follow the `@glion/ast` spec and interoperate with `unist-util-visit`, `unist-builder`, and the rest of the Glion plugin ecosystem.
 
 ### Experimental: empty-array mode
 
-By default the parser represents empty fields with full scaffolding (`Field → FieldRepetition → Component → Subcomponent` with `value: ""`). Passing `experimental: { emptyMode: "empty-array" }` switches to a more compact representation where empty parents carry `children: []` instead of nested empties.
+The parser supports two representations of empty fields, controlled by `settings.experimental.emptyMode` in [`@glion/config`](../config/):
 
-```ts
-import { unified } from "unified";
-import { hl7v2Parser } from "@glion/parser";
-
-const tree = unified()
-  .use(hl7v2Parser, { experimental: { emptyMode: "empty-array" } })
-  .parse("PID|1||");
-
-// PID-2 (empty field) becomes: { type: "field", children: [] }
-// rather than: Field → Rep → Comp → Sub with value: ""
-```
+- `"legacy"` (default) — empty fields carry full scaffolding (`Field → FieldRepetition → Component → Subcomponent` with `value: ""`).
+- `"empty"` — empty parent nodes carry `children: []` instead of nested empties.
 
 Rules:
 
@@ -97,7 +69,7 @@ Rules:
 | `PID\|1\|~\|`   | Field → [Rep → Comp → Sub(""), Rep → ...]      | Field → [Rep[], Rep[]]                 |
 | `PID\|1\|ABC\|` | Field → Rep → Comp → Sub("ABC")                | Field → Rep → Comp → Sub("ABC") (same) |
 
-For messages with many empty fields, the empty-array representation reduces node count by 37–63% and improves sparse-message parsing throughput by about 11%. Empty-array mode is planned to become the default; the legacy representation will be retired.
+For messages with many empty fields, the empty-array representation reduces node count by 37–63% relative to legacy mode and parses sparse messages roughly 11% faster.
 
 ## Part of Glion
 

--- a/packages/preset-annotate-profile-recommended/README.md
+++ b/packages/preset-annotate-profile-recommended/README.md
@@ -39,9 +39,9 @@ visit(file.result, "field", (node) => {
 
 ### `unified().use(hl7v2PresetAnnotateProfileRecommended)`
 
-Default export is a `Preset` (unified's `{ plugins: [...] }` shape). No options — to annotate selectively, compose individual plugins from their own packages instead.
+Default export is a `Preset` (unified's `{ plugins: [...] }` shape). Takes no options. For selective annotation, compose individual plugins from their own packages directly.
 
-## What's bundled
+## Bundled plugins
 
 The preset applies these plugins in order. `annotate-profile-context` runs first so each subsequent plugin reads the pre-resolved profile from `file.data.profile`.
 

--- a/packages/preset-lint-profile-recommended/README.md
+++ b/packages/preset-lint-profile-recommended/README.md
@@ -36,9 +36,9 @@ for (const message of file.messages) {
 
 ### `unified().use(hl7v2PresetLintProfileRecommended)`
 
-Default export is a `Preset` (unified's `{ plugins: [...] }` shape). No options — to configure individual rules, compose them directly from their own packages instead of using the preset.
+Default export is a `Preset` (unified's `{ plugins: [...] }` shape). Takes no options. For per-rule configuration, compose individual lint rules from their own packages directly.
 
-## What's bundled
+## Bundled plugins
 
 The preset applies these plugins in order. `annotate-profile-context` runs first so every subsequent rule sees the resolved profile on `file.data.profile`.
 
@@ -54,7 +54,7 @@ The preset applies these plugins in order. `annotate-profile-context` runs first
 | [`@glion/lint-profile-extra-fields`](../lint-profile-extra-fields)                   | Warns when a segment contains more fields than the profile defines.      |
 | [`@glion/lint-profile-extra-components`](../lint-profile-extra-components)           | Warns when a composite field contains more components than its datatype. |
 
-The companion `@glion/preset-lint-recommended` covers the core (version-independent) lint rules; use both together for comprehensive validation.
+The companion [`@glion/preset-lint-recommended`](../preset-lint-recommended/) covers the core (version-independent) lint rules.
 
 ## Part of Glion
 

--- a/packages/preset-lint-recommended/README.md
+++ b/packages/preset-lint-recommended/README.md
@@ -4,7 +4,7 @@ Preset bundling the core (version-independent) HL7v2 lint rules.
 
 ## What it does
 
-This preset wires the core HL7v2 lint rules into a single `unified` plugin. One `.use(...)` call enables structural checks that apply to every HL7v2 message regardless of version or profile: segment header shape, message header presence, version range, and trailing field hygiene.
+The preset wires the core HL7v2 lint rules into a single `unified` plugin. A single `.use(...)` call enables structural checks that apply to every HL7v2 message regardless of version or profile: segment header shape, message header presence, version range, and trailing field hygiene.
 
 ## Install
 
@@ -34,9 +34,9 @@ for (const message of file.messages) {
 
 ### `unified().use(hl7v2PresetLintRecommended)`
 
-Default export is a `Preset` (unified's `{ plugins: [...] }` shape). No options — to configure individual rules, compose them directly from their own packages instead of using the preset.
+Default export is a `Preset` (unified's `{ plugins: [...] }` shape). The preset takes no options. Individual rules can be reconfigured by registering them again after the preset.
 
-## What's bundled
+## Bundled rules
 
 The preset applies these rules in order. Three are configured at `error` severity; `no-trailing-empty-field` uses its default severity.
 
@@ -47,7 +47,7 @@ The preset applies these rules in order. Three are configured at `error` severit
 | [`@glion/lint-message-version`](../lint-message-version)                 | Flags `MSH-12` values outside the configured semver range.                   |
 | [`@glion/lint-no-trailing-empty-field`](../lint-no-trailing-empty-field) | Flags segments that end with one or more empty fields (stray trailing `\|`). |
 
-The companion `@glion/preset-lint-profile-recommended` covers profile-driven, version-specific lint rules; use both together for comprehensive validation.
+The companion [`@glion/preset-lint-profile-recommended`](../preset-lint-profile-recommended) covers profile-driven, version-specific lint rules.
 
 ## Part of Glion
 

--- a/packages/profiles/README.md
+++ b/packages/profiles/README.md
@@ -1,10 +1,10 @@
 # @glion/profiles
 
-HL7v2 version-specific profile data — segments, fields, datatypes, and tables — with LRU-cached loaders.
+HL7v2 version-specific profile data — fields, datatypes, tables, event structures, and code systems — with cached loaders.
 
 ## What it does
 
-`@glion/profiles` is the data source for Glion's profile-aware plugins. It provides structured HL7v2 profile definitions for every supported version (2.3 through 2.8), loaded on demand and cached in memory. The annotation plugins (`@glion/annotate-profile-*`) and the profile lint rules (`@glion/lint-profile-*`) read from this package to enrich and validate HL7v2 messages against the HL7-published specifications.
+`@glion/profiles` is the data source for Glion's profile-aware plugins. It provides structured HL7v2 profile definitions for every supported version (2.1 through 2.8.2), loaded on demand and cached in memory. The annotation plugins (`@glion/annotate-profile-*`) and the profile lint rules (`@glion/lint-profile-*`) read from this package to enrich and validate HL7v2 messages against the HL7-published specifications.
 
 ## Install
 
@@ -17,35 +17,42 @@ npm install @glion/profiles
 ```ts
 import { profiles } from "@glion/profiles";
 
-const msh = await profiles.segments.load("2.5", "MSH");
-console.log(msh.fields.length); // => 21
-
-const field = await profiles.fields.load("2.5", "MSH", "9");
-console.log(field.name); // => "Message Type"
-console.log(field.required); // => true
-console.log(field.datatype); // => "MSG"
+const fields = await profiles.fields.load("2.5", "MSH");
+const msgType = fields.bySequence.get(9);
+console.log(msgType?.name); // "Message Type"
+console.log(msgType?.required); // true
+console.log(msgType?.datatype); // "MSG"
 
 const cx = await profiles.datatypes.load("2.5", "CX");
-console.log(cx.kind); // => "composite"
-console.log(cx.components.length); // => 10
+console.log(cx.kind); // "composite"
+console.log(cx.componentsBySequence.size); // 10
 ```
 
-Event structure validation uses the same API:
+Segment metadata (id and title only) is loaded all-at-once per version:
 
 ```ts
-const structure = await profiles.events.load("2.5", "ADT_A01");
-// structure.dfa — deterministic finite automaton for segment-order validation
+import { loadSegments } from "@glion/profiles";
+
+const segments = await loadSegments("2.5");
+console.log(segments.byId.get("MSH")?.title); // "Message Header"
+```
+
+Event structures expose a deterministic finite automaton for segment-order validation:
+
+```ts
+const definition = await profiles.events.load("2.5", "ADT_A01");
+// definition.start, definition.transitions, definition.finals, definition.effects
 ```
 
 ## API
 
 ### `profiles`
 
-Shared singleton store (eager LRU cache, 100 entries per kind). Use this unless you need a bespoke cache configuration.
+Default singleton store backed by a built-in LRU cache. Holds five sub-stores: `events`, `fields`, `datatypes`, `tables`, and `codeSystems`, plus a `reset()` method that flushes all caches.
 
-### `createProfiles(options)`
+### `createProfiles(options?)`
 
-Construct a dedicated store with a custom cache size or eviction strategy.
+Constructs a dedicated `Profiles` instance with a custom cache.
 
 ```ts
 import { createLruCache, createProfiles } from "@glion/profiles";
@@ -55,78 +62,143 @@ const store = createProfiles({
 });
 ```
 
+- `options.cache` (`Cache | CacheOptions | false`, optional) — shared cache across stores. `false` disables caching.
+- `options.events`, `options.fields`, `options.datatypes`, `options.tables`, `options.codeSystems` (optional) — per-store cache override of the same shape.
+
 ### Loaders on each store
 
-| Method                                      | Returns                |
-| ------------------------------------------- | ---------------------- |
-| `segments.load(version, segmentId)`         | `SegmentDefinition`    |
-| `fields.load(version, segmentId, position)` | `FieldProfile`         |
-| `datatypes.load(version, datatypeId)`       | `DatatypeDefinition`   |
-| `tables.load(version, tableId)`             | `Table`                |
-| `events.load(version, structureId)`         | `EventStructure`       |
-| `codeSystems.load(version, codeSystemId)`   | `CodeSystemDefinition` |
+| Method                                | Returns                         |
+| ------------------------------------- | ------------------------------- |
+| `events.load(version, id, options?)`  | `Promise<Definition>`           |
+| `fields.load(version, segmentId)`     | `Promise<FieldDefinition>`      |
+| `datatypes.load(version, datatypeId)` | `Promise<DatatypeDefinition>`   |
+| `tables.load(version, tableId)`       | `Promise<TableDefinition>`      |
+| `codeSystems.load(codeSystemId)`      | `Promise<CodeSystemDefinition>` |
+
+Each store also exposes `has(...)`, `evict(...)`, and `reset()`.
+
+`events.load(...)` accepts an optional `{ resolve?: boolean }` options bag. When `resolve` is `true` (the default), trigger event aliases are resolved to canonical structure IDs before the lookup (e.g. `ADT_A04` resolves to `ADT_A01`'s DFA).
+
+`codeSystems` is the only store not keyed by HL7v2 version: UTG code systems are cumulative.
 
 ### `loadSegments(version)`
 
-Standalone helper that loads every segment definition for a given version in one call. Used by batch-processing plugins.
+Standalone async loader for segment metadata. Returns `Promise<SegmentDefinition>` containing every segment id and title for the given version in a single lookup map.
 
-### Automaton runner
+### `runner(definition)`
 
-For segment-order validation, `@glion/profiles` exposes the underlying DFA engine:
-
-```ts
-import { runner, type Definition } from "@glion/profiles";
-
-const engine = runner(definition);
-engine.step("MSH");
-engine.step("EVN");
-// engine.state === RunnerState.Running
-```
-
-## Profile data format
-
-Each kind of profile is loaded on demand from pre-built chunks. The compiled output is sharded into ~170 chunks (merged from ~10,800 source files via Rolldown code-splitting) to keep install size and cold-start cost low.
-
-### Segments
+Stateful automaton runner for segment-order validation. Consumes one symbol at a time and reports each transition.
 
 ```ts
-interface SegmentDefinition {
-  id: string; // "MSH", "PID", ...
-  name: string; // "Message Header"
-  fields: FieldProfile[]; // in positional order
+import { profiles, runner } from "@glion/profiles";
+
+const definition = await profiles.events.load("2.5", "ADT_A01");
+const automaton = runner(definition);
+
+const event = automaton.consume("MSH");
+if (event.type === "step") {
+  // valid transition
 }
+
+console.log(automaton.accepted); // true once a final state is reached
+console.log(automaton.expected); // symbols accepted from the current state
 ```
 
-### Fields
+### `resolveMessageStructure(version, messageType, triggerEvent)`
+
+Resolves a `messageType_triggerEvent` pair (e.g. `ADT_A04`) to the canonical structure id (`ADT_A01`) for the given HL7v2 version, using `eventMaps`.
+
+### `eventMaps`
+
+Record keyed by HL7v2 version, mapping `messageCode_triggerEvent` to canonical structure id.
+
+## Profile data shapes
+
+Compiled output is sharded into ~170 chunks (merged from ~10,800 source files via Rolldown code-splitting) and resolved by lazy dynamic import.
+
+### `FieldDefinition`
 
 ```ts
-interface FieldProfile {
-  id: string; // "MSH-9"
-  name: string; // "Message Type"
-  position: number; // 9
-  datatype: string; // "MSG"
+type FieldDefinition = {
+  segmentId: string;
+  bySequence: ReadonlyMap<number, FieldProfile>;
+  requiredSequences: ReadonlySet<number>;
+};
+
+type FieldProfile = {
+  sequence: number;
+  id: string; // e.g. "MSH-9"
   required: boolean;
   repeatable: boolean;
+  datatype: string;
   maxLength?: number;
-  table?: string; // "HL70001" when the field is coded
+  table?: string; // e.g. "HL70001"
+  name?: string;
   item?: string;
-}
+};
 ```
 
-### Datatypes
+### `DatatypeDefinition`
 
 ```ts
-interface DatatypeDefinition {
-  id: string; // "CX"
-  kind: "primitive" | "composite";
-  title: string;
-  components?: ComponentProfile[]; // only for composite kind
-}
+type DatatypeDefinition = {
+  id: string;
+  version: string;
+  kind: string;
+  title?: string;
+  componentsBySequence: ReadonlyMap<number, ComponentProfile>;
+  requiredSequences: ReadonlySet<number>;
+};
+
+type ComponentProfile = {
+  sequence: number;
+  name: string;
+  datatypeId: string;
+  required: boolean;
+  maxLength?: number;
+};
 ```
 
-### Tables, event structures, code systems
+### `TableDefinition`
 
-Same shape convention: each exposes its id, version, and the typed payload (value lists for tables, DFA definitions for event structures, concept lists with displayNames for code systems).
+```ts
+type TableDefinition = {
+  id: string;
+  description: string;
+  type: "user" | "hl7";
+  codes: ReadonlyMap<string, TableCodeEntry>;
+};
+```
+
+### `SegmentDefinition`
+
+```ts
+type SegmentDefinition = {
+  byId: ReadonlyMap<string, SegmentProfile>;
+};
+
+type SegmentProfile = {
+  id: string;
+  title: string;
+};
+```
+
+### `CodeSystemDefinition`
+
+```ts
+type CodeSystemDefinition = {
+  id: string;
+  url: string;
+  oid?: string;
+  name: string;
+  title: string;
+  codes: ReadonlyMap<string, UtgCodeEntry>;
+};
+```
+
+### `Definition` (events)
+
+The `events` store returns a DFA `Definition` with `start`, `transitions`, `finals`, and optional `effects`. `runner()` consumes a `Definition` to validate segment order incrementally.
 
 ## Part of Glion
 

--- a/packages/to-hl7v2/README.md
+++ b/packages/to-hl7v2/README.md
@@ -4,7 +4,7 @@ Compile HL7v2 ASTs back to HL7v2 text — as a `unified` plugin or a standalone 
 
 ## What it does
 
-`@glion/to-hl7v2` serializes an HL7v2 AST — typically produced by `@glion/parser` — into the original HL7v2 wire format. Delimiters are read from the Root node's data when present, so a parse-then-serialize round trip preserves the message byte-for-byte (modulo intentional edits to the tree in between). The standalone `toHl7v2()` helper works on any subtree, not just the Root, which makes it useful for extracting a single segment, field, or component as text.
+`@glion/to-hl7v2` serializes an HL7v2 AST — typically produced by `@glion/parser` — into the original HL7v2 wire format. Delimiters are read from the Root node's data when present, so a parse-then-serialize round trip preserves the message byte-for-byte (modulo intentional edits to the tree in between). The standalone `toHl7v2()` helper works on any subtree, not just the Root, and produces the corresponding text fragment for a single segment, field, or component.
 
 ## Install
 
@@ -30,16 +30,17 @@ console.log(String(file));
 
 ## API
 
-### `unified().use(hl7v2ToHl7v2)`
+### `unified().use(hl7v2ToHl7v2[, options])`
 
-Register the plugin as the compiler of a `unified` processor. Serializes the AST back to HL7v2 text and sets it as the file contents. No options.
+Registers the plugin as the compiler of a `unified` processor. Serializes the AST back to HL7v2 text and sets it as the file contents.
 
-### `toHl7v2(node, delimiters?)`
+### `toHl7v2(node, delimiters?, options?)`
 
 Standalone serializer. Converts any HL7v2 AST node — `Root`, `Segment`, `Field`, `FieldRepetition`, `Component`, or `Subcomponent` — to its HL7v2 text representation.
 
 - `node` (`Nodes`) — the node to serialize.
-- `delimiters` (`Delimiters`, optional) — custom delimiter set. When omitted, reads from the Root node's `data` or falls back to the HL7v2 defaults (`|`, `^`, `~`, `\`, `&`, `\r`).
+- `delimiters` (`Partial<Delimiters>`, optional) — custom delimiter set. When omitted, derives delimiters from `Root.data` (set by `@glion/annotate-delimiters` or by hand) and falls back to the HL7v2 defaults (`|`, `^`, `~`, `\`, `&`, `\r`).
+- `options` (`Hl7v2ToHl7v2Options`, optional) — see [Options](#options).
 
 Returns the serialized `string`.
 
@@ -52,6 +53,12 @@ toHl7v2(fieldNode); // "DOE^JOHN"
 toHl7v2(componentNode); // "SUB1&SUB2"
 ```
 
+## Options
+
+| Option              | Type      | Default | Description                                                                  |
+| ------------------- | --------- | ------- | ---------------------------------------------------------------------------- |
+| `trailingDelimiter` | `boolean` | `false` | When `true`, appends a field delimiter after the last field of each segment. |
+
 ## Round-trip guarantees
 
 - **Delimiter preservation** — custom delimiters set on `Root.data` (by the parser or by hand) carry through to the output. Messages that do not use the defaults round-trip correctly.
@@ -59,7 +66,11 @@ toHl7v2(componentNode); // "SUB1&SUB2"
 - **Empty fields and components** — preserved in position so field indexes remain stable.
 - **Every node type supported** — serializing a partial subtree produces the exact fragment you would expect to find embedded inside the full message.
 
-Pair with `@glion/parser` to read HL7v2 in and `@glion/to-hl7v2` to write it back out; layer `@glion/encode-escapes` and `@glion/decode-escapes` in between to handle delimiter characters that appear in content values.
+## See also
+
+- [`@glion/parser`](../parser/) — parses HL7v2 text into an AST.
+- [`@glion/encode-escapes`](../encode-escapes/) — encodes delimiter characters appearing in content values.
+- [`@glion/decode-escapes`](../decode-escapes/) — decodes escape sequences back into raw text.
 
 ## Part of Glion
 

--- a/packages/util-query/README.md
+++ b/packages/util-query/README.md
@@ -1,10 +1,10 @@
 # @glion/util-query
 
-Reads HL7v2 ASTs using canonical paths like `PID-5[1].2.1` or `ORDER-ORC-1`.
+Reads and writes HL7v2 ASTs using canonical paths like `PID-5[1].2.1` or `ORDER-ORC-1`.
 
 ## What it does
 
-Provides six path-based helpers — `parse`, `select`, `selectAll`, `value`, `matches`, `format` — that operate on HL7v2 AST trees using the same path syntax found in HL7 specs. Paths can address segments (`PID`), groups (`ORDER`), nested groups and segments (`ORDER-TIMING-TQ1`), field repetitions (`PID-5[2]`), components (`PID-5[1].2`), and subcomponents (`PID-5[1].2.1`). Path parsing is memoized in an LRU cache so repeated lookups stay fast.
+Provides path-based helpers that operate on HL7v2 AST trees using the canonical HL7 path syntax. Paths address segments (`PID`), groups (`ORDER`), nested groups and segments (`ORDER-TIMING-TQ1`), field repetitions (`PID-5[2]`), components (`PID-5[1].2`), and subcomponents (`PID-5[1].2.1`). Path parsing is memoized and a small set of common MSH paths is pre-computed.
 
 ## Install
 
@@ -15,158 +15,108 @@ npm install @glion/util-query
 ## Use
 
 ```typescript
-import {
-  select,
-  selectAll,
-  value,
-  matches,
-  format,
-  parse,
-} from "@glion/util-query";
+import { matches, select, selectAll, set, value } from "@glion/util-query";
 import { parseHL7v2 } from "@glion/parser";
-
-const message = `MSH|^~\\&|MyApp|MyFacility|ReceivingApp|ReceivingFacility|20231201120000||ADT^A01|12345|P|2.5
-PID|1||123456789^^^MRN||Smith^John^Michael||19800101|M|||123 Main St^^Anytown^ST^12345
-OBX|1||8675-3^Glucose^LN||120|mg/dL|70-105|H|||F`;
 
 const ast = parseHL7v2(message);
 
-// Values: drills to subcomponents automatically when the path is unique
-const lastName = value(ast, "PID-5[1].1.1"); // "Smith"
-const sendingApp = value(ast, "MSH-3[1].1.1"); // "MyApp"
-
-// Single node: grab the first matching AST node
-const pidSegment = select(ast, "PID");
-if (pidSegment?.node.type === "segment") {
-  console.log(`PID has ${pidSegment.node.children.length - 1} fields`);
-}
-
-// Multiple nodes
-const allObservations = selectAll(ast, "OBX");
-for (const { node } of allObservations) {
-  console.log(`Found observation: ${node.type}`);
-}
-
-// Existence check
-if (matches(ast, "PID-5")) {
-  console.log("Patient has a name field");
-}
-
-// Path parsing
-const parsed = parse("ORDERS[2]-OBX-5[1].2.1");
+value(ast, "PID-5[1].1.1")?.value; // "Smith"
+select(ast, "PID")?.node.type; // "segment"
+selectAll(ast, "OBX").length; // number of OBX segments
+matches(ast, "PID-5"); // true | false
+set(ast, "MSH-12", "2.7.1");
 ```
 
 ## API
 
-### `parse(path: string): PathParts`
+### `parse(path)`
 
-Breaks a canonical HL7 path into structured pieces. Useful for tooling and diagnostics.
+Breaks a canonical HL7 path string into a `PathParts` record. Throws on invalid format, leading/trailing whitespace, or non-positive repetition indexes.
 
 ```typescript
+import { parse } from "@glion/util-query";
+
 parse("PID-5[1].2.1");
-// {
-//   segment: { name: 'PID' },
-//   field: 5,
-//   repetition: 1,
-//   component: 2,
-//   subcomponent: 1
-// }
+// { segment: { name: "PID" }, field: 5, repetition: 1, component: 2, subcomponent: 1 }
 ```
 
-`parse` memoizes up to 1,000 unique paths using an LRU cache so repeated lookups stay fast without leaking memory.
+### `select(root, path)`
 
-### `select<Path>(root: Root, path: Path): { node: InferNodeType<Path>; ancestors: Nodes[] } | null`
-
-Returns the first AST node addressed by the path, along with its ancestor chain, or `null` when it cannot be found. The return type is automatically inferred from the path string.
+Returns the first AST node addressed by `path`, with its ancestor chain, or `null` when no node exists at that path. The node type is inferred from the path string. The `ancestors` array follows the [`unist-util-visit-parents`](https://github.com/syntax-tree/unist-util-visit-parents) convention: it starts at the root and ends with the immediate parent.
 
 ```typescript
+import { select } from "@glion/util-query";
+
 const result = select(ast, "PID-5[1].2");
-if (result) {
-  result.node; // Type: Component
-  result.ancestors; // [Root, Segment, Field, FieldRepetition]
-}
+result?.node; // Component
+result?.ancestors; // [Root, Segment, Field, FieldRepetition]
 ```
 
-The `ancestors` array follows the [`unist-util-visit-parents`](https://github.com/syntax-tree/unist-util-visit-parents) convention: it starts at the root node, ends with the immediate parent, and never includes the node itself. You can rely on `ancestors[ancestors.length - 1]` being the direct parent.
+### `selectAll(root, path)`
 
-### `selectAll<Path>(root: Root, path: Path): Array<{ node: InferNodeType<Path>; ancestors: Nodes[] }>`
-
-Returns all AST nodes that match the path. Useful when a message contains multiple segments or groups of the same type.
+Returns every AST node that matches `path`, each paired with its ancestor chain. When the path includes a specific repetition, behaves like `select` and returns at most one entry.
 
 ```typescript
-// Get all OBX segments
+import { selectAll } from "@glion/util-query";
+
 const observations = selectAll(ast, "OBX");
 for (const { node } of observations) {
-  console.log(node.type); // 'segment'
-}
-
-// Get all ORDER groups
-const orders = selectAll(ast, "ORDER");
-for (const { node } of orders) {
-  console.log(node.type); // 'group'
-}
-
-// Get all observation values
-const values = selectAll(ast, "OBX-5");
-for (const { node } of values) {
-  console.log(node.type); // 'field'
+  // node is a Segment
 }
 ```
 
-### `value(root: Root, path: string): { value: string; node: Nodes; ancestors: Nodes[] } | null`
+### `value(root, path)`
 
-Returns the string value stored at the path. If the node is not a subcomponent, it walks through single-child layers (field → field repetition → component → subcomponent) automatically.
+Returns the string value at `path`, walking through single-child container nodes (Field → FieldRepetition → Component → Subcomponent) when the path resolves to a non-leaf node. Returns `null` when no node is found.
 
 ```typescript
-const result = value(ast, "PID-3[1].1.1");
-if (result) {
-  console.log(result.value); // "123456789"
-  console.log(result.node.type); // "subcomponent"
-  console.log(result.ancestors); // [Root, Segment, Field, ...]
-}
+import { value } from "@glion/util-query";
+
+value(ast, "PID-3[1].1.1")?.value; // "123456789"
 ```
 
-### `matches(root: Root, path: string): boolean`
+### `matches(root, path)`
 
-Returns `true` when the path points to an existing node, otherwise `false`.
+Returns `true` when a node exists at `path`, otherwise `false`. Equivalent to `select(root, path) !== null`.
 
 ```typescript
-if (!matches(ast, "OBX-5")) {
-  throw new Error("Missing observation value");
-}
+import { matches } from "@glion/util-query";
 
-if (matches(ast, "PID-5")) {
-  const name = value(ast, "PID-5.1.1");
-}
+matches(ast, "OBX-5"); // true | false
 ```
 
-### `format(node: Nodes, ancestors: Nodes[]): string | null`
+### `format(node, ancestors)`
 
-The inverse of `select`. Given a node and its ancestor chain (as returned by `visit` or `select`), produces the canonical path string that would select that node. Returns `null` if the chain contains no segment or group.
+Inverse of `select`. Given a node and its ancestor chain (as produced by `visit` or `select`), returns the canonical path string that would select that node, or `null` when the chain contains no segment or group.
 
 ```typescript
-// With select
+import { format } from "@glion/util-query";
+
 const result = select(ast, "PID-5.2");
-if (result) {
-  format(result.node, result.ancestors); // "PID-5.2"
-}
-
-// With visit
-visit(ast, "field", (node, ancestors) => {
-  const path = format(node, ancestors); // "PID-5", "OBX-1", etc.
-  console.log(`Visiting ${path}`);
-});
-
-// Round-trip: format(select(root, path)) === path
+format(result.node, result.ancestors); // "PID-5.2"
 ```
 
-### `clearParseCache(): void`
+### `set(root, path, val)`
 
-Clears the memoized parse results. Useful for long-running services that want to release memory during idle periods or before reloading configuration.
+Sets a string value at `path`, creating any missing intermediate nodes (fields, repetitions, components, subcomponents). Padding nodes are created with empty `children` arrays. Throws when `path` does not include a field specifier or when the target segment is absent.
 
-### `getParseCacheSize(): number`
+```typescript
+import { set } from "@glion/util-query";
 
-Returns the current number of cached path entries so you can monitor cache pressure.
+set(ast, "MSH-12", "2.7.1");
+set(ast, "PID-3[2]", "ID-002");
+set(ast, "PID-5.1.2", "suffix");
+```
+
+### `delimiters(root)`
+
+Reads `MSH-1` and `MSH-2` and returns the resolved `Delimiters` record. Falls back to `DEFAULT_DELIMITERS` for any value that cannot be derived.
+
+```typescript
+import { delimiters } from "@glion/util-query";
+
+delimiters(ast); // { field: "|", component: "^", repetition: "~", ... }
+```
 
 ### Types
 
@@ -181,6 +131,8 @@ type PathParts = {
 };
 ```
 
+`InferNodeType<Path>` maps a literal path string to its corresponding AST node type. `GroupLocator` and `SegmentLocator` are the underlying name+repetition records.
+
 ## Path format
 
 Canonical path grammar:
@@ -190,75 +142,16 @@ Canonical path grammar:
 - `SEGMENT-FIELD[REP]` — field repetition (e.g., `PID-5[2]`)
 - `SEGMENT-FIELD[REP].COMP` — component (e.g., `PID-5[1].2`)
 - `SEGMENT-FIELD[REP].COMP.SUB` — subcomponent (e.g., `PID-5[1].2.1`)
-- `GROUP[N]-...` — qualify with group name and optional repetition (e.g., `ORDERS[2]-OBX-5`)
+- `GROUP[N]-...` — group prefix with optional repetition (e.g., `ORDERS[2]-OBX-5`)
 
-Repetition indexes are **1-based**. If you omit `[n]`, `select`/`value`/`matches` assume `[1]`.
+Repetition indexes are 1-based. When `[n]` is omitted, `select`, `value`, and `matches` resolve to `[1]`. A bare name (`NAME`) returns whichever segment or group exists, segments first; a path with a field suffix (`NAME-N`) is always resolved against a segment.
 
-Paths select whatever exists in the AST — segments or groups. A bare name (`NAME`) returns whichever exists, trying segments first; adding a field suffix (`NAME-N`) forces segment access because field numbers only apply to segments. Groups can also appear as navigation prefixes (`ORDER-ORC`, `ORDER-TIMING-TQ1-1`).
+## Errors
 
-```typescript
-// Selecting groups directly
-const orderGroup = select(ast, "ORDER");
-if (orderGroup?.node.type === "group") {
-  console.log("Found ORDER group");
-}
-
-// Selecting segments
-const pid = select(ast, "PID");
-if (pid?.node.type === "segment") {
-  console.log("Found PID segment");
-}
-
-// Navigation through groups to segments
-value(ast, "ORDER-ORC-1"); // Order control
-value(ast, "ORDER-TIMING-TQ1-1"); // Timing quantity
-```
-
-## Common recipes
-
-### Patient demographics
-
-```typescript
-const lastName = value(ast, "PID-5[1].1.1")?.value;
-const firstName = value(ast, "PID-5[1].2.1")?.value;
-const middleName = value(ast, "PID-5[1].3.1")?.value;
-const dob = value(ast, "PID-7[1].1.1")?.value;
-```
-
-### Observations
-
-```typescript
-// Single observation
-const obsValue = value(ast, "OBX-5[1].1.1")?.value;
-const units = value(ast, "OBX-6[1].1.1")?.value;
-const refRange = value(ast, "OBX-7[1].1.1")?.value;
-
-// Multiple observations
-const allOBX = selectAll(ast, "OBX");
-for (const { node } of allOBX) {
-  const val = value(node, "OBX-5")?.value;
-  const u = value(node, "OBX-6")?.value;
-  console.log(`${val} ${u}`);
-}
-```
-
-### Validation
-
-```typescript
-if (!matches(ast, "MSH")) throw new Error("Missing message header");
-if (!matches(ast, "PID-3[1].1.1")) throw new Error("Missing patient ID");
-
-if (matches(ast, "OBX")) {
-  const observations = selectAll(ast, "OBX");
-  console.log(`Found ${observations.length} observations`);
-}
-```
-
-## Error messages
-
-- Invalid formats throw with guidance, e.g. `"Invalid HL7 path format: \"PID-\""`.
-- Out-of-range indexes throw, e.g. `"Field number must be ≥1, got: 0"`.
-- Whitespace is rejected to catch accidental typos.
+- Invalid path formats throw with the offending input quoted, e.g. `Invalid HL7 path format: "PID-"`.
+- Repetition or field indexes below 1 throw, e.g. `Field number must be ≥1, got: 0`.
+- Leading or trailing whitespace in a path throws.
+- `set` throws when the path lacks a field specifier or the target segment is absent.
 
 ## Part of Glion
 

--- a/packages/util-semver/README.md
+++ b/packages/util-semver/README.md
@@ -131,30 +131,21 @@ satisfies("2.5.1", "2.5.1"); // true (exact match)
 satisfies("2.5.1", ">=2.6"); // false
 ```
 
-For repeated checks, use a `Range` object to avoid re-parsing:
+A pre-parsed `Range` instance is also accepted in place of the string form:
 
 ```typescript
 const range = new Range(">=2.0 <3.0");
-for (const version of versions) {
-  if (satisfies(version, range)) {
-    /* ... */
-  }
-}
+satisfies("2.5.1", range); // true
 ```
 
 #### `Range` class
 
-Pre-parsed range for efficient reuse.
+A parsed range. Constructed from a range string; `range.test(version)` returns a boolean. `Range` instances are accepted by `satisfies`, `maxSatisfying`, and `minSatisfying` in place of a string.
 
 ```typescript
 const range = new Range(">=2.0 <3.0");
 range.test("2.5.1"); // true
 range.test("3.0.0"); // false
-
-// Works with all range functions
-satisfies("2.5.1", range);
-maxSatisfying(versions, range);
-minSatisfying(versions, range);
 ```
 
 ### Collection operations
@@ -210,30 +201,22 @@ diff("2.5.1", "2.5.1"); // null
 
 ### Errors
 
+`VersionParseError` is thrown for invalid version strings; `RangeParseError` is thrown for invalid range strings. Both expose the offending input.
+
 ```typescript
-import { VersionParseError, RangeParseError } from "@glion/util-semver";
+import { RangeParseError, VersionParseError } from "@glion/util-semver";
 
 try {
   parse("INVALID");
 } catch (e) {
   if (e instanceof VersionParseError) {
-    console.log(e.input); // "INVALID"
-    console.log(e.reason); // "expected format: major.minor.patch..."
-  }
-}
-
-try {
-  satisfies("2.5.1", "INVALID_RANGE");
-} catch (e) {
-  if (e instanceof RangeParseError) {
-    console.log(e.token);
-    console.log(e.reason);
+    e.input; // "INVALID"
+    e.reason; // "expected format: major.minor.patch..."
   }
 }
 ```
 
-- `valid(version)` never throws — returns `false` for invalid input.
-- `parse()`, `clean()`, `compare()`, `satisfies()`, etc. throw on invalid input.
+`valid` never throws and returns `false` for invalid input. `parse`, `clean`, `compare`, `satisfies`, and the comparison operators all throw on invalid input.
 
 ## Version comparison rules
 

--- a/packages/util-timestamp/README.md
+++ b/packages/util-timestamp/README.md
@@ -4,7 +4,7 @@ HL7v2 timestamp parser, formatter, and converter with precision tracking.
 
 ## What it does
 
-Parses, formats, and converts HL7v2 TS (Time Stamp) values across seven precision levels — year, month, day, hour, minute, second, millisecond — so that `Timestamp.parse(str).toString() === str` for any valid input. Timezone offsets are applied during parsing so `toDate()` returns the correct absolute moment, and reconstructed during formatting so the original local-time representation round-trips exactly regardless of the server's timezone. Pure computation, zero runtime dependencies.
+Parses, formats, and converts HL7v2 TS (Time Stamp) values across seven precision levels — year, month, day, hour, minute, second, millisecond. `Timestamp.parse(str).toString() === str` for any valid input. Timezone offsets are applied during parsing so `toDate()` returns the correct absolute moment, and reconstructed during formatting so the original local-time representation round-trips regardless of the server's timezone. No runtime dependencies.
 
 ## Install
 

--- a/packages/util-visit/README.md
+++ b/packages/util-visit/README.md
@@ -4,7 +4,7 @@ Visitor for traversing HL7v2 AST trees with ancestor context, depth, and HL7v2-a
 
 ## What it does
 
-Walks an HL7v2 AST from any starting node — Root, Segment, Field, Component, or Subcomponent — calling a visitor function for each matching node. Each call receives the node, its ancestors (root-to-parent), and a `VisitInfo` record with index, HL7v2 sequence number, depth, and extracted metadata. Supports filtering by type string, property object, or predicate, and exposes `SKIP`/`EXIT` control actions. Delegates core traversal to `unist-util-visit-parents` and pre-computes sibling indices for O(1) lookups.
+Walks an HL7v2 AST from any starting node — Root, Segment, Field, Component, or Subcomponent — calling a visitor function for each matching node. Each call receives the node, its ancestors (root-to-parent), and a `VisitInfo` record with index, HL7v2 sequence number, depth, and extracted metadata. Filters accept a type string, a property object, or a predicate; the visitor can return `SKIP` or `EXIT` to control traversal. Delegates traversal to `unist-util-visit-parents` and pre-computes sibling indices for O(1) lookups.
 
 ## Install
 
@@ -15,45 +15,26 @@ npm install @glion/util-visit
 ## Use
 
 ```typescript
-import { visit, EXIT, SKIP } from "@glion/util-visit";
-import { parse } from "@glion/parser";
+import { EXIT, SKIP, visit } from "@glion/util-visit";
 
-const message = parse("MSH|^~\\&|...\rPID|...");
-
-// Visit all segments
-visit(message, "segment", (node, ancestors, info) => {
-  console.log(`Segment: ${info.metadata?.header} at depth ${info.depth}`);
-});
-
-// Find fields with parent context
-visit(message, "field", (node, ancestors, info) => {
-  const segment = ancestors.find((n) => n.type === "segment");
-  console.log(`Field ${info.sequence} in segment`);
-});
-
-// Skip processing of sensitive segments
-visit(message, (node, ancestors, info) => {
-  if (node.type === "segment" && info.metadata?.header === "NTE") {
-    return SKIP;
-  }
+visit(tree, "segment", (node, ancestors, info) => {
+  // node is a Segment; info.metadata?.name is the segment header
 });
 ```
 
 ## API
 
-### `visit(tree, visitor)`
+### `visit(tree, visitor)` / `visit(tree, test, visitor)`
 
-### `visit(tree, test, visitor)`
-
-Visit nodes in an HL7v2 AST tree.
+Visits nodes in an HL7v2 AST tree.
 
 #### Parameters
 
-- `tree` (`Nodes`) — Tree to traverse. Can be any node type, not just `Root`.
+- `tree` (`Nodes`) — Tree to traverse. Any node type, not just `Root`.
 - `test` (`string | Partial<Nodes> | Test`, optional) — Filter:
-  - `string` — Match nodes by type (e.g., `"segment"`).
-  - `Partial<Nodes>` — Match nodes with matching properties (e.g., `{ name: "PATIENT_GROUP" }`).
-  - `Test` — Custom function `(node, ancestors) => boolean`.
+  - `string` — Match nodes by `node.type` (e.g., `"segment"`).
+  - `Partial<Nodes>` — Match nodes by property equality (e.g., `{ name: "PATIENT_GROUP" }`).
+  - `Test` — Predicate `(node, ancestors) => boolean`.
 - `visitor` (`Visitor`) — Function called for each matching node.
 
 #### Returns
@@ -62,20 +43,21 @@ Visit nodes in an HL7v2 AST tree.
 
 #### Important: test vs visitor functions
 
-**If you pass a function as the second argument, it is always treated as a Visitor, never as a Test.**
+When a single function is passed as the second argument, it is treated as the visitor, never as a test. To filter with a predicate function, pass both the test and the visitor:
 
 ```typescript
-// WRONG — testFn will be treated as a visitor, not a test
-visit(ast, (node) => node.type === 'segment', ...); // Missing visitor!
+// Test as a predicate — three-argument form
+visit(
+  ast,
+  (node) => node.type === "segment",
+  (node, ancestors, info) => {
+    // visited
+  }
+);
 
-// CORRECT — Explicit 3-argument form
-visit(ast, (node) => node.type === 'segment', (node, ancestors, info) => {
-  console.log('Visiting segment');
-});
-
-// CORRECT — Use string or object for simple tests
-visit(ast, 'segment', (node, ancestors, info) => {
-  console.log('Visiting segment');
+// Type string — two-argument form
+visit(ast, "segment", (node, ancestors, info) => {
+  // visited
 });
 ```
 
@@ -92,14 +74,22 @@ type Visitor<T extends Nodes = Nodes> = (
 The visitor receives:
 
 - `node` — Current AST node.
-- `ancestors` — Array of ancestor nodes from root to parent (not including current node).
-- `info` — Visit information with index, sequence, depth, and metadata.
+- `ancestors` — Array of ancestor nodes from root to parent (not including the current node).
+- `info` — Visit information: index, sequence, depth, metadata.
 
 The visitor can return:
 
-- `undefined` or `void` — Continue traversal normally.
-- `SKIP` — Skip children of current node.
+- `undefined` or `void` — Continue traversal.
+- `SKIP` — Skip the children of the current node.
 - `EXIT` — Stop traversal immediately.
+
+```typescript
+visit(ast, "segment", (node, ancestors, info) => {
+  if (info.metadata?.name === "OBX") {
+    return SKIP;
+  }
+});
+```
 
 ### `VisitInfo`
 
@@ -114,247 +104,68 @@ interface VisitInfo {
   /** 1-based depth in tree (root = 1) */
   depth: number;
 
-  /** Metadata (e.g., { header: "MSH" } or { name: "PATIENT" }) */
+  /** Metadata extracted from the node, e.g. { name: "MSH" } or { name: "PATIENT_GROUP" } */
   metadata: Record<string, unknown> | undefined;
 }
 ```
 
-`index` and `sequence` represent the node's **position in the tree**, not its position among filtered results:
+`index` and `sequence` represent the node's position in the tree, not its position among filtered results. HL7v2 paths like `PID-3` refer to tree positions, so a filter that only matches field 3 still reports `info.sequence === 3`.
+
+#### Metadata extraction
+
+`metadata.name` is set automatically when the node carries a `name` field of type string. This applies to both `segment` (header identifier such as `"MSH"`, `"PID"`) and `group` (group name such as `"PATIENT_GROUP"`). For nodes without a `name`, `metadata` is `undefined`.
+
+### Constants
+
+- `SKIP` — Returned from a visitor to skip the children of the current node.
+- `EXIT` — Returned from a visitor to stop traversal.
 
 ```typescript
-// Structure: MSH segment with fields at positions 1, 2, 3, 4
-// Filter matches only field 3
-visit(
-  ast,
-  (n) => n.type === "field" && hasContent(n),
-  (node, ancestors, info) => {
-    console.log(info.sequence); // 3 (position in segment, not "1st match")
+import { EXIT, SKIP } from "@glion/util-visit";
+
+visit(ast, "field", (node, ancestors, info) => {
+  if (someCondition) {
+    return EXIT;
   }
-);
-```
-
-This is correct because HL7v2 paths like `PID.3` refer to tree positions, not filtered positions.
-
-### Automatic metadata extraction
-
-The `metadata` field is populated automatically:
-
-| Node type | Metadata key | Description                                 |
-| --------- | ------------ | ------------------------------------------- |
-| `segment` | `header`     | Segment identifier (e.g., `"MSH"`, `"PID"`) |
-| `group`   | `name`       | Group name (e.g., `"PATIENT_GROUP"`)        |
-
-### Exports
-
-```typescript
-import {
-  visit, // Main traversal function
-  EXIT, // Return to stop traversal
-  SKIP, // Return to skip children
-} from "@glion/util-visit";
-
-import type {
-  VisitInfo, // { index, sequence, depth, metadata }
-  Visitor, // (node, ancestors, info) => VisitorResult
-  VisitorResult, // Return type from visitor
-  Test, // Filter predicate
-  Predicate, // (node, ancestors) => boolean
-} from "@glion/util-visit";
-```
-
-## Examples
-
-### Filter by node type
-
-```typescript
-visit(ast, "segment", (node, ancestors, info) => {
-  console.log(`Found segment: ${info.metadata?.header}`);
 });
 ```
 
-### Filter by properties
+### Types
+
+```typescript
+import type {
+  Predicate, // (node, ancestors) => boolean
+  Test, // string | Partial<Nodes> | predicate | null
+  VisitInfo, // { index, sequence, depth, metadata }
+  Visitor, // (node, ancestors, info) => VisitorResult
+  VisitorResult, // re-exported from unist-util-visit-parents
+} from "@glion/util-visit";
+```
+
+### Examples
+
+Filter by node properties:
 
 ```typescript
 visit(ast, { name: "PATIENT_GROUP" }, (node, ancestors, info) => {
-  console.log("Inside PATIENT_GROUP");
+  // visited inside PATIENT_GROUP
 });
 ```
 
-### Custom test function
+Walk from any starting node:
 
 ```typescript
-// Visit fields in MSH segment only
-visit(
-  ast,
-  (node, ancestors) => {
-    const parent = ancestors.at(-1);
-    return node.type === "field" && parent?.type === "segment";
-  },
-  (node, ancestors, info) => {
-    console.log(`Field at sequence ${info.sequence}`);
-  }
-);
+visit(segment, "field", (node, ancestors, info) => {
+  // segment can be a standalone Segment, not just a Root
+});
 ```
 
-### Access parent and ancestors
+Inspect ancestors:
 
 ```typescript
 visit(ast, "component", (node, ancestors, info) => {
-  const parent = ancestors.at(-1);
   const segment = ancestors.findLast((n) => n.type === "segment");
-  console.log(`Component at depth ${info.depth}`);
 });
-```
-
-### Control flow: skip children
-
-```typescript
-visit(ast, (node, ancestors, info) => {
-  if (node.type === "segment" && info.metadata?.header === "OBX") {
-    return SKIP; // Don't process OBX segment children
-  }
-});
-```
-
-### Control flow: exit early
-
-```typescript
-import { EXIT } from "@glion/util-visit";
-
-let found = false;
-visit(ast, "field", (node, ancestors, info) => {
-  if (/* some condition */) {
-    found = true;
-    return EXIT; // Stop traversal completely
-  }
-});
-```
-
-### Start from any node
-
-```typescript
-import { s, f, c } from "@glion/builder";
-
-// Create a standalone segment
-const segment = s("PID", f(c("value1")), f(c("value2")));
-
-// Traverse from segment (not root)
-visit(segment, "field", (node, ancestors, info) => {
-  console.log(`Field at sequence ${info.sequence}`);
-});
-```
-
-### Track nesting levels
-
-```typescript
-visit(ast, (node, ancestors, info) => {
-  const indent = "  ".repeat(info.depth - 1);
-  console.log(`${indent}${node.type} [${info.sequence}]`);
-});
-// root [1]
-//   segment [1]
-//     segment-header [0]
-//     field [1]
-//       field-repetition [1]
-//         component [1]
-```
-
-### Group hierarchy navigation
-
-```typescript
-visit(ast, "segment", (node, ancestors, info) => {
-  const groups = ancestors
-    .filter((n) => n.type === "group")
-    .map((n) => (n as any).name)
-    .filter((name): name is string => typeof name === "string");
-
-  console.log(`${info.metadata?.header} is in groups: ${groups.join(" > ")}`);
-});
-// PID is in groups: PATIENT_GROUP
-```
-
-### Validate required fields
-
-```typescript
-function validateRequiredFields(ast: Root): string[] {
-  const errors: string[] = [];
-
-  visit(ast, "segment", (node, ancestors, info) => {
-    const segment = node as Segment;
-    const header = info.metadata?.header;
-
-    if (header === "MSH" && segment.children.length < 12) {
-      errors.push("MSH segment missing required fields");
-    }
-
-    if (header === "PID") {
-      const patientId = segment.children[3];
-      if (!patientId || patientId.children.length === 0) {
-        errors.push("PID segment missing required Patient ID (PID.3)");
-      }
-    }
-  });
-
-  return errors;
-}
-```
-
-### Extract data with context
-
-```typescript
-interface PatientName {
-  name: string;
-  sequence: number;
-  inGroup?: string;
-}
-
-function extractPatientNames(ast: Root): PatientName[] {
-  const names: PatientName[] = [];
-
-  visit(ast, "segment", (node, ancestors, info) => {
-    if (info.metadata?.header !== "PID") return;
-
-    const segment = node as Segment;
-    const nameField = segment.children[5];
-    if (nameField?.children[0]?.children[0]) {
-      const nameComponent = nameField.children[0].children[0];
-      const name = (nameComponent.children[0] as Subcomponent)?.value || "";
-      const groupAncestor = ancestors.find((n) => n.type === "group");
-
-      names.push({
-        name,
-        sequence: info.sequence,
-        inGroup: groupAncestor ? (groupAncestor as any).name : undefined,
-      });
-    }
-  });
-
-  return names;
-}
-```
-
-### Find first match and exit
-
-```typescript
-function findFirstObservation(ast: Root, targetCode: string): string | null {
-  let result: string | null = null;
-
-  visit(ast, "segment", (node, ancestors, info) => {
-    if (info.metadata?.header !== "OBX") return;
-
-    const segment = node as Segment;
-    const identifierField = segment.children[3];
-    const code = identifierField?.children[0]?.children[0]?.children[0]?.value;
-
-    if (code === targetCode) {
-      const valueField = segment.children[5];
-      result = valueField?.children[0]?.children[0]?.children[0]?.value || null;
-      return EXIT;
-    }
-  });
-
-  return result;
-}
 ```
 
 ## Part of Glion

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,10 +1,10 @@
 # @glion/utils
 
-Shared helpers for HL7v2 AST work — diagnostics reporting, length/byte measurement, and conformance checks.
+Shared primitives for HL7v2 AST work — emptiness, length and byte-length measurement, and conformance checks.
 
 ## What it does
 
-Provides the low-level utilities used across the Glion ecosystem: a `report()` function for emitting diagnostics onto a `VFile`, `getLength`/`getByteLength` for measuring any AST node without serializing it, and stateless `checkOptionality`/`checkCardinality`/`checkLength` conformance validators. Linters and transformers reach for this package to avoid reimplementing these primitives.
+Exports the low-level utilities that the rest of the Glion ecosystem depends on: `isEmptyNode` for HL7v2 emptiness semantics, `getLength` and `getByteLength` for measuring any AST node without serializing it, and the stateless conformance validators `checkOptionality`, `checkCardinality`, and `checkLength`. Also exports the `DEFAULT_DELIMITERS` constant and the `OptionalityCode` enumeration of HL7v2 usage codes.
 
 ## Install
 
@@ -15,154 +15,122 @@ npm install @glion/utils
 ## Use
 
 ```typescript
-import { report, getByteLength, checkCardinality } from "@glion/utils";
-import type { Diagnostic } from "@glion/utils";
-import { VFile } from "vfile";
+import {
+  checkCardinality,
+  checkOptionality,
+  getByteLength,
+  isEmptyNode,
+} from "@glion/utils";
 
-const rule: Diagnostic = {
-  type: "lint",
-  namespace: "field",
-  code: "required",
-  title: "Required Field Missing",
-  description: "A required field is missing from the segment.",
-  severity: "error",
-  message: (ctx) => `Field '${ctx.fieldPath}' is required`,
-};
-
-const file = new VFile();
-report(file, rule, { context: { fieldPath: "PID-5" }, node: segmentNode });
-
-const bytes = getByteLength(segmentNode);
-const result = checkCardinality(fieldNode, 1, 5);
+isEmptyNode(fieldNode); // true | false
+getByteLength(segmentNode); // number of UTF-8 bytes
+checkCardinality(fieldNode, 1, 5); // { ok: true } | { ok: false, error }
+checkOptionality(fieldNode, "R"); // { ok: true } | { ok: false, error }
 ```
 
 ## API
 
-### `report(file, rule, options?)`
+### `isEmptyNode(node)`
 
-Reports a diagnostic to a VFile. This is the standard way to report issues across Glion linters, validators, and transformers.
-
-#### Parameters
-
-- `file` (`VFile | null | undefined`) — The VFile to report to.
-- `rule` (`Diagnostic`) — The diagnostic rule definition.
-- `options` (`ReportOptions`, optional):
-  - `node` (`Node`, optional) — The AST node related to the diagnostic.
-  - `context` (`Record<string, unknown>`, optional) — Context data passed to the diagnostic's `message` function.
-
-#### Example
+Returns `true` when the node is `null`, `undefined`, missing a value, or has no descendant subcomponent with a non-empty string. Whitespace is treated as data and is therefore not empty.
 
 ```typescript
-import { report } from "@glion/utils";
-import type { Diagnostic } from "@glion/utils";
-import { VFile } from "vfile";
+import { isEmptyNode } from "@glion/utils";
 
-const requiredFieldRule: Diagnostic = {
-  type: "lint",
-  namespace: "field",
-  code: "required",
-  title: "Required Field Missing",
-  description: "A required field is missing from the segment.",
-  severity: "error",
-  message: (ctx) => `Field '${ctx.fieldPath}' is required`,
-  helpUrl: "https://example.com/docs/required-field",
-};
-
-const file = new VFile();
-report(file, requiredFieldRule, {
-  context: { fieldPath: "PID-5" },
-  node: segmentNode,
-});
-```
-
-### `getByteLength(node)`
-
-Calculates the byte length of any HL7v2 AST node. Efficiently computes the total serialized length including all children and separators (assumed to be 1 byte each).
-
-#### Parameters
-
-- `node` (`Nodes | null | undefined`) — The AST node to measure.
-
-#### Returns
-
-`number` — The total byte length when the node is serialized.
-
-#### Algorithm
-
-- For literal nodes (Subcomponent, SegmentHeader): returns the byte length of the value using UTF-8 encoding (i.e., `Buffer.byteLength(value, 'utf8')`).
-- For parent nodes: recursively sums the byte length of all children plus 1 byte per separator between children.
-- Handles all node types: Root, Segment, Group, Field, FieldRepetition, Component, Subcomponent.
-
-O(n) time complexity where n is the total number of nodes in the tree.
-
-#### Example
-
-```typescript
-import { getByteLength } from "@glion/utils";
-import type { Field } from "@glion/ast";
-
-const field: Field = {
-  type: "field",
-  children: [
-    {
-      type: "field-repetition",
-      children: [
-        {
-          type: "component",
-          children: [
-            { type: "subcomponent", value: "SMITH" },
-            { type: "subcomponent", value: "JOHN" },
-          ],
-        },
-      ],
-    },
-  ],
-};
-
-// Calculate: SMITH&JOHN = 5 + 1 + 4 = 10 bytes
-const length = getByteLength(field); // Returns: 10
+isEmptyNode({ type: "subcomponent", value: "" }); // true
+isEmptyNode({ type: "subcomponent", value: " " }); // false
 ```
 
 ### `getLength(node)`
 
-Calculates the string length of any HL7v2 AST node. Efficiently computes the total serialized character length including all children and separators (assumed to be 1 character each).
-
-#### Parameters
-
-- `node` (`Nodes | null | undefined`) — The AST node to measure.
-
-#### Returns
-
-`number` — The total string length when the node is serialized.
-
-#### Algorithm
-
-- For literal nodes (Subcomponent, SegmentHeader): returns `value.length` (JavaScript string length).
-- For parent nodes: recursively sums the string length of all children plus 1 character per separator between children.
-- Handles all node types: Root, Segment, Group, Field, FieldRepetition, Component, Subcomponent.
-
-#### Important note
-
-Returns JavaScript string length (UTF-16 code units). For UTF-8 byte length (e.g., for wire protocol or size constraints), use `getByteLength` instead. These values differ for characters outside the ASCII range.
-
-#### Example
+Returns the JavaScript string length (UTF-16 code units) of the node's content, recursively summing children. Delimiters are not included. For UTF-8 byte length, use `getByteLength`.
 
 ```typescript
-import { getLength, getByteLength } from "@glion/utils";
+import { getLength } from "@glion/utils";
 
-const subcomponent = { type: "subcomponent", value: "café" };
-
-getLength(subcomponent); // 4 (4 characters)
-getByteLength(subcomponent); // 5 (5 bytes in UTF-8: c-a-f-C3-A9)
+getLength({ type: "subcomponent", value: "café" }); // 4
 ```
 
-### Conformance utilities
+### `getByteLength(node)`
 
-Stateless, composable functions to validate HL7v2 AST nodes against constraints like optionality (usage), cardinality, and length.
+Returns the UTF-8 byte length of the node's content, recursively summing children. Delimiters are not included.
 
-#### `ValidationResult`
+```typescript
+import { getByteLength } from "@glion/utils";
 
-All conformance functions return a `ValidationResult` object:
+getByteLength({ type: "subcomponent", value: "café" }); // 5
+```
+
+### `checkOptionality(node, code)`
+
+Validates a node against an HL7v2 usage code (`OptionalityCode` or its string form). Returns `{ ok: true }` when the constraint is satisfied; otherwise returns `{ ok: false, error }` with an error code of `MISSING`, `EMPTY`, or `UNEXPECTED_CONTENT`.
+
+```typescript
+import { checkOptionality } from "@glion/utils";
+
+checkOptionality(undefined, "R"); // { ok: false, error: { code: "MISSING", ... } }
+checkOptionality(populatedNode, "X"); // { ok: false, error: { code: "UNEXPECTED_CONTENT", ... } }
+```
+
+### `checkCardinality(node, min, max)`
+
+Validates that a `Field` has between `min` and `max` repetitions. `max` accepts `"*"` for unbounded. Returns `{ ok: true }` or `{ ok: false, error }` with an error code of `CARDINALITY_UNDERFLOW` or `CARDINALITY_OVERFLOW`. Throws when `min` or `max` is negative or when `min > max`.
+
+```typescript
+import { checkCardinality } from "@glion/utils";
+
+checkCardinality(field, 1, 5);
+checkCardinality(field, 1, "*");
+```
+
+### `checkLength(node, max, min?)`
+
+Validates that the recursive string length of a node falls within `[min, max]`. `min` defaults to `0`. Returns `{ ok: true }` or `{ ok: false, error }` with an error code of `LENGTH_UNDERFLOW` or `LENGTH_OVERFLOW`. Throws when `min` or `max` is negative or when `min > max`.
+
+```typescript
+import { checkLength } from "@glion/utils";
+
+checkLength(node, 10); // 0..10
+checkLength(node, 10, 1); // 1..10
+```
+
+### `OptionalityCode`
+
+An object of HL7v2 usage codes plus a matching union type.
+
+| Code | Constant             | Meaning                  |
+| ---- | -------------------- | ------------------------ |
+| `R`  | `Required`           | Required                 |
+| `RE` | `RequiredOrEmpty`    | Required, may be empty   |
+| `O`  | `Optional`           | Optional                 |
+| `C`  | `Conditional`        | Conditional / undeclared |
+| `X`  | `NotSupported`       | Not supported            |
+| `B`  | `BackwardCompatible` | Backward-compatible      |
+| `W`  | `Withdrawn`          | Withdrawn                |
+
+```typescript
+import { OptionalityCode } from "@glion/utils";
+
+OptionalityCode.Required; // "R"
+```
+
+### `DEFAULT_DELIMITERS`
+
+The HL7v2 default delimiters as derived from `MSH-1` and `MSH-2`.
+
+```typescript
+import { DEFAULT_DELIMITERS } from "@glion/utils";
+
+DEFAULT_DELIMITERS;
+// {
+//   field: "|", component: "^", repetition: "~",
+//   subcomponent: "&", escape: "\\", segment: "\r"
+// }
+```
+
+### `ValidationResult`
+
+The discriminated union returned by all conformance checks.
 
 ```typescript
 type ValidationResult =
@@ -170,7 +138,7 @@ type ValidationResult =
   | {
       ok: false;
       error: {
-        code: string;
+        code: ValidationErrorCode;
         message: string;
         expected?: string | number | Array<string | number>;
         actual?: string | number | Array<string | number>;
@@ -178,59 +146,7 @@ type ValidationResult =
     };
 ```
 
-#### `checkOptionality(node, optionality)`
-
-Checks if a node satisfies the optionality (usage) constraint.
-
-- `node` (`Nodes | undefined`) — The AST node to check.
-- `optionality` (`string`) — The usage code (e.g., `'R'`, `'O'`, `'X'`).
-- Returns `ValidationResult`.
-
-```typescript
-import { checkOptionality } from "@glion/utils";
-
-// 'R' (Required), 'RE' (Required or Empty), 'O' (Optional), 'X' (Not Supported)
-const result = checkOptionality(myFieldNode, "R");
-
-if (!result.ok) {
-  console.error(result.error.message); // "is required but missing"
-}
-```
-
-#### `checkCardinality(node, min, max)`
-
-Checks if a field has the correct number of repetitions.
-
-- `node` (`Field | undefined`) — The field node to check.
-- `min` (`number`) — Minimum repetitions.
-- `max` (`number | '*'`) — Maximum repetitions.
-- Returns `ValidationResult`.
-
-```typescript
-import { checkCardinality } from "@glion/utils";
-
-// Field must repeat between 1 and 5 times
-const result = checkCardinality(myFieldNode, 1, 5);
-```
-
-#### `checkLength(node, max, min?)`
-
-Checks if the content of a node falls within the minimum and maximum length.
-
-- `node` (`Nodes | undefined`) — The node to check (length is calculated recursively).
-- `max` (`number`) — Maximum length.
-- `min` (`number`, optional, default `0`) — Minimum length.
-- Returns `ValidationResult`.
-
-```typescript
-import { checkLength } from "@glion/utils";
-
-// Content length must be between 1 and 10 characters
-const result = checkLength(myNode, 10, 1);
-
-// Content length must be at most 10 characters (min defaults to 0)
-const result2 = checkLength(myNode, 10);
-```
+`ValidationErrorCode` is one of: `MISSING`, `EMPTY`, `UNEXPECTED_CONTENT`, `CARDINALITY_UNDERFLOW`, `CARDINALITY_OVERFLOW`, `LENGTH_UNDERFLOW`, `LENGTH_OVERFLOW`, `VALUE_NOT_IN_TABLE`.
 
 ## Part of Glion
 


### PR DESCRIPTION
Audit of all 35 published-package READMEs against the [glion-readme skill](.claude/skills/glion-readme/) and the reference-voice rules in [ADR-0017](docs/adr/0017-documentation-framework.md). The result is a consistent reference surface: every package follows the same spine, the lint rules carry an ESLint-style metadata header, and several README/source disagreements are repaired.

## What changed

**Lint rule metadata header** — added to all 13 lint rule READMEs (5 core + 8 profile). Each carries a five-row table:

| Column               | Source                                                                                                |
| -------------------- | ----------------------------------------------------------------------------------------------------- |
| **Recommended**      | Membership in `@glion/preset-lint-recommended`'s `dependencies`                                       |
| **Profile-aware**    | Membership in `@glion/preset-lint-profile-recommended`'s `dependencies`                               |
| **Default severity** | `file.message(...)` → `warning`, `file.fail(...)` → `error`                                           |
| **Requires**         | The rule's `peerDependencies` plus the implicit `@glion/parser` / `@glion/annotate-profile-context`   |
| **Since**            | Earliest version in the rule's `CHANGELOG.md`                                                         |

**Voice alignment** — stripped instructive prose ("Use this when…", "Reach for X when…"), marketing adjectives (powerful, robust, easy, simple, elegant, intuitive, blazing, smart, flexible, seamless, first-class, just works), editorial framing ("Useful for…", "Great when…", "We recommend…"), and hedging from API and reference sections. The `## What it does` paragraph stays slightly contextual per the framework; everything below it is reference-voice.

**Factual drift fixed against source** — six places where the docs disagreed with the code:

- `decode-escapes` / `encode-escapes`: delimiter resolution order was inverted (the README had `Root.data` winning over `options.delimiters`; source spreads in the opposite order). Also corrected the attribution from "set by the parser" to "set by `@glion/annotate-delimiters`".
- `annotate-profile-fields`: `## Use` example was missing `hl7v2AnnotateProfileContext`, so it would have produced an unannotated tree at runtime.
- `jsonify`: `## Use` "Yields" block showed a fictional `{ type: "Message", children: [...] }` shape; the real output is `Array<{ segment, fields } | { group, children }>`. Rewrote the example and the `## JSON shape` section against `runtime.ts` and `types.ts`.
- `builder`: `s()` signature was wrong (`s(...fields)` rather than `s(name, ...fields)`), the `g` (Group) builder was undocumented, and the helper count was off by one. The `## Use` example used `s(f("MSH"), …)` which would not have produced a valid segment.
- `to-hl7v2`: `Hl7v2ToHl7v2Options.trailingDelimiter` existed in source but the README claimed "no options". Added `## Options` table and updated signatures.
- `profiles`: substantial drift — non-existent `profiles.segments.load` API, wrong field/datatype shapes, wrong `runner` API, wrong supported-version range. Rewrote `## What it does` and `## API` against `src/`. **This is the largest change in the PR; please give it a maintainer's eye.**

**Out-of-spine content trimmed**:

- `mllp`: 323 → 230 lines. Removed `## Design notes` ("Why no default error response?", "Why no built-in logging?") and the `### Writing middleware — prefer ctx.ast` block with its three worked example functions. The factual one-line takeaway ("no response is sent by default; the sender times out per MLLP convention") is preserved in `## Error handling`.
- `util-visit`: 360 → 176 lines. Removed the `## Examples` section's three multi-segment worked programs (`validateRequiredFields`, `extractPatientNames`, `findFirstObservation`).
- `builder`: removed the `## Design` (Explicit / Composable / Minimal) bullets — design-philosophy prose belongs in `/docs/concepts/`.

## Follow-ups for `/docs`

The trims above name passages worth recreating elsewhere:

- `/docs/concepts/`: mllp error-handling and logging rationale; builder design philosophy.
- `/docs/guides/`: mllp middleware patterns (auth, ACK, validation); util-visit walkers (validate-required, extract-data, find-first-and-exit); the two how-to subsections currently in `annotate-profile-fields` (`Accessing field metadata`, `Finding coded fields`).

## Open conventions

Two questions I derived defaults for and want to confirm:

1. **`Requires` derivation** — none of the rule packages declare `peerDependencies`; I derived `@glion/parser` (and `@glion/annotate-profile-context` for profile rules) from the canonical pipeline. If the convention is "peer-deps only", the cells should be empty.
2. **`Since` semantics** — I tracked the earliest published version under any name (i.e., back through the `@rethinkhealth/hl7v2-*` prefix). If we want this to track the `@glion/*` rename instead, `Since` for several rules will move forward.

## Test plan

- [ ] `pnpm --filter @glion/check-readme test` and `pnpm --filter ./tools/check-readme exec glion-check-readme packages/*` — both still pass; structural contract is intact.
- [ ] Spot-check the `profiles` rewrite against `packages/profiles/src/` — the most likely place to find a remaining inaccuracy.
- [ ] Eyeball one or two lint rule pages on the docs site preview to confirm the metadata table renders well in the `/docs/reference/packages/<name>` layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)