### PR TITLE
feat(mllp-client): Deno runtime adapter

### DIFF
--- a/.changeset/mllp-client-deno-runtime.md
+++ b/.changeset/mllp-client-deno-runtime.md
@@ -1,0 +1,38 @@
+---
+"@glion/mllp-client": minor
+---
+
+Add the **Deno** runtime adapter — `@glion/mllp-client/deno` — backed by `Deno.connect` and `Deno.connectTls`.
+
+```ts
+import { MllpClient } from "@glion/mllp-client/deno";
+
+const client = new MllpClient({ host: "127.0.0.1", port: 2575 });
+const ack = await client.send(rawHl7Message);
+```
+
+Bundlers that honour the `deno` key in `package.json` `exports` automatically pick this adapter when you import the bare `@glion/mllp-client` from a Deno target. The explicit subpath is available for monorepos that mix runtimes.
+
+The user-facing API (`new MllpClient({ host, port }).send(message)`, `client.stream(...)`, `MllpClientError`, `AckException`) is identical to the Node adapter — only the import path changes.
+
+**Adapter-specific behaviour**
+
+- **TLS material accepted as `string` or `Uint8Array`.** A non-string CA/cert/key is decoded to a PEM string before being handed to `Deno.connectTls` (which expects `string` / `string[]`).
+- **`tls.passphrase` rejected with `INVALID_INPUT`.** Deno's `connectTls` does not accept inline passphrases — decrypt the private key before passing it to the client.
+- **`tls.insecure: true` rejected with `INVALID_INPUT`.** Deno has no runtime flag to disable certificate verification; for self-signed local-dev scenarios, run Deno with `--unsafely-ignore-certificate-errors=<host>` instead.
+- **Permission failures route to `INVALID_INPUT`.** `Deno.errors.PermissionDenied` and `NotCapable` are mapped to `MllpClientError(INVALID_INPUT)` with a message naming the host:port the operator must add to `--allow-net=…`. (Previously these would have been miscategorised as `CONNECTION_REFUSED`.)
+- **Caller-supplied `AbortSignal` honoured at connect-phase.** Pre-aborted signals short-circuit before `Deno.connect` runs (no socket allocated). A signal that fires during the open is mapped to `TIMEOUT` with the abort reason chained as `cause`.
+
+**Tests**
+
+`test/deno.test.ts` monkey-patches `globalThis.Deno` so the adapter's wiring is exercised in plain Node vitest. Coverage:
+
+- TCP / TLS connect with parameter forwarding and PEM coercion.
+- `tls.insecure: true` rejection.
+- `tls.passphrase` rejection.
+- `PermissionDenied` mapping with `--allow-net=…` hint.
+- `Deno.connect` failure → `CONNECTION_REFUSED`.
+- `conn.close()` runs after a successful exchange.
+- Pre-aborted `AbortSignal` short-circuits before the runtime allocates a socket.
+
+For end-to-end verification inside the actual Deno runtime, write a `*.deno.test.ts` file that runs via `deno test` against a real server. The MLLP exchange logic itself is already covered by the runtime-free `test/core.test.ts`.

--- a/packages/mllp-client/README.md
+++ b/packages/mllp-client/README.md
@@ -16,17 +16,18 @@ npm install @glion/mllp-client @glion/ack
 
 ## Runtime support
 
-`@glion/mllp-client` currently ships **Node.js and Bun** support. The package is built to be runtime-agnostic — `@glion/mllp-client/core` accepts a caller-supplied `MllpConnect` function — but only the Node adapter has shipped so far.
+`@glion/mllp-client` runs on every JavaScript runtime that can open a raw TCP socket. Pick the import path that matches your runtime — the client API is identical in every case.
 
