### PR TITLE
chore: migrate vitest + @vitest/coverage-v8 to pnpm catalog

### DIFF
--- a/.changeset/catalog-vitest-deps.md
+++ b/.changeset/catalog-vitest-deps.md
@@ -1,0 +1,17 @@
+---
+---
+
+Migrate `vitest` and `@vitest/coverage-v8` to the `pnpm-workspace.yaml` `catalog:` so the version is the single source of truth across the monorepo.
+
+**Why**
+
+The two devdeps were hard-pinned in 47 `package.json` files. With each new package, the version had to be copied; with each upgrade, every file had to be touched. One package (`@glion/annotate-profile-segments`) had silently drifted to `4.1.0` while the rest sat on `4.1.2`, so two distinct vitest installs lived in `node_modules` until pnpm's hoister deduplicated them. Catalog references make drift impossible.
+
+**What changed**
+
+- `pnpm-workspace.yaml` gains a `catalog:` block with `vitest` and `@vitest/coverage-v8` at `4.1.2`.
+- All 47 affected `package.json` files now reference `"vitest": "catalog:"` and `"@vitest/coverage-v8": "catalog:"`.
+- `pnpm install` removed 44 packages from the lockfile (the duplicate vitest install).
+- `@glion/annotate-profile-segments` is reconciled from `4.1.0` to `4.1.2` along with everyone else; its 8 tests pass under the bumped version.
+
+No code changes; no public API impact. Future test-tooling additions just reference `catalog:` and stay aligned.

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -19,7 +19,7 @@
     "@glion/util-query": "workspace:*",
     "unified": "^11.0.5",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/ack/package.json
+++ b/packages/ack/package.json
@@ -55,11 +55,11 @@
     "@glion/to-hl7v2": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/annotate-delimiters/package.json
+++ b/packages/annotate-delimiters/package.json
@@ -37,13 +37,13 @@
     "@glion/tsconfig": "workspace:*",
     "@glion/utils": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "unified": "^11.0.5",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/annotate-profile-context/package.json
