### PR TITLE
fix(mllp-client): deterministic node adapter drop tests on Node ≥22

### DIFF
--- a/packages/mllp-client/src/duplex.ts
+++ b/packages/mllp-client/src/duplex.ts
@@ -14,7 +14,11 @@
  *   awaits `close()` in `finally` blocks and fires-and-forgets from abort
  *   handlers.
  * - `closed` MUST resolve when either side ends the connection (peer drop,
- *   explicit close, error). It must not reject.
+ *   explicit close, error) **while the consumer is draining `readable`**. It
+ *   must not reject. A pull-based bridge (e.g. Node's `Duplex.toWeb`) only
+ *   observes a peer FIN/RST while the readable is being read; the client's read
+ *   loop drains `readable` for the connection's whole lifetime, so this
+ *   precondition always holds in practice.
  */
 export interface MllpDuplex {
   readonly readable: ReadableStream<Uint8Array>;

--- a/packages/mllp-client/test/node.test.ts
+++ b/packages/mllp-client/test/node.test.ts
@@ -17,6 +17,7 @@ import { frame } from "@glion/mllp-transport";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { MllpClient } from "../src/index";
+import type { MllpDuplex } from "../src/index";
 import { connectNode } from "../src/runtime/node";
 
 interface ServerHandle {
@@ -91,6 +92,40 @@ async function startEchoAckServer(
     host: address.address,
     port: address.port,
   };
+}
+
+/**
+ * Engage the duplex's read pump and confirm the socket is flowing before the
+ * caller triggers a peer drop, then keep draining in the background.
+ *
+ * `Duplex.toWeb` is pull-based: a socket that has never been read stays
+ * paused and never observes the peer's FIN/RST, so `closed` would not resolve
+ * on drop. Reading one chunk activates the socket's underlying read handle,
+ * which then observes connection events for the rest of its life — exactly
+ * what the client's persistent read loop guarantees from the moment it
+ * connects. Writing a probe frame elicits the echo server's ACK so the first
+ * read resolves deterministically (no reliance on event-loop timing).
+ */
+async function engageReadPump(duplex: MllpDuplex): Promise<void> {
+  const writer = duplex.writable.getWriter();
+  await writer.write(frame(REQUEST));
+  writer.releaseLock();
+  const reader = duplex.readable.getReader();
+  await reader.read();
+  void (async () => {
+    try {
+      for (;;) {
+        const { done } = await reader.read();
+        if (done) {
+          return;
+        }
+      }
+    } catch {
+      // The reader rejects when the socket is destroyed mid-read — expected
+      // on peer drop. `closed` resolution is observed via the socket's own
+      // "close" event, independent of this reader.
+    }
+  })();
 }
 
 describe("connectNode — happy path", () => {
@@ -172,6 +207,9 @@ describe("MllpDuplex contract — closed resolves on peer drop", () => {
       port: server.port,
       signal: new AbortController().signal,
     });
+    // Engage the pull-based read pump as the client's read loop does;
+    // otherwise the paused socket never observes the RST (see engageReadPump).
+    await engageReadPump(duplex);
     // Don't await `duplex.closed` until after we trigger the drop.
     const closedPromise = duplex.closed;
     server.dropAllSockets();
@@ -214,6 +252,9 @@ describe("MllpDuplex contract — close() is idempotent and always resolves", ()
       port: server.port,
       signal: new AbortController().signal,
     });
+    // Engage the read pump so the pull-based socket observes the drop and
+    // `closed` resolves (see engageReadPump).
+    await engageReadPump(duplex);
     server.dropAllSockets();
     await duplex.closed;
     await expect(duplex.close()).resolves.toBeUndefined();


### PR DESCRIPTION
**Stack:** #645 → **this** → `client-consumed`

Two `node.test.ts` isolation tests for the `MllpDuplex.closed` contract timed out on Node 24.9.0 (they passed on the Node version the suite was authored against).

**Root cause:** `Duplex.toWeb`'s pull-based bridge. A socket whose web `readable` has never been read stays paused, so it never processes the peer's FIN/RST and the underlying `"close"` event — which the adapter resolves `closed` from — never fires.

**Why production is unaffected:** the real `MllpClient` acquires a reader and starts pulling the moment `connect()` returns (`#runReadLoop`), so the socket is always flowing and `closed` resolves on drop. The two tests violated that precondition by awaiting `closed` on a socket they never read.

**Fix:**
- `engageReadPump(duplex)` writes a probe frame, awaits the first echoed chunk (which permanently activates the socket's libuv read handle), then drains in the background. Verified deterministic over 50 runs — a bare `setTimeout(0)` tick was flaky at 49/50; a microtask at 4/50.
- Tighten the `MllpDuplex.closed` JSDoc to state the draining precondition.

No production code-path changes. Restores green baseline (56/56) on Node ≥22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)