### PR TITLE
docs(mllp-client): remove the runtime-status heads-up alert

### DIFF
--- a/packages/mllp-client/README.md
+++ b/packages/mllp-client/README.md
@@ -24,8 +24,6 @@ npm install @glion/mllp-client @glion/ack
 | **Deno**               | —                    | `Deno.connect` / `Deno.connectTls` | in progress (PR [#615]) |
 | **Cloudflare Workers** | —                    | `cloudflare:sockets`               | in progress (PR [#616]) |
 
-> **Heads-up.** The Deno and Cloudflare Workers adapters are being reviewed in separate pull requests and are not yet part of a release. The runtime-agnostic core is stable; you can wire your own `MllpConnect` against any transport (or a custom test harness) by importing from `@glion/mllp-client/core` until those adapters land.
-
 [#615]: https://github.com/rethinkhealth/glion/pull/615
 [#616]: https://github.com/rethinkhealth/glion/pull/616
 


### PR DESCRIPTION
## Summary

Removes the runtime-status heads-up alert from `packages/mllp-client/README.md`. The runtime-status table directly above it already lists each adapter's shipping state and links to the in-flight PRs (#615, #616); the heads-up paragraph repeats the same information in prose and adds no new content for the reader.

```diff
 | **Cloudflare Workers** | —                    | `cloudflare:sockets`               | in progress (PR [#616]) |

-> **Heads-up.** The Deno and Cloudflare Workers adapters are being reviewed in separate pull requests and are not yet part of a release. The runtime-agnostic core is stable; you can wire your own `MllpConnect` against any transport (or a custom test harness) by importing from `@glion/mllp-client/core` until those adapters land.
-
 [#615]: https://github.com/rethinkhealth/glion/pull/615
```

## Scope

This PR only removes the alert paragraph. The `[#615]` / `[#616]` link references at the bottom of the section stay because the table rows above still use them. Once #615 and #616 land and each updates its own table row to `shipped`, the orphaned link references can be removed in a small follow-up.

## Test plan

- [ ] CI: lint passes
- [ ] Visual diff: the runtime support section now ends with the table + link references, no heads-up paragraph

https://claude.ai/code/session_01MvBEUcGkRokNw2GWYVHADg

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvBEUcGkRokNw2GWYVHADg)_