+++ b/packages/annotate-profile-context/package.json
@@ -60,11 +60,11 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/annotate-profile-datatypes/package.json
+++ b/packages/annotate-profile-datatypes/package.json
@@ -61,11 +61,11 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/annotate-profile-fields-code-systems/package.json
+++ b/packages/annotate-profile-fields-code-systems/package.json
@@ -63,11 +63,11 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/annotate-profile-fields/package.json
+++ b/packages/annotate-profile-fields/package.json
@@ -60,11 +60,11 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/annotate-profile-segments/package.json
+++ b/packages/annotate-profile-segments/package.json
@@ -60,11 +60,11 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.0",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.0"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -37,13 +37,13 @@
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "unified": "^11.0.5",
     "unist-builder": "^4.0.0",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -52,12 +52,12 @@
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "unified": "^11.0.5",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -54,11 +54,11 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2",
+    "vitest": "catalog:",
     "zod-to-json-schema": "3.25.0"
   },
   "engines": {

--- a/packages/decode-escapes/package.json
+++ b/packages/decode-escapes/package.json
@@ -56,12 +56,12 @@
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/encode-escapes/package.json
+++ b/packages/encode-escapes/package.json
@@ -56,12 +56,12 @@
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/glion/package.json
+++ b/packages/glion/package.json
@@ -64,13 +64,13 @@
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
     "@types/react": "^18.3.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "execa": "^9.5.0",
     "ink-testing-library": "^4.0.0",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "optionalDependencies": {
     "chokidar": "^4.0.0",

--- a/packages/hl7v2/package.json
+++ b/packages/hl7v2/package.json
@@ -60,11 +60,11 @@
     "@glion/utils": "workspace:*",
     "@types/node": "^25.5.0",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/jsonify/package.json
+++ b/packages/jsonify/package.json
@@ -52,11 +52,11 @@
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/lint-max-message-size/package.json
+++ b/packages/lint-max-message-size/package.json
@@ -60,12 +60,12 @@
     "@types/node": "^25.5.0",
     "@types/pluralize": "^0.0.33",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/lint-message-version/package.json
+++ b/packages/lint-message-version/package.json
@@ -59,13 +59,13 @@
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "unified": "^11.0.5",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/lint-no-trailing-empty-field/package.json
+++ b/packages/lint-no-trailing-empty-field/package.json
@@ -60,13 +60,13 @@
     "@types/node": "^25.5.0",
     "@types/pluralize": "^0.0.33",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "vfile": "^6.0.3",
     "vfile-reporter": "^8.1.1",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/lint-profile-events-segments-order/package.json
+++ b/packages/lint-profile-events-segments-order/package.json
@@ -54,13 +54,13 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "unified": "^11.0.5",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/lint-profile-extra-components/package.json
+++ b/packages/lint-profile-extra-components/package.json
@@ -55,13 +55,13 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "unified": "^11.0.5",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/lint-profile-extra-fields/package.json
+++ b/packages/lint-profile-extra-fields/package.json
@@ -54,13 +54,13 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "unified": "^11.0.5",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/lint-profile-field-max-length/package.json
+++ b/packages/lint-profile-field-max-length/package.json
@@ -55,13 +55,13 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "unified": "^11.0.5",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/lint-profile-field-repetition/package.json
+++ b/packages/lint-profile-field-repetition/package.json
@@ -54,13 +54,13 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "unified": "^11.0.5",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/lint-profile-required-components/package.json
+++ b/packages/lint-profile-required-components/package.json
@@ -56,13 +56,13 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "unified": "^11.0.5",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/lint-profile-required-fields/package.json
+++ b/packages/lint-profile-required-fields/package.json
@@ -55,13 +55,13 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "unified": "^11.0.5",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/lint-profile-table-values/package.json
+++ b/packages/lint-profile-table-values/package.json
@@ -55,13 +55,13 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "unified": "^11.0.5",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/lint-required-message-header/package.json
+++ b/packages/lint-required-message-header/package.json
@@ -57,13 +57,13 @@
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "vfile": "^6.0.3",
     "vfile-reporter": "^8.1.1",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/lint-segment-header-length/package.json
+++ b/packages/lint-segment-header-length/package.json
@@ -59,12 +59,12 @@
     "@types/node": "^25.5.0",
     "@types/pluralize": "^0.0.33",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/mllp-ack/package.json
+++ b/packages/mllp-ack/package.json
@@ -59,11 +59,11 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/mllp-client/package.json
+++ b/packages/mllp-client/package.json
@@ -69,11 +69,11 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/mllp-transport/package.json
+++ b/packages/mllp-transport/package.json
@@ -54,11 +54,11 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/mllp/package.json
+++ b/packages/mllp/package.json
@@ -65,11 +65,11 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -54,12 +54,12 @@
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "unist": "^0.0.1",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/preset-annotate-profile-recommended/package.json
+++ b/packages/preset-annotate-profile-recommended/package.json
@@ -63,11 +63,11 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/preset-lint-profile-recommended/package.json
+++ b/packages/preset-lint-profile-recommended/package.json
@@ -63,13 +63,13 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "unified": "^11.0.5",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/preset-lint-recommended/package.json
+++ b/packages/preset-lint-recommended/package.json
@@ -62,13 +62,13 @@
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "vfile": "^6.0.3",
     "vfile-reporter": "^8.1.1",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/profiles/package.json
+++ b/packages/profiles/package.json
@@ -62,12 +62,12 @@
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "unist": "^0.0.1",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/to-hl7v2/package.json
+++ b/packages/to-hl7v2/package.json
@@ -56,13 +56,13 @@
     "@glion/util-query": "workspace:*",
     "@types/node": "^25.5.0",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "unist-builder": "^4.0.0",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/util-query/package.json
+++ b/packages/util-query/package.json
@@ -53,11 +53,11 @@
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/util-semver/package.json
+++ b/packages/util-semver/package.json
@@ -46,11 +46,11 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/util-timestamp/package.json
+++ b/packages/util-timestamp/package.json
@@ -47,11 +47,11 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/util-visit/package.json
+++ b/packages/util-visit/package.json
@@ -54,11 +54,11 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -48,13 +48,13 @@
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
     "@types/unist": "^3.0.3",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "publint": "0.3.18",
     "tsdown": "0.21.7",
     "typescript": "^5.9.3",
     "unist-builder": "^4.0.0",
     "vfile": "^6.0.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,15 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@vitest/coverage-v8':
+      specifier: 4.1.2
+      version: 4.1.2
+    vitest:
+      specifier: 4.1.2
+      version: 4.1.2
+
 importers:
 
   .:
@@ -85,7 +94,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   examples/glion-bun:
@@ -194,7 +203,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -206,7 +215,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/annotate-delimiters:
@@ -237,7 +246,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -255,7 +264,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/annotate-profile-context:
@@ -295,7 +304,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -307,7 +316,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/annotate-profile-datatypes:
@@ -347,7 +356,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -359,7 +368,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/annotate-profile-fields:
@@ -399,7 +408,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -411,7 +420,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/annotate-profile-fields-code-systems:
@@ -454,7 +463,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -466,7 +475,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/annotate-profile-segments:
@@ -506,8 +515,8 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.0
-        version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        specifier: 'catalog:'
+        version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
         version: 0.3.18
@@ -518,8 +527,8 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 'catalog:'
+        version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/ast:
     devDependencies:
@@ -536,7 +545,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -554,7 +563,7 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/builder:
@@ -585,7 +594,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -600,7 +609,7 @@ importers:
         specifier: ^11.0.5
         version: 11.0.5
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/config:
@@ -631,7 +640,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -643,7 +652,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       zod-to-json-schema:
         specifier: 3.25.0
@@ -686,7 +695,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -701,7 +710,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/encode-escapes:
@@ -741,7 +750,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -756,7 +765,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/glion:
@@ -793,7 +802,7 @@ importers:
         specifier: ^18.3.0
         version: 18.3.28
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       execa:
         specifier: ^9.5.0
@@ -811,7 +820,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
       chokidar:
@@ -873,7 +882,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -885,7 +894,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/jsonify:
@@ -916,7 +925,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -928,7 +937,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/lint-max-message-size:
@@ -974,7 +983,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -989,7 +998,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/lint-message-version:
@@ -1029,7 +1038,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1047,7 +1056,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/lint-no-trailing-empty-field:
@@ -1093,7 +1102,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1111,7 +1120,7 @@ importers:
         specifier: ^8.1.1
         version: 8.1.1
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/lint-profile-events-segments-order:
@@ -1148,7 +1157,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1166,7 +1175,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/lint-profile-extra-components:
@@ -1203,7 +1212,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1221,7 +1230,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/lint-profile-extra-fields:
@@ -1255,7 +1264,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1273,7 +1282,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/lint-profile-field-max-length:
@@ -1310,7 +1319,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1328,7 +1337,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/lint-profile-field-repetition:
@@ -1362,7 +1371,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1380,7 +1389,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/lint-profile-required-components:
@@ -1420,7 +1429,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1438,7 +1447,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/lint-profile-required-fields:
@@ -1475,7 +1484,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1493,7 +1502,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/lint-profile-table-values:
@@ -1530,7 +1539,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1548,7 +1557,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/lint-required-message-header:
@@ -1585,7 +1594,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1603,7 +1612,7 @@ importers:
         specifier: ^8.1.1
         version: 8.1.1
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/lint-segment-header-length:
@@ -1646,7 +1655,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1661,7 +1670,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/mllp:
@@ -1701,7 +1710,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1713,7 +1722,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/mllp-ack:
@@ -1756,7 +1765,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1768,7 +1777,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/mllp-client:
@@ -1811,7 +1820,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1823,7 +1832,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/mllp-transport:
@@ -1841,7 +1850,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1853,7 +1862,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/parser:
@@ -1887,7 +1896,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1902,7 +1911,7 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/preset-annotate-profile-recommended:
@@ -1948,7 +1957,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -1960,7 +1969,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/preset-lint-profile-recommended:
@@ -2018,7 +2027,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -2033,7 +2042,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/preset-lint-recommended:
@@ -2085,7 +2094,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -2103,7 +2112,7 @@ importers:
         specifier: ^8.1.1
         version: 8.1.1
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/profiles:
@@ -2140,7 +2149,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -2155,7 +2164,7 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/to-hl7v2:
@@ -2198,7 +2207,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -2216,7 +2225,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/util-query:
@@ -2250,7 +2259,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -2262,7 +2271,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/util-semver:
@@ -2280,7 +2289,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -2292,7 +2301,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/util-timestamp:
@@ -2310,7 +2319,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -2322,7 +2331,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/util-visit:
@@ -2356,7 +2365,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -2368,7 +2377,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/utils:
@@ -2392,7 +2401,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       publint:
         specifier: 0.3.18
@@ -2410,7 +2419,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   qa:
@@ -2440,7 +2449,7 @@ importers:
         specifier: ^11.0.5
         version: 11.0.5
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   tools/check-readme:
@@ -2455,13 +2464,13 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   tools/testing:
@@ -2473,7 +2482,7 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
       '@vitest/coverage-v8':
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       tsdown:
         specifier: 0.21.7
@@ -2488,7 +2497,7 @@ importers:
         specifier: 7.3.2
         version: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
-        specifier: 4.1.2
+        specifier: 'catalog:'
         version: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   tools/tsconfig: {}
@@ -3532,15 +3541,6 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@vitest/coverage-v8@4.1.0':
-    resolution: {integrity: sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==}
-    peerDependencies:
-      '@vitest/browser': 4.1.0
-      vitest: 4.1.0
-    peerDependenciesMeta:
-      '@vitest/browser':
-        optional: true
-
   '@vitest/coverage-v8@4.1.2':
     resolution: {integrity: sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==}
     peerDependencies:
@@ -3550,22 +3550,8 @@ packages:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.0':
-    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
-
   '@vitest/expect@4.1.2':
     resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
-
-  '@vitest/mocker@4.1.0':
-    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
 
   '@vitest/mocker@4.1.2':
     resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
@@ -3578,32 +3564,17 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.0':
-    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
-
   '@vitest/pretty-format@4.1.2':
     resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
-
-  '@vitest/runner@4.1.0':
-    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
 
   '@vitest/runner@4.1.2':
     resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
 
-  '@vitest/snapshot@4.1.0':
-    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
-
   '@vitest/snapshot@4.1.2':
     resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
 
-  '@vitest/spy@4.1.0':
-    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
-
   '@vitest/spy@4.1.2':
     resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
-
-  '@vitest/utils@4.1.0':
-    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
@@ -5088,41 +5059,6 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.0:
-    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.0
-      '@vitest/browser-preview': 4.1.0
-      '@vitest/browser-webdriverio': 4.1.0
-      '@vitest/ui': 4.1.0
-      happy-dom: '*'
-      jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser-playwright':
-        optional: true
-      '@vitest/browser-preview':
-        optional: true
-      '@vitest/browser-webdriverio':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-
   vitest@4.1.2:
     resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -6056,20 +5992,6 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))':
