### PR TITLE
refactor(mllp-client): extract request MSH-10 via parser, not a hand scan

### DIFF
--- a/.changeset/client-controlid-parser.md
+++ b/.changeset/client-controlid-parser.md
@@ -1,0 +1,5 @@
+---
+"@glion/mllp-client": patch
+---
+
+Extract the request control ID (MSH-10) via the parser instead of a hand-rolled byte scan, and document the "parsed tree for logic, caller's bytes on the wire" contract for `send()` (a `string`/`Uint8Array` is framed verbatim; a `Root` is serialized with `@glion/to-hl7v2`).

--- a/packages/mllp-client/README.md
+++ b/packages/mllp-client/README.md
@@ -4,7 +4,7 @@ Persistent, single-flight MLLP client for HL7v2.
 
 ## What it does
 
-`@glion/mllp-client` opens one long-lived MLLP/TCP connection and sends HL7v2 messages over it, one in flight at a time. Each `send()` writes a framed message, waits for the peer's ACK, parses it, verifies the MSA-2 correlation ID against the request's MSH-10, and resolves with a structured response. Application/commit accept codes (`AA`/`CA`) resolve; reject codes (`AE`/`AR`/`CE`/`CR`) throw the matching `@glion/ack` `AckException` (`AckApplicationError`, `AckApplicationReject`, `AckCommitError`, `AckCommitReject`).
+`@glion/mllp-client` opens one long-lived MLLP/TCP connection and sends HL7v2 messages over it, one in flight at a time. `send()` accepts a `string`, `Uint8Array`, or parsed `Root` AST. The client follows the grain of the AST: it uses the tree for _reading_ meaning (MSH-10 correlation, the parsed ACK) and the caller's own bytes for the _wire_. A `string`/`Uint8Array` is framed verbatim — never round-tripped through the parser, which (being an AST, not a byte-exact CST) would silently normalize it — while a `Root` is serialized with `@glion/to-hl7v2`. Each `send()` waits for the peer's ACK, verifies the MSA-2 correlation ID against the request's MSH-10, and resolves with a structured response. Application/commit accept codes (`AA`/`CA`) resolve; reject codes (`AE`/`AR`/`CE`/`CR`) throw the matching `@glion/ack` `AckException` (`AckApplicationError`, `AckApplicationReject`, `AckCommitError`, `AckCommitReject`).
 
 The client is one class managing one socket lifecycle: `connect()` initializes, `send()` uses, `close()` tears down. Concurrent sends queue (FIFO) and run one at a time. The wire transport is supplied by a runtime adapter — the Node adapter ships at `@glion/mllp-client/node`. A peer drop, write failure, or decoder framing error is terminal: the connection moves to `closed` and the instance is spent. Reconnect is deferred to a later version.
 
@@ -94,19 +94,20 @@ All are an `MllpClientError`; branch on `code`:
 
 ### `client.send(message, options?): Promise<MllpClientResponse>`
 
-Frames `message` (a `string` or `Uint8Array`), writes it, and resolves with the parsed ACK. `options.signal` cancels the wait; `options.timeoutMs` overrides the default deadline (the deadline covers the wait for the ACK).
+Accepts a `string`, `Uint8Array`, or `Root` (`SendInput`). A `string`/`Uint8Array` is sent on the wire **verbatim** — the caller's exact bytes, never round-tripped through the parser — while the tree is read (best-effort) for the MSH-10 correlation ID. A `Root` has no original bytes, so it is serialized with `@glion/to-hl7v2`. Resolves with the parsed ACK. `options.signal` cancels the wait; `options.timeoutMs` overrides the default deadline (the deadline covers the wait for the ACK).
 
 **Throws**
 
 - `AckException` (from `@glion/ack`) — the peer returned a NAK (`AE`/`AR`/`CE`/`CR`). The concrete subclass encodes the code (`AckApplicationError` = AE, `AckApplicationReject` = AR, `AckCommitError` = CE, `AckCommitReject` = CR); it carries `code`, `errorCode` / `severity` (ERR-3 / ERR-4), `controlId`, `raw`, and the parsed `tree`.
-- `FramingError` (from `@glion/mllp-transport`) — the payload contains an embedded control character that cannot be framed (thrown before any state change).
+- `FramingError` (from `@glion/mllp-transport`) — the message contains an embedded MLLP control character (VT / FS / CR) that cannot be framed (thrown before any state change).
 - otherwise an `MllpClientError`; branch on `code`:
   - `CORRELATION_MISMATCH` — both the request's MSH-10 and the response's MSA-2 are non-empty and differ (carries `expected` / `actual` / `tree` / `raw`). If either is empty, correlation is skipped.
   - `SEND_TIMEOUT` — no ACK arrived within the deadline (`timeoutMs` is set).
   - `DROPPED` — the connection ended (peer drop, write failure, framing error, frame flood); `reason` discriminates. Terminal.
   - `SEND_ABORTED` — `options.signal` aborted.
   - `NOT_CONNECTED` / `CLOSED` — the client is not connected, or has been closed (the in-flight send and every queued send reject).