-| Runtime                | Import path          | Connector                          | Status                  |
-| ---------------------- | -------------------- | ---------------------------------- | ----------------------- |
-| **Node.js / Bun**      | `@glion/mllp-client` | `node:net` / `node:tls` (default)  | shipped                 |
-| **Deno**               | —                    | `Deno.connect` / `Deno.connectTls` | in progress (PR [#615]) |
-| **Cloudflare Workers** | —                    | `cloudflare:sockets`               | in progress (PR [#616]) |
+| Runtime                | Import path               | Connector                          | Status                  |
+| ---------------------- | ------------------------- | ---------------------------------- | ----------------------- |
+| **Node.js / Bun**      | `@glion/mllp-client`      | `node:net` / `node:tls` (default)  | shipped                 |
+| **Deno**               | `@glion/mllp-client/deno` | `Deno.connect` / `Deno.connectTls` | shipped                 |
+| **Cloudflare Workers** | —                         | `cloudflare:sockets`               | in progress (PR [#616]) |
 
-> **Heads-up.** The Deno and Cloudflare Workers adapters are being reviewed in separate pull requests and are not yet part of a release. The runtime-agnostic core is stable; you can wire your own `MllpConnect` against any transport (or a custom test harness) by importing from `@glion/mllp-client/core` until those adapters land.
+Bundlers that honour the `deno` key in this package's `exports` map will automatically pick the right entry for the target runtime when you import the bare `@glion/mllp-client`. The explicit subpath exists for clarity and for monorepos that mix runtimes in one workspace.
 
-[#615]: https://github.com/rethinkhealth/glion/pull/615
+> **Heads-up.** The Cloudflare Workers adapter is being reviewed in a separate pull request and is not yet part of a release. The runtime-agnostic core is stable; you can wire your own `MllpConnect` against any transport (or a custom test harness) by importing from `@glion/mllp-client/core` until that adapter lands.
+
 [#616]: https://github.com/rethinkhealth/glion/pull/616
 
 **Browsers cannot run this client directly** — they have no API for raw TCP sockets.
@@ -89,6 +90,15 @@ const client = new MllpClient({
   },
 });
 
+const ack = await client.send(rawMessage);
+```
+
+The same code on **Deno**:
+
+```ts
+import { MllpClient } from "@glion/mllp-client/deno";
+
+const client = new MllpClient({ host: "127.0.0.1", port: 2575 });
 const ack = await client.send(rawMessage);
 ```
 

--- a/packages/mllp-client/package.json
+++ b/packages/mllp-client/package.json
@@ -30,8 +30,14 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "deno": {
+        "types": "./dist/runtimes/deno.d.ts",
+        "import": "./dist/runtimes/deno.js"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
     },
     "./core": {
       "types": "./dist/core/index.d.ts",
@@ -40,6 +46,10 @@
     "./node": {
       "types": "./dist/runtimes/node.d.ts",
       "import": "./dist/runtimes/node.js"
+    },
+    "./deno": {
+      "types": "./dist/runtimes/deno.d.ts",
+      "import": "./dist/runtimes/deno.js"
     }
   },
   "publishConfig": {

--- a/packages/mllp-client/src/runtimes/deno.ts
+++ b/packages/mllp-client/src/runtimes/deno.ts
@@ -1,0 +1,267 @@
+/**
+ * Deno runtime adapter for `@glion/mllp-client`.
+ *
+ * Re-exports the core `MllpClient` pre-wired with a `connect`
+ * implementation that uses `Deno.connect` / `Deno.connectTls`.
+ * Application code on Deno imports from this entry:
+ *
+ * ```ts
+ * import { MllpClient } from "@glion/mllp-client/deno";
+ *
+ * const client = new MllpClient({ host: "127.0.0.1", port: 2575 });
+ * const ack = await client.send(rawHl7Message);
+ * ```
+ *
+ * The `Deno.connect*` family is only available inside the Deno
+ * runtime. Importing this entry from a Node or Workers build will
+ * fail at module-resolution time — that's the intended behaviour,
+ * since each runtime should pick its own adapter.
+ *
+ * @module
+ */
+
+// `Deno` is a runtime-provided global — its shape is declared in
+// `./deno-types.d.ts` so this file type-checks in any TypeScript
+// environment without forcing a dependency on `@types/deno`.
+import { MllpClient as CoreMllpClient } from "../core/client";
+import type {
+  BoundMllpClientOptions,
+  MllpClientOptions,
+  MllpClientTlsOptions,
+} from "../core/client";
+import type { MllpConnect, MllpDuplexStream } from "../core/connect";
+import { MllpClientError, MllpClientErrorCode } from "../core/errors";
+
+// ---------------------------------------------------------------------------
+// Public class
+// ---------------------------------------------------------------------------
+
+/**
+ * MLLP client pre-wired with the Deno connector. API-identical to
+ * the core class — the only difference is that callers do not need
+ * to supply `connect`.
+ */
+export class MllpClient extends CoreMllpClient {
+  constructor(options: BoundMllpClientOptions) {
+    super({ ...options, connect: denoConnect });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Re-exports
+// ---------------------------------------------------------------------------
+
+export type { Acknowledgment } from "../core/acknowledgment";
+export type {
+  MllpConnect,
+  MllpConnectParams,
+  MllpDuplexStream,
+} from "../core/connect";
+export type {
+  BoundMllpClientOptions,
+  MllpClientOptions,
+  MllpClientTlsOptions,
+  SendMode,
+  SendOptions,
+} from "../core/client";
+export { MllpClientError, MllpClientErrorCode } from "../core/errors";
+
+// ---------------------------------------------------------------------------
+// Deno connector
+// ---------------------------------------------------------------------------
+
+/**
+ * `MllpConnect` implementation backed by `Deno.connect` /
+ * `Deno.connectTls`. Returns a {@link MllpDuplexStream} that mirrors
+ * the Deno connection's already-Web-Streams shape.
+ *
+ * Deno's TLS API exposes `caCerts` (array of PEM strings) and a
+ * client-cert/key pair. The `passphrase` option from
+ * {@link MllpClientTlsOptions} is currently ignored because Deno's
+ * `connectTls` does not surface it; encrypted private keys must be
+ * decrypted before being passed to the client.
+ *
+ * `insecure: true` is rejected — Deno does not expose an option to
+ * skip certificate verification on `connectTls`. For local-dev
+ * scenarios that need a self-signed cert, run Deno with
+ * `--unsafely-ignore-certificate-errors=<host>` instead.
+ */
+export const denoConnect: MllpConnect = async (params) => {
+  rejectUnsupportedTls(params.tls);
+
+  // Eagerly honour an already-aborted signal so we don't even start
+  // the connect. `subscribeAbort` collapses the "aborted-vs-aborting"
+  // branch but we want this short-circuit before allocating a conn.
+  if (params.signal?.aborted) {
+    throw toAbortError(params.signal.reason, params.host, params.port);
+  }
+
+  let conn: Deno.TcpConn;
+  try {
+    conn = await (params.tls
+      ? Deno.connectTls({
+          caCerts: toCaCerts(params.tls.ca),
+          certChain: toPem(params.tls.cert),
+          hostname: params.tls.servername ?? params.host,
+          port: params.port,
+          privateKey: toPem(params.tls.key),
+        })
+      : Deno.connect({
+          hostname: params.host,
+          port: params.port,
+        }));
+  } catch (error) {
+    if (params.signal?.aborted) {
+      throw toAbortError(params.signal.reason, params.host, params.port, error);
+    }
+    throw mapDenoConnectError(error, params.host, params.port);
+  }
+
+  // If the deadline fired while we were connecting, close the
+  // freshly-opened conn and surface as TIMEOUT.
+  if (params.signal?.aborted) {
+    try {
+      conn.close();
+    } catch {
+      /* already closed by Deno itself */
+    }
+    throw toAbortError(params.signal.reason, params.host, params.port);
+  }
+
+  const duplex: MllpDuplexStream = {
+    close: () => {
+      try {
+        conn.close();
+      } catch {
+        /* close() must be idempotent; tolerate post-close calls */
+      }
+    },
+    readable: conn.readable,
+    writable: conn.writable,
+  };
+  return duplex;
+};
+
+/**
+ * Translate an abort `reason` from the connect-phase signal into a typed
+ * {@link MllpClientError}. Mirrors the precedence in `normaliseSendError` in
+ * `core/client.ts`: typed reasons pass through, anything else maps to TIMEOUT
+ * with the reason chained as `cause`.
+ */
+function toAbortError(
+  reason: unknown,
+  host: string,
+  port: number,
+  fallbackCause?: unknown
+): MllpClientError {
+  if (reason instanceof MllpClientError) {
+    return reason;
+  }
+  return new MllpClientError(
+    MllpClientErrorCode.TIMEOUT,
+    `Connect to ${host}:${port} aborted`,
+    { cause: pickError(reason, fallbackCause) }
+  );
+}
+
+/**
+ * Reject TLS configuration the Deno runtime cannot honour. Surfacing
+ * the mismatch as `INVALID_INPUT` is more honest than silently
+ * dropping the material.
+ *
+ * `insecure: true` is rejected because `Deno.connectTls` has no
+ * runtime opt-out; `passphrase` is rejected because Deno expects the
+ * private key to be already decrypted.
+ */
+function rejectUnsupportedTls(tls: MllpClientTlsOptions | undefined): void {
+  if (!tls) {
+    return;
+  }
+  if (tls.insecure === true) {
+    throw new MllpClientError(
+      MllpClientErrorCode.INVALID_INPUT,
+      "Deno does not expose a runtime flag to disable cert verification — pass --unsafely-ignore-certificate-errors=<host> to the Deno binary instead"
+    );
+  }
+  if (tls.passphrase !== undefined) {
+    throw new MllpClientError(
+      MllpClientErrorCode.INVALID_INPUT,
+      "Deno's connectTls does not accept a passphrase — decrypt the private key before passing it to the client"
+    );
+  }
+}
+
+/**
+ * Translate a thrown value from `Deno.connect*` into a typed
+ * {@link MllpClientError}, narrowing on Deno's error subclasses
+ * where possible. Permission failures become `INVALID_INPUT` (the
+ * caller forgot `--allow-net`); everything else routes to
+ * `CONNECTION_REFUSED`.
+ */
+function mapDenoConnectError(
+  error: unknown,
+  host: string,
+  port: number
+): MllpClientError {
+  const message = error instanceof Error ? error.message : String(error);
+  const cause = error instanceof Error ? error : undefined;
+  const target = `${host}:${port}`;
+
+  // Deno surfaces permission failures as `Deno.errors.PermissionDenied`
+  // which subclasses Error. We sniff the constructor name because
+  // structured access varies across Deno versions.
+  const name = error instanceof Error ? error.constructor.name : "";
+  if (name === "PermissionDenied" || name === "NotCapable") {
+    return new MllpClientError(
+      MllpClientErrorCode.INVALID_INPUT,
+      `Deno denied network access to ${target} — re-run with --allow-net=${host}:${port}: ${message}`,
+      { cause }
+    );
+  }
+
+  return new MllpClientError(
+    MllpClientErrorCode.CONNECTION_REFUSED,
+    `Could not connect to ${target}: ${message}`,
+    { cause }
+  );
+}
+
+/**
+ * Coerce CA material from the cross-runtime `string | Uint8Array`
+ * shape into Deno's `string[]` (array of PEM strings) form. Multiple
+ * concatenated PEM blocks in a single string are passed through as
+ * one entry — Deno parses concatenated blocks transparently.
+ */
+function toCaCerts(
+  input: string | Uint8Array | undefined
+): string[] | undefined {
+  if (input === undefined) {
+    return;
+  }
+  return [toPem(input)!];
+}
+
+/**
+ * Coerce a `string | Uint8Array` into the PEM string form Deno
+ * expects. Returns `undefined` when the input is undefined.
+ */
+function toPem(input: string | Uint8Array | undefined): string | undefined {
+  if (input === undefined) {
+    return;
+  }
+  return typeof input === "string" ? input : new TextDecoder().decode(input);
+}
+
+/**
+ * Pick the first `Error`-shaped value from a list of candidates,
+ * or `undefined` if none qualify. Used when chaining a `cause` from
+ * either the abort signal's `reason` or the underlying connect-time
+ * error — whichever is an actual Error.
+ */
+function pickError(...candidates: unknown[]): Error | undefined {
+  for (const candidate of candidates) {
+    if (candidate instanceof Error) {
+      return candidate;
+    }
+  }
+}

--- a/packages/mllp-client/test/deno.test.ts
+++ b/packages/mllp-client/test/deno.test.ts
@@ -1,0 +1,266 @@
+// oxlint-disable promise/avoid-new
+/**
+ * Deno adapter test suite.
+ *
+ * The Deno adapter calls the runtime-provided `Deno.connect` /
+ * `Deno.connectTls` globals. We monkey-patch `globalThis.Deno`
+ * before importing the adapter so its wiring (TLS option coercion,
+ * `insecure` rejection, error mapping) can be exercised in plain
+ * Node vitest.
+ *
+ * For end-to-end verification inside the actual Deno runtime, write
+ * a `*.deno.test.ts` file that runs via `deno test` against a real
+ * server. The MLLP exchange logic itself is already covered by the
+ * runtime-free `test/core.test.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { frame, SAMPLE_ADT, VALID_AA } from "./fixtures";
+
+// Captured calls and configurable state for the fake Deno globals.
+const mockState = {
+  closeCount: 0,
+  connectCalls: [] as { type: "tcp" | "tls"; options: unknown }[],
+  connectError: undefined as Error | undefined,
+  reply: "no-reply" as Uint8Array | "no-reply",
+};
+
+interface DenoLike {
+  connect(opts: unknown): Promise<unknown>;
+  connectTls(opts: unknown): Promise<unknown>;
+}
+
+// oxlint-disable-next-line typescript/no-explicit-any
+const globals = globalThis as any;
+let originalDeno: DenoLike | undefined;
+
+// Install the mock before importing the adapter — the adapter
+// captures references to `Deno.connect` / `Deno.connectTls` lazily
+// inside its `connect` function, so the global must be set whenever
+// `denoConnect` runs (not only at import time).
+function installMockDeno(): void {
+  originalDeno = globals.Deno;
+  const fakeConn = () => ({
+    close: () => {
+      mockState.closeCount++;
+    },
+    readable: new ReadableStream<Uint8Array>({
+      start(controller) {
+        if (mockState.reply !== "no-reply") {
+          controller.enqueue(mockState.reply);
+        }
+        controller.close();
+      },
+    }),
+    writable: new WritableStream<Uint8Array>(),
+  });
+
+  globals.Deno = {
+    connect(options: unknown) {
+      mockState.connectCalls.push({ options, type: "tcp" });
+      if (mockState.connectError) {
+        return Promise.reject(mockState.connectError);
+      }
+      return Promise.resolve(fakeConn());
+    },
+    connectTls(options: unknown) {
+      mockState.connectCalls.push({ options, type: "tls" });
+      if (mockState.connectError) {
+        return Promise.reject(mockState.connectError);
+      }
+      return Promise.resolve(fakeConn());
+    },
+  };
+}
+
+function uninstallMockDeno(): void {
+  if (originalDeno === undefined) {
+    Reflect.deleteProperty(globals, "Deno");
+  } else {
+    globals.Deno = originalDeno;
+  }
+}
+
+// Imports must come after we install the mock the first time so
+// that any module-load-time logic in the adapter sees the fake.
+installMockDeno();
+const { MllpClient } = await import("../src/runtimes/deno");
+const { MllpClientError, MllpClientErrorCode } =
+  await import("../src/core/errors");
+uninstallMockDeno();
+
+describe("MllpClient (deno adapter)", () => {
+  beforeEach(() => {
+    mockState.closeCount = 0;
+    mockState.connectCalls.length = 0;
+    mockState.connectError = undefined;
+    mockState.reply = "no-reply";
+    installMockDeno();
+  });
+
+  afterEach(() => {
+    uninstallMockDeno();
+  });
+
+  it("calls Deno.connect for plain TCP and returns a parsed ACK", async () => {
+    mockState.reply = frame(VALID_AA);
+    const client = new MllpClient({ host: "mllp.example", port: 2575 });
+
+    const ack = await client.send(SAMPLE_ADT);
+
+    expect(ack.code).toBe("AA");
+    expect(mockState.connectCalls).toHaveLength(1);
+    expect(mockState.connectCalls[0]?.type).toBe("tcp");
+    expect(mockState.connectCalls[0]?.options).toEqual({
+      hostname: "mllp.example",
+      port: 2575,
+    });
+  });
+
+  it("calls Deno.connectTls when tls is set, forwarding ca/cert/key", async () => {
+    mockState.reply = frame(VALID_AA);
+    const client = new MllpClient({
+      host: "mllp.example",
+      port: 6661,
+      tls: {
+        ca: "ca-pem-string",
+        cert: "cert-pem-string",
+        key: "key-pem-string",
+        servername: "secure.example",
+      },
+    });
+
+    await client.send(SAMPLE_ADT);
+
+    expect(mockState.connectCalls[0]?.type).toBe("tls");
+    expect(mockState.connectCalls[0]?.options).toMatchObject({
+      caCerts: ["ca-pem-string"],
+      certChain: "cert-pem-string",
+      hostname: "secure.example",
+      port: 6661,
+      privateKey: "key-pem-string",
+    });
+  });
+
+  it("decodes Uint8Array TLS material into PEM strings", async () => {
+    mockState.reply = frame(VALID_AA);
+    const client = new MllpClient({
+      host: "mllp.example",
+      port: 6661,
+      tls: { ca: new TextEncoder().encode("encoded-ca-pem") },
+    });
+
+    await client.send(SAMPLE_ADT);
+
+    expect(mockState.connectCalls[0]?.options).toMatchObject({
+      caCerts: ["encoded-ca-pem"],
+    });
+  });
+
+  it("rejects with INVALID_INPUT when tls.insecure is true (Deno cannot disable verification at runtime)", async () => {
+    const client = new MllpClient({
+      host: "mllp.example",
+      port: 6661,
+      tls: { insecure: true },
+    });
+
+    try {
+      await client.send(SAMPLE_ADT);
+      expect.fail("expected throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(MllpClientError);
+      expect((error as MllpClientError).code).toBe(
+        MllpClientErrorCode.INVALID_INPUT
+      );
+    }
+  });
+
+  it("maps a failed Deno.connect to CONNECTION_REFUSED", async () => {
+    mockState.connectError = new Error("connection refused");
+    const client = new MllpClient({ host: "mllp.example", port: 2575 });
+
+    try {
+      await client.send(SAMPLE_ADT);
+      expect.fail("expected throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(MllpClientError);
+      expect((error as MllpClientError).code).toBe(
+        MllpClientErrorCode.CONNECTION_REFUSED
+      );
+    }
+  });
+
+  it("calls conn.close() after a successful exchange", async () => {
+    mockState.reply = frame(VALID_AA);
+    const client = new MllpClient({ host: "mllp.example", port: 2575 });
+
+    await client.send(SAMPLE_ADT);
+
+    expect(mockState.closeCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("rejects a passphrase-protected key with INVALID_INPUT (Deno cannot accept inline passphrases)", async () => {
+    const client = new MllpClient({
+      host: "mllp.example",
+      port: 6661,
+      tls: {
+        cert: "cert-pem-string",
+        key: "key-pem-string",
+        passphrase: "supersecret",
+      },
+    });
+
+    try {
+      await client.send(SAMPLE_ADT);
+      expect.fail("expected throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(MllpClientError);
+      expect((error as MllpClientError).code).toBe(
+        MllpClientErrorCode.INVALID_INPUT
+      );
+    }
+  });
+
+  it("maps a PermissionDenied error from Deno.connect to INVALID_INPUT", async () => {
+    // Deno surfaces missing `--allow-net` as a PermissionDenied error
+    // subclass. The adapter sniffs the constructor name and maps it
+    // to INVALID_INPUT with a hint message naming the host:port the
+    // operator must add to the allow list.
+    class PermissionDenied extends Error {}
+    mockState.connectError = new PermissionDenied("net access denied");
+    const client = new MllpClient({ host: "mllp.example", port: 2575 });
+
+    try {
+      await client.send(SAMPLE_ADT);
+      expect.fail("expected throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(MllpClientError);
+      expect((error as MllpClientError).code).toBe(
+        MllpClientErrorCode.INVALID_INPUT
+      );
+      expect((error as MllpClientError).message).toContain(
+        "--allow-net=mllp.example:2575"
+      );
+    }
+  });
+
+  it("rejects with TIMEOUT when the abort signal fires before connect", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const client = new MllpClient({ host: "mllp.example", port: 2575 });
+
+    try {
+      await client.send(SAMPLE_ADT, { signal: controller.signal });
+      expect.fail("expected throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(MllpClientError);
+      expect((error as MllpClientError).code).toBe(MllpClientErrorCode.TIMEOUT);
+      // Adapter MUST short-circuit before calling Deno.connect when
+      // the signal is already aborted — otherwise the runtime would
+      // open a socket only to immediately tear it down.
+      expect(mockState.connectCalls).toHaveLength(0);
+    }
+  });
+});

--- a/packages/mllp-client/tsdown.config.ts
+++ b/packages/mllp-client/tsdown.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: {
     "core/index": "src/core/index.ts",
     index: "src/index.ts",
+    "runtimes/deno": "src/runtimes/deno.ts",
     "runtimes/node": "src/runtimes/node.ts",
   },
   format: "esm",


### PR DESCRIPTION
## Summary

Adds the **Deno** runtime adapter to `@glion/mllp-client`, backed by `Deno.connect` / `Deno.connectTls`. Now rebased onto `main` after PR #609 landed.

```ts
import { MllpClient } from "@glion/mllp-client/deno";

const client = new MllpClient({ host: "127.0.0.1", port: 2575 });
const ack = await client.send(rawHl7Message);
```

The user-facing API (`new MllpClient({ host, port }).send(message)`, `client.stream(...)`, `MllpClientError`, `AckException`) is identical to the Node adapter — only the import path changes.

## Adapter-specific behaviour

- **TLS material accepted as `string` or `Uint8Array`.** Non-string CA/cert/key is decoded to a PEM string before being handed to `Deno.connectTls` (which expects `string` / `string[]`).
- **`tls.passphrase` rejected with `INVALID_INPUT`.** Deno's `connectTls` does not accept inline passphrases — decrypt the private key before passing it to the client.
- **`tls.insecure: true` rejected with `INVALID_INPUT`.** Deno has no runtime flag to disable certificate verification; for self-signed local-dev scenarios, run Deno with `--unsafely-ignore-certificate-errors=<host>` instead.
- **Permission failures route to `INVALID_INPUT`.** `Deno.errors.PermissionDenied` and `NotCapable` are mapped with a message naming the `host:port` the operator must add to `--allow-net=…`. (Otherwise these would be miscategorised as `CONNECTION_REFUSED`.)
- **Caller-supplied `AbortSignal` honoured at connect-phase.** Pre-aborted signals short-circuit before `Deno.connect` runs (no socket allocated). A signal that fires during the open is mapped to `TIMEOUT` with the abort reason chained as `cause`.

## Files of interest

| File | Purpose |
|---|---|
| `packages/mllp-client/src/runtimes/deno.ts` | The adapter — `denoConnect` + the `MllpClient` subclass with `denoConnect` pre-bound |
| `packages/mllp-client/test/deno.test.ts` | 9 mock-based unit tests |
| `packages/mllp-client/package.json` | Adds `deno` conditional export at `.` and `./deno` subpath |
| `packages/mllp-client/tsdown.config.ts` | Adds `runtimes/deno` entry-point binding |
| `packages/mllp-client/README.md` | Marks Deno as `shipped` in the runtime status table and adds the Deno code example |

## Tests

`test/deno.test.ts` monkey-patches `globalThis.Deno` so the adapter's wiring is exercised in plain Node vitest. Coverage:

- TCP / TLS connect with parameter forwarding and PEM coercion of `Uint8Array` inputs.
- `tls.insecure: true` rejection.
- `tls.passphrase` rejection.
- `Deno.errors.PermissionDenied` mapping with `--allow-net=…` hint.
- Generic `Deno.connect` failure → `CONNECTION_REFUSED`.
- `conn.close()` runs after a successful exchange.
- Pre-aborted `AbortSignal` short-circuits before the runtime allocates a socket.

For end-to-end verification inside the actual Deno runtime, write a `*.deno.test.ts` file that runs via `deno test` against a real server. The MLLP exchange logic itself is covered by the runtime-free `test/core.test.ts` (already on main).

## Test plan

- [ ] CI: build, typecheck, test, lint pass
- [ ] Smoke test in actual Deno runtime against a real HL7v2 receiver:
  - [ ] `await client.send(message)` resolves with `AA`.
  - [ ] TLS connect with a real CA.
  - [ ] Without `--allow-net`, the surfaced error is `INVALID_INPUT` and names the required permission flag.

https://claude.ai/code/session_01MvBEUcGkRokNw2GWYVHADg