-    dependencies:
-      '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.0
-      ast-v8-to-istanbul: 1.0.0
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-reports: 3.2.0
-      magicast: 0.5.2
-      obug: 2.1.1
-      std-env: 4.0.0
-      tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
-
   '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -6084,15 +6006,6 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
-  '@vitest/expect@4.1.0':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
-      chai: 6.2.2
-      tinyrainbow: 3.1.0
-
   '@vitest/expect@4.1.2':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -6102,14 +6015,6 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.0
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-
   '@vitest/mocker@4.1.2(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.2
@@ -6118,29 +6023,13 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/pretty-format@4.1.0':
-    dependencies:
-      tinyrainbow: 3.1.0
-
   '@vitest/pretty-format@4.1.2':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.0':
-    dependencies:
-      '@vitest/utils': 4.1.0
-      pathe: 2.0.3
-
   '@vitest/runner@4.1.2':
     dependencies:
       '@vitest/utils': 4.1.2
-      pathe: 2.0.3
-
-  '@vitest/snapshot@4.1.0':
-    dependencies:
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/utils': 4.1.0
-      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/snapshot@4.1.2':
@@ -6150,15 +6039,7 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.0': {}
-
   '@vitest/spy@4.1.2': {}
-
-  '@vitest/utils@4.1.0':
-    dependencies:
-      '@vitest/pretty-format': 4.1.0
-      convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
 
   '@vitest/utils@4.1.2':
     dependencies:
