### PR TITLE
bench(mllp-client): add ephemeral-connection baseline for CodSpeed

### DIFF
--- a/benchmarks/mllp-client.bench.ts
+++ b/benchmarks/mllp-client.bench.ts
@@ -1,0 +1,71 @@
+/**
+ * MLLP client benchmarks — measures the end-to-end cost of a `send()`
+ * round trip under the current "open a fresh TCP connection per
+ * message" model.
+ *
+ * These scenarios are the **baseline** for the persistent-connection
+ * work: any future pooled / keep-alive client should make the multi-send
+ * scenarios materially cheaper without regressing single-send latency.
+ * Keeping the ephemeral baseline benches in the suite when the new
+ * client lands lets CodSpeed track both modes side-by-side.
+ *
+ * The MLLP server runs in-process on loopback with plain TCP — TLS
+ * handshake cost is a separate axis we can measure once persistent
+ * connections exist (where the handshake-amortisation story is most
+ * interesting).
+ */
+// Vitest bench mode does not run `beforeAll` / `afterAll` hooks, so
+// the in-process MLLP server is started here at module load via
+// top-level await. The server stays up for the lifetime of the bench
+// worker; vitest tears the worker down after the suite completes.
+import { parseHL7v2 } from "@glion/hl7v2";
+import { Mllp } from "@glion/mllp";
+import { ackMiddleware } from "@glion/mllp-ack";
+import { MllpClient } from "@glion/mllp-client/node";
+import { serve } from "@glion/mllp/node";
+import { bench, describe } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SMALL_ADT = [
+  "MSH|^~\\&|SendApp|SendFac|RecvApp|RecvFac|20240101120000||ADT^A01^ADT_A01|MSG001|P|2.5.1",
+  "EVN|A01|20240101120000",
+  "PID|1||12345^^^MRN||Doe^John",
+].join("\r");
+
+// ---------------------------------------------------------------------------
+// Shared in-process MLLP server (plain TCP, loopback)
+// ---------------------------------------------------------------------------
+
+const app = new Mllp().parser(parseHL7v2);
+app.use(ackMiddleware());
+app.on("ADT^A01", () => {});
+const server = serve(app, { port: 0 });
+await server.listening;
+const port = server.port;
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+describe("mllp-client (ephemeral connection per send)", () => {
+  bench("mllp-client: send 1 small message", async () => {
+    const client = new MllpClient({ host: "127.0.0.1", port, tls: false });
+    await client.send(SMALL_ADT);
+  });
+
+  bench("mllp-client: send 10 small messages serially", async () => {
+    const client = new MllpClient({ host: "127.0.0.1", port, tls: false });
+    for (let i = 0; i < 10; i++) {
+      await client.send(SMALL_ADT);
+    }
+  });
+
+  bench("mllp-client: send 10 small messages concurrently", async () => {
+    const client = new MllpClient({ host: "127.0.0.1", port, tls: false });
+    const sends = Array.from({ length: 10 }, () => client.send(SMALL_ADT));
+    await Promise.all(sends);
+  });
+});

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -12,6 +12,8 @@
     "@glion/builder": "workspace:*",
     "@glion/hl7v2": "workspace:*",
     "@glion/mllp": "workspace:*",
+    "@glion/mllp-ack": "workspace:*",
+    "@glion/mllp-client": "workspace:*",
     "@glion/parser": "workspace:*",
     "@glion/preset-lint-profile-recommended": "workspace:*",
     "@glion/profiles": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,12 @@ importers:
       '@glion/mllp':
         specifier: workspace:*
         version: link:../packages/mllp
+      '@glion/mllp-ack':
+        specifier: workspace:*
+        version: link:../packages/mllp-ack
+      '@glion/mllp-client':
+        specifier: workspace:*
+        version: link:../packages/mllp-client
       '@glion/parser':
         specifier: workspace:*
         version: link:../packages/parser


### PR DESCRIPTION
## Summary

Adds a CodSpeed-tracked baseline for the current `MllpClient.send()` model, which opens a fresh TCP connection per message. The new benchmarks let us measure the impact of a future persistent-connection / keep-alive client without guessing — when that work lands, the same scenarios will be repeated against the persistent path and the deltas will show up in CodSpeed.

This PR is scope-limited to **just the perf test**. The persistent-connection design and implementation will be follow-up work.

## What's added

`benchmarks/mllp-client.bench.ts` — three scenarios against an in-process MLLP server (plain TCP on loopback, `ackMiddleware`, no-op `ADT^A01` handler):

| Scenario | Local result | What it measures |
| --- | --- | --- |
| `send 1 small message` | ~900 hz / ~1.1 ms | per-send floor (connect + write + ACK + close) |
| `send 10 small messages serially` | ~105 hz / ~9.5 ms | amplifies per-connect overhead — almost perfectly linear |
| `send 10 small messages concurrently` | ~130 hz / ~7.5 ms | current parallelism ceiling (10 sockets at once) |

The persistent-connection variants will eventually sit alongside these, so we can directly compare ephemeral vs. persistent for the same workload shape.

## Implementation notes

- Lives in the existing `@glion/benchmarks` package; CodSpeed plugin is already wired up via the `Benchmarks` GH Action.
- Uses **plain TCP** only for now — TLS handshake cost is a separate axis that's most informative once persistent connections amortize it. Adding TLS scenarios up front would just add noise to this baseline.
- The MLLP server is started at module load via top-level `await`, because **Vitest bench mode does not run `beforeAll` / `afterAll` hooks**. I confirmed this with a small repro before committing the final shape. The worker tears down naturally after the suite finishes, so no explicit `close()` is needed.
- Adds `@glion/mllp-client` and `@glion/mllp-ack` to `benchmarks/package.json` devDependencies; `@glion/mllp` and `@glion/hl7v2` were already present.

## Test plan

- [x] `pnpm --filter @glion/benchmarks bench` runs cleanly and produces hz/p99 numbers for all three scenarios
- [x] `pnpm --filter @glion/mllp-client test` — 56/56 still passing (no transitive impact)
- [x] `pnpm exec ultracite check benchmarks/mllp-client.bench.ts` clean
- [x] `pnpm build` — 44/44 packages build
- [ ] CodSpeed action runs against this PR and uploads a baseline measurement

## Follow-ups (not in this PR)

- Architecture review of the persistent-connection design space (single connection vs. pool, reconnect policy, abort semantics, Workers behaviour, enhanced-mode FIFO).
- Implementation, scoped to a separate PR once the design is agreed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw8MoZkxmuJF8dA1LmgwCj)_