### PR TITLE
docs(examples): ship as standalone scaffolds

### DIFF
--- a/examples/mllp-client/.gitignore
+++ b/examples/mllp-client/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+*.log
+.env
+.env.local
+.DS_Store

--- a/examples/mllp-client/README.md
+++ b/examples/mllp-client/README.md
@@ -1,24 +1,25 @@
 # MLLP client
 
-Send HL7v2 messages over MLLP with [`@glion/mllp-client`](../../packages/mllp-client).
+Send HL7v2 messages over MLLP with [`@glion/mllp-client`](https://github.com/rethinkhealth/glion/tree/main/packages/mllp-client). Pairs with the [`mllp-server`](https://github.com/rethinkhealth/glion/tree/main/examples/mllp-server) example.
 
-This example pairs with [`glion-server`](../glion-server) — start the server first, then run a client command in a second terminal.
+## How to use
 
-## Prerequisites
-
-- Node.js ≥ 20
-- pnpm
+Clone this example into a new directory:
 
 ```bash
+npx degit rethinkhealth/glion/examples/mllp-client my-mllp-client
+cd my-mllp-client
 pnpm install
 ```
 
-## Send a message
+Start the [`mllp-server`](https://github.com/rethinkhealth/glion/tree/main/examples/mllp-server) example in another terminal, then send a sample message:
 
 ```bash
 pnpm send --sample adt-a01     # → AA · MSG00001
 pnpm send --sample oru-r01     # → AE · Patient not available · ERR 200
 ```
+
+## Configuration
 
 | Flag       | Default         | Description                                      |
 | ---------- | --------------- | ------------------------------------------------ |
@@ -36,7 +37,7 @@ cat my-message.hl7 | pnpm send
 
 ## Handle NAK responses
 
-The companion `glion-server`'s `ORU^R01` route throws `AckApplicationError`, which the receiver-side ack middleware turns into an `AE` ACK on the wire. `@glion/mllp-client` re-throws the same exception type on the client side, so a single `instanceof AckException` check catches every NAK code (`AE`/`AR`/`CE`/`CR`):
+The companion server's `ORU^R01` route throws `AckApplicationError`, which the receiver-side ack middleware turns into an `AE` ACK on the wire. `@glion/mllp-client` re-throws the same exception type on the client side, so a single `instanceof AckException` check catches every NAK code (`AE`/`AR`/`CE`/`CR`):
 
 ```ts
 import { AckException } from "@glion/ack";
@@ -66,7 +67,7 @@ Branch on the concrete subclass (`AckApplicationError`, `AckApplicationReject`, 
 pnpm stream --sample adt-a01
 ```
 
-The `glion-server` example only emits one ACK per message, so you'll see a single line. Pointed at an enhanced-mode receiver, the loop yields twice. NAK codes still throw, so wrap the loop in `try/catch` exactly like `send`.
+The `mllp-server` example only emits one ACK per message, so you'll see a single line. Pointed at an enhanced-mode receiver, the loop yields twice. NAK codes still throw, so wrap the loop in `try/catch` exactly like `send`.
 
 ## Use commit-level acknowledgments
 
@@ -76,7 +77,7 @@ The `glion-server` example only emits one ACK per message, so you'll see a singl
 pnpm send --sample adt-a01 --mode OnCommit
 ```
 
-Use this against receivers that only emit a commit-level ACK, or when you want to return as soon as receipt is confirmed without waiting for application-level processing. See the [`@glion/mllp-client`](../../packages/mllp-client) README for full mode semantics.
+Use this against receivers that only emit a commit-level ACK, or when you want to return as soon as receipt is confirmed without waiting for application-level processing. See the [`@glion/mllp-client`](https://github.com/rethinkhealth/glion/tree/main/packages/mllp-client) README for full mode semantics.
 
 ## TLS
 
@@ -94,7 +95,7 @@ const client = new MllpClient({
 });
 ```
 
-See the [`@glion/mllp-client`](../../packages/mllp-client) README for the full TLS option set, including the Cloudflare Workers adapter.
+See the [`@glion/mllp-client`](https://github.com/rethinkhealth/glion/tree/main/packages/mllp-client) README for the full TLS option set, including the Cloudflare Workers adapter.
 
 ## Layout
 
@@ -107,8 +108,9 @@ src/
 samples/             ← .hl7 fixtures
 ```
 
-## See also
+## Notes
 
-- [`glion-server`](../glion-server) — companion server example.
-- [`@glion/mllp-client`](../../packages/mllp-client) — full client API, TLS configuration, transport error codes, Workers adapter.
-- [`@glion/ack`](../../packages/ack) — `AckException` hierarchy.
+- Requires Node.js ≥ 20.
+- [`mllp-server`](https://github.com/rethinkhealth/glion/tree/main/examples/mllp-server) — companion server example.
+- [`@glion/mllp-client`](https://github.com/rethinkhealth/glion/tree/main/packages/mllp-client) — full client API, TLS configuration, transport error codes, Workers adapter.
+- [`@glion/ack`](https://github.com/rethinkhealth/glion/tree/main/packages/ack) — `AckException` hierarchy.

--- a/examples/mllp-client/package.json
+++ b/examples/mllp-client/package.json
@@ -1,21 +1,17 @@
 {
-  "name": "mllp-client",
-  "version": "0.0.0",
   "private": true,
-  "description": "Send HL7v2 messages over MLLP using @glion/mllp-client. Companion client for the glion-server example.",
   "type": "module",
   "scripts": {
     "send": "tsx src/send.ts",
     "stream": "tsx src/stream.ts"
   },
   "dependencies": {
-    "@glion/ack": "workspace:*",
-    "@glion/mllp-client": "workspace:*",
+    "@glion/ack": "latest",
+    "@glion/mllp-client": "latest",
     "citty": "0.1.6",
     "consola": "3.4.2"
   },
   "devDependencies": {
-    "@glion/tsconfig": "workspace:*",
     "@types/node": "25.6.0",
     "tsx": "4.21.0"
   }

--- a/examples/mllp-server-bun/.gitignore
+++ b/examples/mllp-server-bun/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+*.log
+.env
+.env.local
+.DS_Store

--- a/examples/mllp-server-bun/README.md
+++ b/examples/mllp-server-bun/README.md
@@ -1,26 +1,22 @@
-# MLLP Server for Bun runtime
+# MLLP server (Bun)
 
-Basic example of an MLLP server using Bun runtime.
+A basic HL7v2 MLLP server with route handlers and ACK/NAK responses, run via the [`glion`](https://github.com/rethinkhealth/glion/tree/main/packages/glion) CLI under [Bun](https://bun.sh).
 
-## Prerequisites
+## How to use
 
-- [Bun](https://bun.sh) (latest)
-- pnpm
+Clone this example into a new directory:
+
+```bash
+npx degit rethinkhealth/glion/examples/mllp-server-bun my-mllp-server
+cd my-mllp-server
+```
+
+Install dependencies and run:
 
 ```bash
 pnpm install
-```
-
-## Run
-
-```bash
-# For development
-# TUI with file-watching and hot reload
-pnpm dev
-
-# When deploying to production
-# JSON-lines log output, no watcher
-pnpm start
+pnpm dev      # development: TUI, file-watching, hot reload
+pnpm start    # production: JSON-lines logs, no watcher
 ```
 
 Both scripts use `bun --bun glion …` to force Bun's runtime through the script runner. Without `--bun`, the `glion` bin's `#!/usr/bin/env node` shebang would hand it to Node.
@@ -30,11 +26,11 @@ Both scripts use `bun --bun glion …` to force Bun's runtime through the script
 - `glion.config.ts` — entry path and port.
 - `src/app.ts` — the `Mllp` instance, exported as the default. The CLI picks it up via the config.
 
-The app routes `ADT^A01`, `ORM^O01`, and `ORU^R01`, plus a catch-all, and uses `ackMiddleware()` to translate handler return values and throws into ACK/NAK responses. See [`glion-server`](../glion-server) for the full breakdown — the code is identical.
+The app routes `ADT^A01`, `ORM^O01`, and `ORU^R01`, plus a catch-all, and uses `ackMiddleware()` to translate handler return values and throws into ACK/NAK responses. The code is identical to [`mllp-server`](https://github.com/rethinkhealth/glion/tree/main/examples/mllp-server) — only the runtime differs.
 
 ## Send a test message
 
-The companion [`mllp-client`](../mllp-client) example sends bundled samples:
+The companion [`mllp-client`](https://github.com/rethinkhealth/glion/tree/main/examples/mllp-client) example sends bundled samples:
 
 ```bash
 cd ../mllp-client
@@ -42,8 +38,9 @@ pnpm send --sample adt-a01     # → AA
 pnpm send --sample oru-r01     # → AE · Patient not available · ERR 200
 ```
 
-## See also
+## Notes
 
-- [`glion-server`](../glion-server) — the same app under Node.
-- [`mllp-client`](../mllp-client) — companion client example.
-- [`@glion/mllp`](../../packages/mllp) — server API and CLI reference.
+- Requires [Bun](https://bun.sh) (latest).
+- [`mllp-server`](https://github.com/rethinkhealth/glion/tree/main/examples/mllp-server) — same app under Node.
+- [`mllp-client`](https://github.com/rethinkhealth/glion/tree/main/examples/mllp-client) — companion client example.
+- [`@glion/mllp`](https://github.com/rethinkhealth/glion/tree/main/packages/mllp) — server API and CLI reference.

--- a/examples/mllp-server-bun/package.json
+++ b/examples/mllp-server-bun/package.json
@@ -1,23 +1,19 @@
 {
-  "name": "mllp-server-bun",
-  "version": "0.0.0",
   "private": true,
-  "description": "HL7v2 MLLP server example with route handlers and ACK/NAK responses, run via the glion CLI under Bun",
   "type": "module",
   "scripts": {
     "dev": "bun --bun glion dev",
     "start": "bun --bun glion start"
   },
   "dependencies": {
-    "@glion/ack": "workspace:*",
-    "@glion/cli": "workspace:*",
-    "@glion/hl7v2": "workspace:*",
-    "@glion/mllp": "workspace:*",
-    "@glion/mllp-ack": "workspace:*",
+    "@glion/ack": "latest",
+    "@glion/cli": "latest",
+    "@glion/hl7v2": "latest",
+    "@glion/mllp": "latest",
+    "@glion/mllp-ack": "latest",
     "consola": "3.4.2"
   },
   "devDependencies": {
-    "@glion/tsconfig": "workspace:*",
     "@types/bun": "latest"
   }
 }

--- a/examples/mllp-server/.gitignore
+++ b/examples/mllp-server/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+*.log
+.env
+.env.local
+.DS_Store

--- a/examples/mllp-server/README.md
+++ b/examples/mllp-server/README.md
@@ -1,27 +1,25 @@
-# MLLP Server for Node
+# MLLP server (Node)
 
-A basic HL7v2 MLLP server with route handlers and ACK/NAK responses.
+A basic HL7v2 MLLP server with route handlers and ACK/NAK responses, run via the [`glion`](https://github.com/rethinkhealth/glion/tree/main/packages/glion) CLI on Node.js.
 
-## Prerequisites
+## How to use
 
-- Node.js ≥ 20
-- pnpm
+Clone this example into a new directory:
+
+```bash
+npx degit rethinkhealth/glion/examples/mllp-server my-mllp-server
+cd my-mllp-server
+```
+
+Install dependencies and run:
 
 ```bash
 pnpm install
+pnpm dev      # development: TUI, file-watching, hot reload
+pnpm start    # production: JSON-lines logs, no watcher
 ```
 
-## Run
-
-```bash
-# For development.
-# TUI with file-watching and hot reload
-pnpm dev
-
-# For production
-# with JSON-lines log output, no watcher
-pnpm start
-```
+The server listens on `127.0.0.1:2575` by default.
 
 ## What's in it
 
@@ -37,7 +35,7 @@ The app:
 
 ## Send a test message
 
-The companion [`mllp-client`](../mllp-client) example sends bundled samples:
+The companion [`mllp-client`](https://github.com/rethinkhealth/glion/tree/main/examples/mllp-client) example sends bundled samples:
 
 ```bash
 cd ../mllp-client
@@ -52,10 +50,11 @@ printf '\x0bMSH|^~\&|SENDER|SENDER|GLION|NODE|20240101120000||ADT^A01|MSG001|P|2
   | nc 127.0.0.1 2575
 ```
 
-## See also
+## Notes
 
-- [`@glion/mllp`](../../packages/mllp) — server API and routing reference.
-- [`@glion/mllp-ack`](../../packages/mllp-ack) — ACK middleware.
-- [`@glion/ack`](../../packages/ack) — `AckException` hierarchy.
-- [`glion-server-bun`](../glion-server-bun) — same app under Bun, zero-config.
-- [`mllp-client`](../mllp-client) — companion client example.
+- Requires Node.js ≥ 20.
+- [`@glion/mllp`](https://github.com/rethinkhealth/glion/tree/main/packages/mllp) — server API and routing reference.
+- [`@glion/mllp-ack`](https://github.com/rethinkhealth/glion/tree/main/packages/mllp-ack) — ACK middleware.
+- [`@glion/ack`](https://github.com/rethinkhealth/glion/tree/main/packages/ack) — `AckException` hierarchy.
+- [`mllp-server-bun`](https://github.com/rethinkhealth/glion/tree/main/examples/mllp-server-bun) — same app under Bun.
+- [`mllp-client`](https://github.com/rethinkhealth/glion/tree/main/examples/mllp-client) — companion client example.

--- a/examples/mllp-server/package.json
+++ b/examples/mllp-server/package.json
@@ -1,23 +1,19 @@
 {
-  "name": "mllp-server",
-  "version": "0.0.0",
   "private": true,
-  "description": "HL7v2 MLLP server example with route handlers and ACK/NAK responses, run via the glion CLI on Node.js",
   "type": "module",
   "scripts": {
     "dev": "glion dev",
     "start": "glion start"
   },
   "dependencies": {
-    "@glion/ack": "workspace:*",
-    "@glion/cli": "workspace:*",
-    "@glion/hl7v2": "workspace:*",
-    "@glion/mllp": "workspace:*",
-    "@glion/mllp-ack": "workspace:*",
+    "@glion/ack": "latest",
+    "@glion/cli": "latest",
+    "@glion/hl7v2": "latest",
+    "@glion/mllp": "latest",
+    "@glion/mllp-ack": "latest",
     "consola": "3.4.2"
   },
   "devDependencies": {
-    "@glion/tsconfig": "workspace:*",
     "@types/node": "25.6.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,70 +88,14 @@ importers:
         specifier: 4.1.5
         version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
 
-  examples/glion-server:
-    dependencies:
-      '@glion/ack':
-        specifier: workspace:*
-        version: link:../../packages/ack
-      '@glion/cli':
-        specifier: workspace:*
-        version: link:../../packages/glion
-      '@glion/hl7v2':
-        specifier: workspace:*
-        version: link:../../packages/hl7v2
-      '@glion/mllp':
-        specifier: workspace:*
-        version: link:../../packages/mllp
-      '@glion/mllp-ack':
-        specifier: workspace:*
-        version: link:../../packages/mllp-ack
-      consola:
-        specifier: 3.4.2
-        version: 3.4.2
-    devDependencies:
-      '@glion/tsconfig':
-        specifier: workspace:*
-        version: link:../../tools/tsconfig
-      '@types/node':
-        specifier: 25.6.0
-        version: 25.6.0
-
-  examples/glion-server-bun:
-    dependencies:
-      '@glion/ack':
-        specifier: workspace:*
-        version: link:../../packages/ack
-      '@glion/cli':
-        specifier: workspace:*
-        version: link:../../packages/glion
-      '@glion/hl7v2':
-        specifier: workspace:*
-        version: link:../../packages/hl7v2
-      '@glion/mllp':
-        specifier: workspace:*
-        version: link:../../packages/mllp
-      '@glion/mllp-ack':
-        specifier: workspace:*
-        version: link:../../packages/mllp-ack
-      consola:
-        specifier: 3.4.2
-        version: 3.4.2
-    devDependencies:
-      '@glion/tsconfig':
-        specifier: workspace:*
-        version: link:../../tools/tsconfig
-      '@types/bun':
-        specifier: latest
-        version: 1.3.13
-
   examples/mllp-client:
     dependencies:
       '@glion/ack':
-        specifier: workspace:*
-        version: link:../../packages/ack
+        specifier: latest
+        version: 0.16.0
       '@glion/mllp-client':
-        specifier: workspace:*
-        version: link:../../packages/mllp-client
+        specifier: latest
+        version: 0.16.0
       citty:
         specifier: 0.1.6
         version: 0.1.6
@@ -159,15 +103,62 @@ importers:
         specifier: 3.4.2
         version: 3.4.2
     devDependencies:
-      '@glion/tsconfig':
-        specifier: workspace:*
-        version: link:../../tools/tsconfig
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
       tsx:
         specifier: 4.21.0
         version: 4.21.0
+
+  examples/mllp-server:
+    dependencies:
+      '@glion/ack':
+        specifier: latest
+        version: 0.16.0
+      '@glion/cli':
+        specifier: latest
+        version: 0.16.0(@types/react@18.3.28)
+      '@glion/hl7v2':
+        specifier: latest
+        version: 0.16.0
+      '@glion/mllp':
+        specifier: latest
+        version: 0.16.0
+      '@glion/mllp-ack':
+        specifier: latest
+        version: 0.16.0
+      consola:
+        specifier: 3.4.2
+        version: 3.4.2
+    devDependencies:
+      '@types/node':
+        specifier: 25.6.0
+        version: 25.6.0
+
+  examples/mllp-server-bun:
+    dependencies:
+      '@glion/ack':
+        specifier: latest
+        version: 0.16.0
+      '@glion/cli':
+        specifier: latest
+        version: 0.16.0(@types/react@18.3.28)
+      '@glion/hl7v2':
+        specifier: latest
+        version: 0.16.0
+      '@glion/mllp':
+        specifier: latest
+        version: 0.16.0
+      '@glion/mllp-ack':
+        specifier: latest
+        version: 0.16.0
+      consola:
+        specifier: 3.4.2
+        version: 3.4.2
+    devDependencies:
+      '@types/bun':
+        specifier: latest
+        version: 1.3.13
 
   packages/ack:
     dependencies:
@@ -3013,6 +3004,147 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@glion/ack@0.16.0':
+    resolution: {integrity: sha512-SjbVXpazT7aNzgmaASjenQr22zu6usE7QqaiweWIvBiLBzH2v29uI1oIn2cLTRltAPyWiX91wKFEIO/v7Oj9gA==}
+    engines: {node: '>=20'}
+
+  '@glion/annotate-profile-context@0.16.0':
+    resolution: {integrity: sha512-hNGjiafdDyEejn2Pr2K1xzAyh+s1QB6aRhUA1Db05ZibSjo+1joJaO1s94n/HClP1O8TKhVlT7XgnbjNgsYemw==}
+    engines: {node: '>=20'}
+
+  '@glion/ast@0.16.0':
+    resolution: {integrity: sha512-otBPQVsIEbTFKjgX62Gnbujz/OQ9mXXbH9Q52Az71t8cng2lVYp1BzKkb+iyHKCIKNJfekCtaEiLLS/fi7BeJg==}
+    engines: {node: '>=20'}
+
+  '@glion/builder@0.16.0':
+    resolution: {integrity: sha512-sxlZ8CBhzeuPgCQ+WswsC2WA7ZcykcNIyEVezkDQorK+SB5mH8qzZDL5SarjYxHsLSu2Lh4tx9JTMHrS+2tLNw==}
+    engines: {node: '>=20'}
+
+  '@glion/cli@0.16.0':
+    resolution: {integrity: sha512-2uruZtc4LlFB1Iw/4phmU+K1MgS30WQDLsV14Kl51CNzlxbjN9F35NIhdRhadDW2ONXY61bwwki+gBdh+bMJCg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  '@glion/decode-escapes@0.16.0':
+    resolution: {integrity: sha512-1vpsi0pdg7Z57GKmxXghEqC1ikuMjyP8LpHjxNP86YSnr2sBEm2T80vbQFvVrGIP4o5sjyRKV5BUOKQqJdvs1Q==}
+    engines: {node: '>=20'}
+
+  '@glion/encode-escapes@0.16.0':
+    resolution: {integrity: sha512-6I7awwuEVZRWGd5xJS8lBBdvAtfB3Rw1ZDaLMMwB0BkbIpZp9DdIuf+qNkBguPml14DgFlR6Y8d29N8bsUOrvw==}
+    engines: {node: '>=20'}
+
+  '@glion/hl7v2@0.16.0':
+    resolution: {integrity: sha512-hmLTIhH+eqoYKGAJQx8F5kyGJDL9MdTSjb1A+Iq3ZyximllYmdqnN2l15dyL3HKzKhO6Tn8wtFNW2IJN/8Q6VQ==}
+    engines: {node: '>=20'}
+
+  '@glion/jsonify@0.16.0':
+    resolution: {integrity: sha512-gyZ5aq5tj1KxzTQ5hYTNkQWSzNFLsWSIrI4MBnnsReSAFmYFeo/YkWIS7Cb7LLzkM3CQoru2MdsTQVm/7CfQpw==}
+    engines: {node: '>=20'}
+
+  '@glion/lint-message-version@0.16.0':
+    resolution: {integrity: sha512-PGxL1Cis9kDnCsV0cu2IlG38hoHmy+c0j5rXj+aD1L5/64T237bdA8RvZckAbZLwPrNdEiiwmU6lG6JLv6C2xw==}
+    engines: {node: '>=20'}
+
+  '@glion/lint-no-trailing-empty-field@0.16.0':
+    resolution: {integrity: sha512-BHPeipF7HHVSpswAmgwLL2ECPU+uubiA6DrP40/gmWiRW6ZmGUHmukBMmo8LOqtAjllbm+43XV+do3yo3tVRJg==}
+    engines: {node: '>=20'}
+
+  '@glion/lint-profile-events-segments-order@0.16.0':
+    resolution: {integrity: sha512-htp1R+mfjnVMSRFjF4zR2U1C67eXOp6N158OL3RmZ6TDVET7IeQTWhjPEqK2NPWF5mTxK2OEsEcx0X0ADu/2mA==}
+    engines: {node: '>=20'}
+
+  '@glion/lint-profile-extra-components@0.16.0':
+    resolution: {integrity: sha512-PngZ9/CdXIgm0099A2lK0/Uj+iVLolCEXhq5SVTVVxpclka5z+o2MBQTW8kSfRsAIBSGcuWTITmZLJn8BG/zFQ==}
+    engines: {node: '>=20'}
+
+  '@glion/lint-profile-extra-fields@0.16.0':
+    resolution: {integrity: sha512-PWNbJsnGlVaeLkkbi1C0W0T3awdT6YulQLmYCZdKrejSi4bIBsznD3MdkZASoisjYLhhf1ZbAKqBsOP3BGK0gw==}
+    engines: {node: '>=20'}
+
+  '@glion/lint-profile-field-max-length@0.16.0':
+    resolution: {integrity: sha512-KSpLX5Y5tWfWuOCccdygd/t+Ak7hxnYlS6btzHAO0pXkQZ50REG0W2fkUr7MgH4A7rwYCWE1Tsmhr8nOrtJMWA==}
+    engines: {node: '>=20'}
+
+  '@glion/lint-profile-field-repetition@0.16.0':
+    resolution: {integrity: sha512-Cpj6Wu+Am54Rp/HO4wWkTHGtRxftAb/pTULJoJL6jKbog566FSC/fgKihrys9PRENgDBUnrxWmcBFuRdYM2PUg==}
+    engines: {node: '>=20'}
+
+  '@glion/lint-profile-required-components@0.16.0':
+    resolution: {integrity: sha512-0w9TB3G2hr6QMafgRWWA6MCpsqwdXNo0QOqWNDQh2EH0y1t09mOPRkILYXg1HJB0BmiZgMbTyUhd7htIF6ljPw==}
+    engines: {node: '>=20'}
+
+  '@glion/lint-profile-required-fields@0.16.0':
+    resolution: {integrity: sha512-VCJfycVep2YuAQYAlihaYMy5iCPBr0L02J4AwVyPlZG2ZelPGNJVYxnSFEeBQw5TqCb12qX20yg0LHW+Xz7gNg==}
+    engines: {node: '>=20'}
+
+  '@glion/lint-profile-table-values@0.16.0':
+    resolution: {integrity: sha512-FXgAAD2b/WdsLAjgSoKCv7IRADZs5Bqgb1/+07yix2Wm9Rj9T1KEbWih8NhnLkNssJ9piBBGuK5dzvNZ4KRTvw==}
+    engines: {node: '>=20'}
+
+  '@glion/lint-required-message-header@0.16.0':
+    resolution: {integrity: sha512-V381JiGbpdH0qrSZ7l1vEwGlxf9qnzSNeGHHaVrDkXFVB2Ke5+5cnnbp+1Iu+AnLnXvBOoLiKC234dU4FelFYA==}
+    engines: {node: '>=20'}
+
+  '@glion/lint-segment-header-length@0.16.0':
+    resolution: {integrity: sha512-2S5vDDF+XHnC3PRt81+EQclCsI9Wyk78PiGjU+E1d3BLNTXfwx4xYAlQ61qh+aLWHT1xyeFUy56TDsp6w4BDWg==}
+    engines: {node: '>=20'}
+
+  '@glion/mllp-ack@0.16.0':
+    resolution: {integrity: sha512-js+Tif6sZHgFtY0q8pEaUbFEy7Qyp/6yoxO3vB/Q+ZezNPdEBoJnpZ3NZumdQVUjuYO2w0USBW7FRjGEcr/qsw==}
+    engines: {node: '>=20'}
+
+  '@glion/mllp-client@0.16.0':
+    resolution: {integrity: sha512-yB7ovLz0S+B04UtoeoLPmXQmyobOgl1nKOwXHuNWiyawVCl7FR1+TZvHLbPCNp99bN9WWSJl5gPt7Ab04gW6mw==}
+    engines: {node: '>=20'}
+
+  '@glion/mllp-transport@0.16.0':
+    resolution: {integrity: sha512-NKd5YLfnE81TnYjxDiLg1h9+frCisUP2Kw9GulMqE8OGVtbL1s+JHeZFowE8tOgbJ0p8nD2ZRhR1MqmEmX95cw==}
+    engines: {node: '>=20'}
+
+  '@glion/mllp@0.16.0':
+    resolution: {integrity: sha512-k0ClcraJJjpp30FgvkHB/omi6dPWUipFZ3//DtJBhILIYXhaMb4hIKPmmL4Ow3j2gGEAquLxPLRxyNjfdy03Yw==}
+    engines: {node: '>=20'}
+
+  '@glion/parser@0.16.0':
+    resolution: {integrity: sha512-ekoa7gxHu7vHhQXwbdJlbmIh3zeWwkvBZGuVV1IAdSdIJIF9jq6XHZuC/1C5EF9X2dVxDjvKL2c+wnynCRu5oQ==}
+    engines: {node: '>=20'}
+
+  '@glion/preset-lint-profile-recommended@0.16.0':
+    resolution: {integrity: sha512-WDe/FlU12FDvr/m4BXkZXu5W2Kp1VOwQz5cOakJ2ELGzWjYFvYZ1AHWM5mTHxTBqbOEWb5mX6Fq+v6Mg5vTPFg==}
+    engines: {node: '>=20'}
+
+  '@glion/preset-lint-recommended@0.16.0':
+    resolution: {integrity: sha512-wQ1N6B+P8n9OoUEQEXQltHFAnojn8p/EUybngMglFs2xjayY8MWCx167zXlP/d9qMuHLrkMcYFmiHvluKJdODQ==}
+    engines: {node: '>=20'}
+
+  '@glion/profiles@0.16.0':
+    resolution: {integrity: sha512-jhuqHBRQsns4iEtHF8/g5vx1ZBYPaa6wgEiezx8OdhAW9u4gN52yuuVb7c++B9errcKYqZlhZvl6sXytWZv3LA==}
+    engines: {node: '>=20'}
+
+  '@glion/to-hl7v2@0.16.0':
+    resolution: {integrity: sha512-Svw9odnoF3rUDeY/BiQobF9c93XHIcInePz9DXSoDKcI0r8Ws1Cn8wLA5SM5eh09oN6ZytlJSBe77PiVB1JwCw==}
+    engines: {node: '>=20'}
+
+  '@glion/util-query@0.16.0':
+    resolution: {integrity: sha512-NiXixo2Z7ikZoN6OxDl30+E5qwZKWWSIjHTMHFLBLqRJoCI6fbTXCfekEi0NGWb5VP/59Z6fOBFbuBUo8JupjQ==}
+    engines: {node: '>=20'}
+
+  '@glion/util-semver@0.16.0':
+    resolution: {integrity: sha512-UjO6EKQJ25rcLQ28mpM7pWg0dW66WRd2iGBURiPvBH+qc5LcU3htMBO7rCxEvw6L/rpVBLgfHiTA2wQiH/Kp4A==}
+    engines: {node: '>=20'}
+
+  '@glion/util-timestamp@0.16.0':
+    resolution: {integrity: sha512-ToIkEbCeFPV/Bd9+FnmYZ3qty5c25k5jjuD7nms8CJxoqYH6Jjyug4CHFkpAn918lPaXhel02Rur39GIfpcq/Q==}
+    engines: {node: '>=20'}
+
+  '@glion/util-visit@0.16.0':
+    resolution: {integrity: sha512-gGv0BGyXhiKyzjKFe6RpXOXk+jWc3wyDDU5WIsrJY4yOHsNnCg6Wv+lAiFOY8JCsGoeVwHWMis9/bBr9Xeco7Q==}
+    engines: {node: '>=20'}
+
+  '@glion/utils@0.16.0':
+    resolution: {integrity: sha512-9vayxv4kcWBAt5CMTrswBdZ88+I4KaQ+7JB746UAB/m139GHNr9VKdOYEuigY/8XJz2VnSHQcyRoMzsEWRo7/g==}
+    engines: {node: '>=20'}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -5971,6 +6103,238 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.7':
     optional: true
+
+  '@glion/ack@0.16.0':
+    dependencies:
+      '@glion/ast': 0.16.0
+      '@glion/builder': 0.16.0
+      '@glion/util-query': 0.16.0
+      '@glion/util-timestamp': 0.16.0
+      nanoid: 5.1.7
+
+  '@glion/annotate-profile-context@0.16.0':
+    dependencies:
+      '@glion/ast': 0.16.0
+      '@glion/profiles': 0.16.0
+      '@glion/util-query': 0.16.0
+      '@glion/util-visit': 0.16.0
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  '@glion/ast@0.16.0': {}
+
+  '@glion/builder@0.16.0':
+    dependencies:
+      '@glion/ast': 0.16.0
+      unist-builder: 4.0.0
+
+  '@glion/cli@0.16.0(@types/react@18.3.28)':
+    dependencies:
+      '@glion/mllp': 0.16.0
+      rolldown: 1.0.0-rc.14
+      zod: 3.25.76
+    optionalDependencies:
+      chokidar: 4.0.3
+      ink: 5.2.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - react-devtools-core
+      - utf-8-validate
+
+  '@glion/decode-escapes@0.16.0':
+    dependencies:
+      '@glion/utils': 0.16.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+
+  '@glion/encode-escapes@0.16.0':
+    dependencies:
+      '@glion/utils': 0.16.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+
+  '@glion/hl7v2@0.16.0':
+    dependencies:
+      '@glion/ast': 0.16.0
+      '@glion/decode-escapes': 0.16.0
+      '@glion/jsonify': 0.16.0
+      '@glion/parser': 0.16.0
+      '@glion/preset-lint-profile-recommended': 0.16.0
+      '@glion/preset-lint-recommended': 0.16.0
+      unified: 11.0.5
+
+  '@glion/jsonify@0.16.0':
+    dependencies:
+      '@glion/ast': 0.16.0
+      unified: 11.0.5
+
+  '@glion/lint-message-version@0.16.0':
+    dependencies:
+      '@glion/util-query': 0.16.0
+      '@glion/util-semver': 0.16.0
+      ensure-error: 5.0.0
+      unified-lint-rule: 3.0.1
+
+  '@glion/lint-no-trailing-empty-field@0.16.0':
+    dependencies:
+      '@glion/utils': 0.16.0
+      pluralize: 8.0.0
+      unified: 11.0.5
+      unified-lint-rule: 3.0.1
+      unist-util-visit-parents: 6.0.2
+
+  '@glion/lint-profile-events-segments-order@0.16.0':
+    dependencies:
+      '@glion/ast': 0.16.0
+      '@glion/profiles': 0.16.0
+      '@glion/util-query': 0.16.0
+      '@glion/util-visit': 0.16.0
+      unified-lint-rule: 3.0.1
+
+  '@glion/lint-profile-extra-components@0.16.0':
+    dependencies:
+      '@glion/ast': 0.16.0
+      '@glion/util-visit': 0.16.0
+      '@glion/utils': 0.16.0
+      unified-lint-rule: 3.0.1
+
+  '@glion/lint-profile-extra-fields@0.16.0':
+    dependencies:
+      '@glion/ast': 0.16.0
+      '@glion/util-visit': 0.16.0
+      unified-lint-rule: 3.0.1
+
+  '@glion/lint-profile-field-max-length@0.16.0':
+    dependencies:
+      '@glion/ast': 0.16.0
+      '@glion/util-visit': 0.16.0
+      '@glion/utils': 0.16.0
+      unified-lint-rule: 3.0.1
+
+  '@glion/lint-profile-field-repetition@0.16.0':
+    dependencies:
+      '@glion/ast': 0.16.0
+      '@glion/util-visit': 0.16.0
+      unified-lint-rule: 3.0.1
+
+  '@glion/lint-profile-required-components@0.16.0':
+    dependencies:
+      '@glion/ast': 0.16.0
+      '@glion/util-visit': 0.16.0
+      '@glion/utils': 0.16.0
+      unified-lint-rule: 3.0.1
+
+  '@glion/lint-profile-required-fields@0.16.0':
+    dependencies:
+      '@glion/ast': 0.16.0
+      '@glion/util-visit': 0.16.0
+      '@glion/utils': 0.16.0
+      unified-lint-rule: 3.0.1
+
+  '@glion/lint-profile-table-values@0.16.0':
+    dependencies:
+      '@glion/ast': 0.16.0
+      '@glion/util-visit': 0.16.0
+      '@glion/utils': 0.16.0
+      unified-lint-rule: 3.0.1
+
+  '@glion/lint-required-message-header@0.16.0':
+    dependencies:
+      unified: 11.0.5
+      unified-lint-rule: 3.0.1
+      unist-util-visit-parents: 6.0.2
+
+  '@glion/lint-segment-header-length@0.16.0':
+    dependencies:
+      pluralize: 8.0.0
+      unified: 11.0.5
+      unified-lint-rule: 3.0.1
+      unist-util-visit-parents: 6.0.2
+
+  '@glion/mllp-ack@0.16.0':
+    dependencies:
+      '@glion/ack': 0.16.0
+      '@glion/encode-escapes': 0.16.0
+      '@glion/mllp': 0.16.0
+      '@glion/to-hl7v2': 0.16.0
+      unified: 11.0.5
+
+  '@glion/mllp-client@0.16.0':
+    dependencies:
+      '@glion/ack': 0.16.0
+      '@glion/ast': 0.16.0
+      '@glion/mllp-transport': 0.16.0
+      '@glion/parser': 0.16.0
+      '@glion/util-query': 0.16.0
+
+  '@glion/mllp-transport@0.16.0': {}
+
+  '@glion/mllp@0.16.0':
+    dependencies:
+      '@glion/ast': 0.16.0
+      '@glion/mllp-transport': 0.16.0
+      '@glion/parser': 0.16.0
+      '@glion/util-query': 0.16.0
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  '@glion/parser@0.16.0':
+    dependencies:
+      '@glion/utils': 0.16.0
+      unified: 11.0.5
+
+  '@glion/preset-lint-profile-recommended@0.16.0':
+    dependencies:
+      '@glion/annotate-profile-context': 0.16.0
+      '@glion/lint-profile-events-segments-order': 0.16.0
+      '@glion/lint-profile-extra-components': 0.16.0
+      '@glion/lint-profile-extra-fields': 0.16.0
+      '@glion/lint-profile-field-max-length': 0.16.0
+      '@glion/lint-profile-field-repetition': 0.16.0
+      '@glion/lint-profile-required-components': 0.16.0
+      '@glion/lint-profile-required-fields': 0.16.0
+      '@glion/lint-profile-table-values': 0.16.0
+      unified: 11.0.5
+
+  '@glion/preset-lint-recommended@0.16.0':
+    dependencies:
+      '@glion/lint-message-version': 0.16.0
+      '@glion/lint-no-trailing-empty-field': 0.16.0
+      '@glion/lint-required-message-header': 0.16.0
+      '@glion/lint-segment-header-length': 0.16.0
+      unified: 11.0.5
+      unified-lint-rule: 3.0.1
+
+  '@glion/profiles@0.16.0':
+    dependencies:
+      '@glion/utils': 0.16.0
+      lru-cache: 11.2.7
+      unified: 11.0.5
+
+  '@glion/to-hl7v2@0.16.0':
+    dependencies:
+      '@glion/utils': 0.16.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+
+  '@glion/util-query@0.16.0':
+    dependencies:
+      '@glion/ast': 0.16.0
+      '@glion/utils': 0.16.0
+
+  '@glion/util-semver@0.16.0': {}
+
+  '@glion/util-timestamp@0.16.0': {}
+
+  '@glion/util-visit@0.16.0':
+    dependencies:
+      unist-util-visit-parents: 6.0.2
+
+  '@glion/utils@0.16.0': {}
 
   '@img/colour@1.1.0': {}
 


### PR DESCRIPTION
Reshapes the three examples (`mllp-client`, `mllp-server`, `mllp-server-bun`) so a user can clone any one of them with `degit` and run it standalone. Today they declare `@glion/*` deps as `workspace:*`, which fails the moment someone clones a single example outside the monorepo (`ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`).

## What changed

- **Deps use `"latest"`** instead of `workspace:*`, matching how `vercel/next.js` ships its `examples/`. Fresh clones resolve `@glion/*` from npm; in-repo `pnpm install` still works (examples remain workspace members for build/lint, they just don't dev-link to local package source — same trade-off Next.js makes).
- **Stripped `package.json`** to `private`, `type`, `scripts`, `dependencies`, `devDependencies`. Dropped `name`, `version`, `description` — these are scaffolds, not publishable packages. Also dropped the unused `@glion/tsconfig` devDependency (the example `tsconfig.json` files don't `extend` it, so it was dead weight that would also have broken standalone clones since `@glion/tsconfig` is private).
- **READMEs follow the Next.js shape**: title → one-paragraph description → "How to use" with `npx degit rethinkhealth/glion/examples/<name>` clone block → configuration → notes. Cross-references switched to absolute GitHub URLs so they still resolve after a single-example degit. Fixed stale `../glion-server` / `../glion-server-bun` links — actual directory names are `mllp-server` / `mllp-server-bun`.
- **Per-example `.gitignore`** so each directory is a self-contained scaffold post-clone.

## How to verify

```bash
# Standalone-clone path (the user-facing one)
npx degit rethinkhealth/glion/examples/mllp-server /tmp/test-server
cd /tmp/test-server && pnpm install && pnpm dev

# In-repo path (still works)
pnpm install && pnpm --filter mllp-server dev
```

## Note on `link-workspace-packages`

I briefly tried adding `link-workspace-packages=true` to `.npmrc` to keep examples dev-linked to the workspace `packages/*` — it didn't take effect for `"latest"` specifiers in pnpm 10, and trying to make it work added more complexity than it was worth. Examples are now scaffolds: iterate on packages via their own tests, not via examples. Reverted.