@@ -7635,33 +7516,6 @@ snapshots:
       jiti: 2.6.1
       tsx: 4.21.0
       yaml: 2.8.3
-
-  vitest@4.1.0(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 25.5.0
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.2(@types/node@25.5.0)(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,10 @@ packages:
   - "packages/*"
   - "qa"
   - "tools/*"
+
+# Shared dependency versions consumed via the `catalog:` protocol.
+# Add entries here when a dependency is used by more than one package,
+# or when avoiding silent version drift across packages matters.
+catalog:
+  "@vitest/coverage-v8": 4.1.2
+  vitest: 4.1.2

--- a/qa/package.json
+++ b/qa/package.json
@@ -16,7 +16,7 @@
     "@glion/tsconfig": "workspace:*",
     "fast-check": "^3.23.2",
     "unified": "^11.0.5",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/tools/check-readme/package.json
+++ b/tools/check-readme/package.json
@@ -17,9 +17,9 @@
     "@glion/testing": "workspace:*",
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "typescript": "^5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/tools/testing/package.json
+++ b/tools/testing/package.json
@@ -18,16 +18,16 @@
   "devDependencies": {
     "@glion/tsconfig": "workspace:*",
     "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "4.1.2",
+    "@vitest/coverage-v8": "catalog:",
     "tsdown": "0.21.7",
     "tsx": "4.21.0",
     "typescript": "^5.9.3",
     "vite": "7.3.2",
-    "vitest": "4.1.2"
+    "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@vitest/coverage-v8": "4.1.2",
-    "vitest": "4.1.2"
+    "@vitest/coverage-v8": "catalog:",
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Closing per discussion — pnpm catalogs aren't yet adopted in this repo. The decision on whether to migrate is being tracked separately. The branch can be deleted; the changeset and commits are preserved on `claude/catalog-vitest-deps` if we want to revisit.