### PR TITLE
fix(ci): unblock changesets release via pnpm 10 + OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,17 +20,16 @@ jobs:
       issues: read
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
+      - uses: pnpm/action-setup@v4
 
       - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: pnpm ci:install


### PR DESCRIPTION
## Problem

The `Changesets` workflow on `main` failed during publish with `ENEEDAUTH`, even though the changesets action correctly reported `OIDC is available - using npm trusted publishing`.

Root cause: `release.yml` was installing pnpm v8 while the repo declares `packageManager: pnpm@10.14.0`. pnpm v8 doesn't know how to exchange a GitHub OIDC token for an npm auth token, so the OIDC handshake never happens and `pnpm recursive publish` falls through to a plain unauthenticated publish.

## Fix

Align the release workflow with the modern setup already used in `ci.yml`:

| Step | Before | After |
| --- | --- | --- |
| Checkout | `actions/checkout@v3` | `actions/checkout@v5` |
| pnpm | `pnpm/action-setup@v2` pinned to `version: 8` | `pnpm/action-setup@v4` (picks up pnpm 10.14.0 from `packageManager`) |
| Node | `setup-node@v4`, no registry | `setup-node@v4` + `registry-url: https://registry.npmjs.org` |

`id-token: write` and the `changesets/action@v1` invocation were already correct, so no other workflow changes needed.

## Prerequisite outside this PR

OIDC trusted publishing also requires each `@glion/*` package on npmjs.com to have a Trusted Publisher configured pointing at this repo + workflow. If that isn't set up, the next publish will fail with a clearer auth error from npm — at which point either configure it per-package at `npmjs.com/package/<name>/access`, or fall back to `NPM_TOKEN`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7, 1M context)