-  - `PARSE_FAILED` / `UNKNOWN_ACK_CODE` — the ACK is not parseable HL7v2 or carries a non-standard MSA-1.
+  - `PARSE_FAILED` — the ACK is not parseable HL7v2. (Reading the request's MSH-10 is best-effort and never throws; an unparseable request is still sent verbatim, with correlation skipped.)
+  - `UNKNOWN_ACK_CODE` — the ACK carries a non-standard MSA-1.
 
 ### `client.close(): Promise<void>`
 

--- a/packages/mllp-client/src/client.ts
+++ b/packages/mllp-client/src/client.ts
@@ -169,6 +169,19 @@ export class MllpClient {
     return this.#queue.length;
   }
 
+  /**
+   * Open the wire through the runtime adapter and start the read loop.
+   * Single-shot: each instance manages one connection lifecycle.
+   *
+   * @param opts.signal - Cancels an in-flight connect.
+   * @throws {MllpClientError} `CLOSED` when the instance is already
+   *   `closed`/`closing` (construct a new instance); `ALREADY_CONNECTED` when
+   *   called while `connecting`/`ready`/`sending`; `CONNECT_ABORTED` when
+   *   `opts.signal` aborts or `close()` interrupts the connect.
+   *   `CONNECT_FAILED` when the adapter rejects (underlying error on `cause`);
+   *   `CONNECT_TIMEOUT` when the adapter exceeds `connectTimeoutMs`
+   *   (`timeoutMs` set).
+   */
   async connect(opts: { signal?: AbortSignal } = {}): Promise<void> {
     if (this.#state === "closed" || this.#state === "closing") {
       throw new MllpClientError(
@@ -372,6 +385,26 @@ export class MllpClient {
     }
   }
 
+  /**
+   * Frame and enqueue `message`, then resolve with the parsed ACK. Concurrent
+   * sends queue (FIFO) and run one at a time.
+   *
+   * @param opts.signal - Cancels the send; may abort while it is still queued.
+   * @param opts.timeoutMs - Overrides the default deadline (it spans the queue
+   *   wait as well as the wire round-trip).
+   * @throws {AckException} (from `@glion/ack`) The peer returned a NAK — the
+   *   subclass encodes the code: `AckApplicationError`/`AckApplicationReject`/
+   *   `AckCommitError`/`AckCommitReject` for AE/AR/CE/CR.
+   * @throws {MllpClientError} Otherwise; branch on `code`: `CORRELATION_MISMATCH`
+   *   (request MSH-10 and response MSA-2 both non-empty and differ),
+   *   `SEND_TIMEOUT` (no ACK in time), `DROPPED` (connection ended; `reason`
+   *   discriminates — terminal), `SEND_ABORTED` (`opts.signal` aborted),
+   *   `NOT_CONNECTED`/`CLOSED` (state guard), `PARSE_FAILED`/`UNKNOWN_ACK_CODE`
+   *   (ACK unparseable or non-standard MSA-1). Reading the request's MSH-10 is
+   *   best-effort and never throws.
+   * @throws {FramingError} The message carries an embedded MLLP framing byte
+   *   (VT or FS) that cannot be framed. CR is allowed (segment terminator).
+   */
   // `async` keeps the Promise contract: the synchronous guard and toWireFrame()
   // failures below surface as rejections, never as synchronous throws — which
   // is what callers (and the tests) rely on. No `await` is needed in the body.
@@ -639,6 +672,11 @@ export class MllpClient {
     });
   }
 
+  /**
+   * Tear the connection down. Idempotent: resolves from any state and never
+   * rejects. The in-flight `send()` rejects with `MllpClientError` (`CLOSED`),
+   * as does every queued send.
+   */
   async close(): Promise<void> {
     if (this.#state === "closed" || this.#state === "closing") {
       return;
@@ -696,6 +734,7 @@ export class MllpClient {
     this.#state = "closed";
   }
 
+  /** Calls {@link close}. Enables `await using`. */
   async [Symbol.asyncDispose](): Promise<void> {
     await this.close();
   }

--- a/packages/mllp-client/test/client.test.ts
+++ b/packages/mllp-client/test/client.test.ts
@@ -207,6 +207,21 @@ describe("send() — accept codes", () => {
     expect(written.at(-1)).toBe(0x0d);
   });
 
+  it("sends string input on the wire verbatim — a trailing empty field survives", async () => {
+    // The wire-fidelity guarantee: caller bytes are framed verbatim, never
+    // round-tripped through the parser (which, being an AST, would drop the
+    // trailing field delimiter in "PID|1|"). MSH-9 carries no MSH-10, so
+    // correlation is skipped and the ACK resolves.
+    const request = ["MSH|^~\\&|S|F|R|RF|20240101||ADT^A01", "PID|1|"].join(
+      "\r"
+    );
+    const fake = createFakeDuplex({ onWrite: respondWith(ACK_AA) });
+    const client = makeClient(fake);
+    await client.connect();
+    await client.send(request);
+    expect(fake.capturedWrites()).toEqual(frame(request));
+  });
+
   it("accepts Uint8Array message input", async () => {
     const fake = createFakeDuplex({ onWrite: respondWith(ACK_AA) });
     const client = makeClient(fake);
@@ -317,11 +332,44 @@ describe("send() — correlation verification", () => {
     const fake = createFakeDuplex({ onWrite: respondWith(ACK_AA) });
     const client = makeClient(fake);
     await client.connect();
-    // Request without MSH-10 — must be a valid HL7v2-ish line with no
-    // VT/FS bytes; we don't pre-parse the request beyond the MSH scan.
+    // Request without MSH-10 — a valid HL7v2-ish line with no VT/FS bytes.
     const noControl = "MSH|^~\\&|S|F|R|RF|20240101||ADT^A01|";
     const response = await client.send(noControl);
     expect(response.code).toBe("AA");
+  });
+
+  it("correlates MSH-10 to MSA-2 at the component level", async () => {
+    // Request MSH-10 carries a component suffix; the peer echoes only its
+    // first component in MSA-2. They correlate at the component level —
+    // request and response are both extracted via the parser, so a
+    // field-level "MSGID^suffix" vs "MSGID" false mismatch can't happen.
+    const request =
+      "MSH|^~\\&|SENDER|FAC|RECV|RFAC|20241201120000||ADT^A01^ADT_A01|MSGID^suffix|P|2.5\rPID|1||x";
+    const fake = createFakeDuplex({
+      onWrite: respondWith(requestAck("AA", "MSGID")),
+    });
+    const client = makeClient(fake);
+    await client.connect();
+    const response = await client.send(request);
+    expect(response.code).toBe("AA");
+    expect(response.requestControlId).toBe("MSGID");
+    expect(response.controlId).toBe("MSGID");
+  });
+
+  it("honours a non-standard MSH-1 field separator when extracting MSH-10", async () => {
+    // Field separator is '#', not '|'. The parser reads MSH-1 and honours it,
+    // so MSH-10 ("CUSTOMID") is extracted and the mismatch against the peer's
+    // MSA-2 is caught. A "#"-delimited request would have defeated a
+    // split("|") scanner, which would skip correlation entirely.
+    const request = "MSH#^~\\&#S#F#R#RF#20240101##ADT^A01#CUSTOMID#P#2.5";
+    const fake = createFakeDuplex({
+      onWrite: respondWith(requestAck("AA", "OTHERID")),
+    });
+    const client = makeClient(fake);
+    await client.connect();
+    await expect(client.send(request)).rejects.toMatchObject({
+      code: MllpErrorCode.CORRELATION_MISMATCH,
+    });
   });
 });
 


### PR DESCRIPTION
**Stack:** #645 → #649 → #650 → #651 → #652 → **this**

`extractMshControlId` hand-rolled MSH-10 extraction (slice first line → `split("|")` → field 9). Fragile, and — worse — **inconsistent with the response side**, which reads MSA-2 via `parseHL7v2` + `value()` at the component level. The two sides could disagree even when they correlate:

- Request MSH-10 `MSGID^suffix` was compared *whole* against a response MSA-2 of `MSGID` (component 1) → **false `CORRELATION_MISMATCH`**.
- A non-`|` MSH-1 field separator (spec-allowed) defeated `split("|")` → MSH-10 came back `""` and correlation was **silently skipped**.
- Repetitions / escaped delimiters were likewise mishandled.

**Fix:** use the same tested path the response already uses — `value(parseHL7v2(msh), "MSH-10[1].1.1")`. Only the first segment is parsed (located by the segment terminator), so it stays cheap even for multi-MB payloads. `@glion/parser` and `@glion/util-query` were already dependencies; this just makes the request side consistent. Extraction failure still yields `""` (best-effort — the client requires framability, not valid HL7v2) via one local, documented catch.

**Tests** the old scanner could not pass: component-level correlation (`MSGID^suffix` ↔ `MSGID`), and MSH-10 extraction under a `#` field separator. **69/69 passing**, types + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)