### PR TITLE
chore(create-glion): fix CHANGELOG formatting

### DIFF
--- a/packages/create-glion/CHANGELOG.md
+++ b/packages/create-glion/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Minor Changes
 
 - 3e38721: Add `starter` template and skip the example-select prompt by default so a fresh interactive run only asks for the project directory.
-
   - Add `starter` example (minimal MLLP server: one `ADT^A01` route with `ackMiddleware()`, plus a catch-all reject)
   - Use `starter` silently when `--example` is omitted; the interactive picker now only opens when the flag is passed without a value (e.g. `create-glion --example`)
   - Default the directory prompt to `./my-glion-app` via `defaultValue`; pressing enter is no longer rejected as empty input


### PR DESCRIPTION
## Summary
- Removes a stray blank line in `packages/create-glion/CHANGELOG.md` between the changeset entry and its sub-bullet list, which was failing the Ultracite formatting check in CI.

## Test plan
- [x] `pnpm dlx ultracite check packages/create-glion/CHANGELOG.md` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)