### PR TITLE
feat(create-glion): scaffold examples via giget

### DIFF
--- a/examples/mllp-client/README.md
+++ b/examples/mllp-client/README.md
@@ -4,13 +4,15 @@ Send HL7v2 messages over MLLP with [`@glion/mllp-client`](https://github.com/ret
 
 ## How to use
 
-Clone this example into a new directory:
+Scaffold this example into a new directory:
 
 ```bash
-npx degit rethinkhealth/glion/examples/mllp-client my-mllp-client
+pnpm create glion my-mllp-client --example mllp-client
 cd my-mllp-client
 pnpm install
 ```
+
+Works under `npm`, `yarn`, and `bun` too — they all resolve to the same [`create-glion`](https://github.com/rethinkhealth/glion/tree/main/packages/create-glion) package. Run with no args for an interactive picker.
 
 Start the [`mllp-server`](https://github.com/rethinkhealth/glion/tree/main/examples/mllp-server) example in another terminal, then send a sample message:
 

--- a/examples/mllp-client/README.md
+++ b/examples/mllp-client/README.md
@@ -12,8 +12,6 @@ cd my-mllp-client
 pnpm install
 ```
 
-Works under `npm`, `yarn`, and `bun` too — they all resolve to the same [`create-glion`](https://github.com/rethinkhealth/glion/tree/main/packages/create-glion) package. Run with no args for an interactive picker.
-
 Start the [`mllp-server`](https://github.com/rethinkhealth/glion/tree/main/examples/mllp-server) example in another terminal, then send a sample message:
 
 ```bash

--- a/examples/mllp-server-bun/README.md
+++ b/examples/mllp-server-bun/README.md
@@ -4,12 +4,14 @@ A basic HL7v2 MLLP server with route handlers and ACK/NAK responses, run via the
 
 ## How to use
 
-Clone this example into a new directory:
+Scaffold this example into a new directory:
 
 ```bash
-npx degit rethinkhealth/glion/examples/mllp-server-bun my-mllp-server
+pnpm create glion my-mllp-server --example mllp-server-bun
 cd my-mllp-server
 ```
+
+Works under `npm`, `yarn`, and `bun` too — they all resolve to the same [`create-glion`](https://github.com/rethinkhealth/glion/tree/main/packages/create-glion) package. Run with no args for an interactive picker.
 
 Install dependencies and run:
 

--- a/examples/mllp-server-bun/README.md
+++ b/examples/mllp-server-bun/README.md
@@ -11,8 +11,6 @@ pnpm create glion my-mllp-server --example mllp-server-bun
 cd my-mllp-server
 ```
 
-Works under `npm`, `yarn`, and `bun` too — they all resolve to the same [`create-glion`](https://github.com/rethinkhealth/glion/tree/main/packages/create-glion) package. Run with no args for an interactive picker.
-
 Install dependencies and run:
 
 ```bash

--- a/examples/mllp-server/README.md
+++ b/examples/mllp-server/README.md
@@ -4,12 +4,14 @@ A basic HL7v2 MLLP server with route handlers and ACK/NAK responses, run via the
 
 ## How to use
 
-Clone this example into a new directory:
+Scaffold this example into a new directory:
 
 ```bash
-npx degit rethinkhealth/glion/examples/mllp-server my-mllp-server
+pnpm create glion my-mllp-server --example mllp-server
 cd my-mllp-server
 ```
+
+Works under `npm`, `yarn`, and `bun` too — they all resolve to the same [`create-glion`](https://github.com/rethinkhealth/glion/tree/main/packages/create-glion) package. Run with no args for an interactive picker.
 
 Install dependencies and run:
 

--- a/examples/mllp-server/README.md
+++ b/examples/mllp-server/README.md
@@ -11,8 +11,6 @@ pnpm create glion my-mllp-server --example mllp-server
 cd my-mllp-server
 ```
 
-Works under `npm`, `yarn`, and `bun` too — they all resolve to the same [`create-glion`](https://github.com/rethinkhealth/glion/tree/main/packages/create-glion) package. Run with no args for an interactive picker.
-
 Install dependencies and run:
 
 ```bash

--- a/packages/create-glion/README.md
+++ b/packages/create-glion/README.md
@@ -1,0 +1,38 @@
+# create-glion
+
+Scaffold a new Glion app from an example in [`rethinkhealth/glion`](https://github.com/rethinkhealth/glion).
+
+## Usage
+
+```bash
+# Interactive
+pnpm create glion
+npm create glion
+yarn create glion
+bun create glion
+
+# Non-interactive
+pnpm create glion my-app --example mllp-server
+```
+
+## Options
+
+| Flag                   | Description                                              |
+| ---------------------- | -------------------------------------------------------- |
+| `[dir]` (positional)   | Target directory. Prompts when omitted.                  |
+| `-e, --example <name>` | Example to clone from `examples/`. Prompts when omitted. |
+| `-h, --help`           | Print usage and exit.                                    |
+
+## Examples
+
+| Name              | Description                                                    |
+| ----------------- | -------------------------------------------------------------- |
+| `mllp-server`     | HL7v2 MLLP server with route handlers (Node.js).               |
+| `mllp-server-bun` | HL7v2 MLLP server with route handlers (Bun).                   |
+| `mllp-client`     | MLLP client sending sample messages — companion to the server. |
+
+Each example is fetched from `github:rethinkhealth/glion/examples/<name>` via [`giget`](https://github.com/unjs/giget).
+
+## License
+
+MIT © Glion contributors

--- a/packages/create-glion/package.json
+++ b/packages/create-glion/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "create-glion",
+  "version": "0.0.0",
+  "description": "Scaffold a new Glion app from an example.",
+  "keywords": [
+    "create",
+    "glion",
+    "hl7",
+    "hl7v2",
+    "mllp",
+    "scaffold",
+    "starter",
+    "template"
+  ],
+  "homepage": "https://glion.dev",
+  "license": "MIT",
+  "author": {
+    "name": "Melek Somai",
+    "email": "melek@rethinkhealth.io"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rethinkhealth/glion.git",
+    "directory": "packages/create-glion"
+  },
+  "bin": {
+    "create-glion": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "check-types": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "publint": "publint --strict"
+  },
+  "dependencies": {
+    "@clack/prompts": "0.11.0",
+    "giget": "2.0.0"
+  },
+  "devDependencies": {
+    "@glion/testing": "workspace:*",
+    "@glion/tsconfig": "workspace:*",
+    "@types/node": "25.6.0",
+    "publint": "0.3.18",
+    "tsdown": "0.21.10",
+    "typescript": "6.0.3",
+    "vitest": "4.1.5"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "packageManager": "pnpm@10.14.0"
+}

--- a/packages/create-glion/package.json
+++ b/packages/create-glion/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "tsdown",
     "check-types": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "publint": "publint --strict"
   },

--- a/packages/create-glion/src/index.ts
+++ b/packages/create-glion/src/index.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { parseArgs } from "node:util";
+
+import * as p from "@clack/prompts";
+import { downloadTemplate } from "giget";
+
+const REPO = "github:rethinkhealth/glion";
+
+const EXAMPLES = [
+  {
+    hint: "HL7v2 MLLP server with route handlers (Node.js)",
+    label: "mllp-server",
+    value: "mllp-server",
+  },
+  {
+    hint: "HL7v2 MLLP server with route handlers (Bun)",
+    label: "mllp-server-bun",
+    value: "mllp-server-bun",
+  },
+  {
+    hint: "MLLP client sending sample messages",
+    label: "mllp-client",
+    value: "mllp-client",
+  },
+] as const;
+
+type ExampleId = (typeof EXAMPLES)[number]["value"];
+
+const HELP = `Usage: create-glion [dir] [--example <name>]
+
+Options:
+  -e, --example <name>  Example to clone from examples/
+  -h, --help            Show this message
+
+Examples:
+${EXAMPLES.map((e) => `  ${e.value.padEnd(18)} ${e.hint}`).join("\n")}
+`;
+
+function isExampleId(value: string): value is ExampleId {
+  return EXAMPLES.some((e) => e.value === value);
+}
+
+function abort(message = "Aborted."): never {
+  p.cancel(message);
+  process.exit(0);
+}
+
+async function run(): Promise<void> {
+  const { values, positionals } = parseArgs({
+    allowPositionals: true,
+    args: process.argv.slice(2),
+    options: {
+      example: { short: "e", type: "string" },
+      help: { short: "h", type: "boolean" },
+    },
+  });
+
+  if (values.help) {
+    process.stdout.write(`${HELP}\n`);
+    return;
+  }
+
+  p.intro("create-glion");
+
+  let dir = positionals[0];
+  if (!dir) {
+    const answer = await p.text({
+      message: "Where should we scaffold your project?",
+      placeholder: "./my-glion-app",
+      validate: (value) =>
+        value.trim().length === 0 ? "Please enter a directory." : undefined,
+    });
+    if (p.isCancel(answer)) {
+      abort();
+    }
+    dir = answer;
+  }
+
+  const target = resolve(process.cwd(), dir);
+
+  if (existsSync(target)) {
+    const proceed = await p.confirm({
+      initialValue: false,
+      message: `${target} already exists. Continue and overwrite?`,
+    });
+    if (p.isCancel(proceed) || !proceed) {
+      abort();
+    }
+  }
+
+  let example = values.example;
+  if (example && !isExampleId(example)) {
+    p.cancel(
+      `Unknown example: ${example}. Available: ${EXAMPLES.map((e) => e.value).join(", ")}`
+    );
+    process.exit(1);
+  }
+
+  if (!example) {
+    const choice = await p.select({
+      message: "Choose an example",
+      options: EXAMPLES.map((e) => ({
+        hint: e.hint,
+        label: e.label,
+        value: e.value,
+      })),
+    });
+    if (p.isCancel(choice)) {
+      abort();
+    }
+    example = choice;
+  }
+
+  const spinner = p.spinner();
+  spinner.start(`Downloading example: ${example}`);
+  await downloadTemplate(`${REPO}/examples/${example}`, {
+    dir: target,
+    force: true,
+  });
+  spinner.stop(`Scaffolded ${example} → ${target}`);
+
+  p.note(`cd ${dir}\npnpm install\npnpm dev`, "Next steps");
+  p.outro("Happy hacking!");
+}
+
+try {
+  await run();
+} catch (error: unknown) {
+  p.cancel(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/packages/create-glion/tsconfig.json
+++ b/packages/create-glion/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@glion/tsconfig/library.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*"],
+  "exclude": []
+}

--- a/packages/create-glion/tsdown.config.ts
+++ b/packages/create-glion/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  clean: true,
+  dts: false,
+  entry: { index: "src/index.ts" },
+  fixedExtension: false,
+  format: "esm",
+  hash: false,
+  sourcemap: true,
+  target: "es2022",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -646,6 +646,37 @@ importers:
         specifier: 3.25.0
         version: 3.25.0(zod@3.25.76)
 
+  packages/create-glion:
+    dependencies:
+      '@clack/prompts':
+        specifier: 0.11.0
+        version: 0.11.0
+      giget:
+        specifier: 2.0.0
+        version: 2.0.0
+    devDependencies:
+      '@glion/testing':
+        specifier: workspace:*
+        version: link:../../tools/testing
+      '@glion/tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      '@types/node':
+        specifier: 25.6.0
+        version: 25.6.0
+      publint:
+        specifier: 0.3.18
+        version: 0.3.18
+      tsdown:
+        specifier: 0.21.10
+        version: 0.21.10(publint@0.3.18)(typescript@6.0.3)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+
   packages/decode-escapes:
     dependencies:
       '@glion/utils':
@@ -2613,9 +2644,15 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
+  '@clack/core@0.5.0':
+    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
+
   '@clack/core@1.3.0':
     resolution: {integrity: sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA==}
     engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@0.11.0':
+    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@clack/prompts@1.3.0':
     resolution: {integrity: sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw==}
@@ -4509,6 +4546,10 @@ packages:
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
+  giget@2.0.0:
+    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    hasBin: true
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -4814,6 +4855,9 @@ packages:
     resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
+
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
@@ -5864,9 +5908,20 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
+  '@clack/core@0.5.0':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
   '@clack/core@1.3.0':
     dependencies:
       fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.11.0':
+    dependencies:
+      '@clack/core': 0.5.0
+      picocolors: 1.1.1
       sisteransi: 1.0.5
 
   '@clack/prompts@1.3.0':
@@ -7449,6 +7504,15 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  giget@2.0.0:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.7
+      node-fetch-native: 1.6.7
+      nypm: 0.6.6
+      pathe: 2.0.3
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -7731,6 +7795,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanoid@5.1.7: {}
+
+  node-fetch-native@1.6.7: {}
 
   node-gyp-build@4.8.4: {}
 
@@ -8493,7 +8559,7 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.0.4
+      tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)


### PR DESCRIPTION
Adds `create-glion` so users can scaffold any example in `examples/` with one command:

```bash
pnpm create glion my-app --example mllp-server
# or interactive:
pnpm create glion
```

Works identically under `npm create glion`, `yarn create glion`, and `bun create glion` — the convention resolves to the same unscoped `create-glion` package across all four package managers.

## Approach

Thin wrapper, not a custom scaffolder. [`giget`](https://github.com/unjs/giget) handles the GitHub fetch (with caching/offline fallback); [`@clack/prompts`](https://github.com/bombshell-dev/clack) handles the interactive UX. Same pattern as `create-astro`, `create-vite`, `create-svelte`. The CLI itself is ~130 lines.

This builds on rethinkhealth/glion#636 (already merged): examples now use `"latest"` instead of `workspace:*`, so once cloned a user can `pnpm install && pnpm dev` standalone — without that change, `create-glion` would produce a directory that can't install outside the monorepo.

## Design notes

| Decision | Choice | Why |
| --- | --- | --- |
| Package name | Unscoped `create-glion` | `pnpm create glion` → `create-glion`. Scoped form would require `pnpm create @glion/foo` which is wrong UX. |
| Build | tsdown ESM, no dts | CLI bin only, no public exports — dts would be dead weight. |
| Examples list | Hardcoded (3 entries) | Three is below the threshold where auto-discovery earns its keep. Revisit if the list grows past ~6. |
| Args | `[dir] [--example <name>]` with prompts when missing | Matches `create-astro`. Both fully-interactive and fully-non-interactive flows work. |

## Verification

- `pnpm --filter create-glion build` — clean
- `pnpm --filter create-glion check-types` — clean
- `pnpm exec ultracite check packages/create-glion` — clean
- End-to-end: `node dist/index.js smoke-app --example mllp-client` against live GitHub successfully cloned the example into a fresh dir

## Follow-ups (intentionally out of scope)

- **npm publish + changeset** — needs the `create-glion` name claimed on npm before `pnpm create glion` works for users; will add a changeset in a separate PR once that's done
- **Tests** — small CLI, but a vitest covering arg parsing and the unknown-example exit path would be cheap
- **Auto-discovery of examples** — only worth it if the list grows

---

[![Compound Engineering v2.40.0](https://img.shields.io/badge/Compound_Engineering-v2.40.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)