### PR TITLE
feat(mllp)!: the server reads through unframe() and reports protocol violations

### DIFF
--- a/packages/mllp/README.md
+++ b/packages/mllp/README.md
@@ -57,32 +57,46 @@ The server class. Built with a fluent chainable API:
 
 Start a Node.js or Bun TCP server that dispatches incoming MLLP frames through the `Mllp` instance.
 
-- `port` (`number`) — TCP port to listen on.
-- `hostname` (`string`, optional) — interface to bind. Defaults to all interfaces.
-- `tls` (`{ cert, key }`, optional) — enable MLLP over TLS.
+| Option                  | Type                                        | Description                                                                                    |
+| ----------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `port`                  | `number`                                    | TCP port to listen on.                                                                         |
+| `hostname`              | `string`, optional                          | Interface to bind. Defaults to all interfaces.                                                 |
+| `tls`                   | `{ cert, key, ca?, passphrase? }`, optional | Enable MLLP over TLS.                                                                          |
+| `keepAlive`             | `boolean`, optional                         | Enable TCP keep-alive on accepted sockets. Defaults to `true`.                                 |
+| `keepAliveInitialDelay` | `number`, optional                          | Delay in ms before the first keep-alive probe on an idle socket. Defaults to `60000`.          |
+| `socketTimeout`         | `number`, optional                          | Socket inactivity timeout in ms — an idle socket past it is destroyed. `0` (default) disables. |
+| `onConnect`             | `ConnectionCallback`, optional              | Called when a new TCP connection is accepted.                                                  |
+| `onDisconnect`          | `ConnectionCallback`, optional              | Called when a connection closes — always fires, even if `onConnect` threw.                     |
+| `onError`               | `ErrorCallback`, optional                   | Called when a handler error goes unhandled or a lifecycle callback throws.                     |
 
-### Primitives
+### Wire framing
 
-| Function                        | Description                                            |
-| ------------------------------- | ------------------------------------------------------ |
-| `encode(message)`               | Encode a message string into an MLLP frame.            |
-| `decode(frame)`                 | Decode a single MLLP frame to its message.             |
-| `createDecoderStream(options?)` | TransformStream for streaming decode from chunked TCP. |
+MLLP framing lives in [`@glion/mllp-codec`](https://github.com/rethinkhealth/glion/tree/main/packages/mllp-codec) — `frame()` wraps outbound messages, `unframe()` streams inbound bytes back into them. `@glion/mllp` consumes it internally and re-exports nothing from it; import it directly when you need the codec.
 
 ### Types
 
-| Type               | Description                                                         |
-| ------------------ | ------------------------------------------------------------------- |
-| `Context`          | Request context with message data and routing fields.               |
-| `Response`         | Response object `{ raw: string }`.                                  |
-| `Hl7v2Processor`   | Unified `Processor` type for HL7v2 (`Processor<Root, Root, Root>`). |
-| `Middleware`       | Middleware function `(ctx, next) => ...`.                           |
-| `Handler`          | Terminal route handler `(ctx) => Response`.                         |
-| `ErrorHandler`     | Error handler `(err, ctx) => Response`.                             |
-| `RouteFilter`      | Filter function `(ctx) => boolean` used for routing.                |
-| `MiddlewareReturn` | Return type of middleware functions.                                |
-| `ConnectionInfo`   | Connection metadata (remote/local address, TLS flag).               |
-| `RoutePattern`     | Parsed route pattern.                                               |
+| Type               | Description                                                                                                                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Context`          | Request context with message data and routing fields.                                                                                                                                       |
+| `Response`         | Response object `{ raw: string }`.                                                                                                                                                          |
+| `Hl7v2Processor`   | Unified `Processor` type for HL7v2 (`Processor<Root, Root \| undefined, Root \| undefined>` — head/tail admit `undefined` so the bare `unified().use(hl7v2Parser).freeze()` is assignable). |
+| `Middleware`       | Middleware function `(ctx, next) => ...`.                                                                                                                                                   |
+| `Handler`          | Terminal route handler `(ctx) => Response`.                                                                                                                                                 |
+| `ErrorHandler`     | Error handler `(err, ctx) => Response`.                                                                                                                                                     |
+| `RouteFilter`      | Filter function `(ctx) => boolean` used for routing.                                                                                                                                        |
+| `MiddlewareReturn` | Return type of middleware functions.                                                                                                                                                        |
+| `ConnectionInfo`   | Connection metadata (remote/local address, TLS flag).                                                                                                                                       |
+| `RoutePattern`     | Parsed route pattern.                                                                                                                                                                       |
+
+### Errors
+
+Server-side failures are raised (or passed to `onError`) as `MllpServerError` — branch on its stable `code`; the underlying codec or charset error rides on `cause`:
+
+| Code                   | Meaning                                                                                           |
+| ---------------------- | ------------------------------------------------------------------------------------------------- |
+| `NO_PARSER`            | `app.handle()` ran before a parser was registered via `app.parser()`.                             |
+| `INCOMPATIBLE_CHARSET` | An inbound message could not be decoded as UTF-8 (the `CharsetError` is on `cause`).              |
+| `PROTOCOL_VIOLATION`   | The MLLP byte stream was violated and the connection closed (the `MllpCodecError` is on `cause`). |
 
 ## Routing
 
@@ -253,37 +267,6 @@ const server = serve(app, {
     key: fs.readFileSync("key.pem"),
   },
 });
-```
-
-## Primitives
-
-### Simple API
-
-```ts
-import { encode, decode } from "@glion/mllp";
-
-const mllpFrame = encode(hl7Message);
-const decoded = decode(mllpFrame);
-console.log(decoded.text);
-```
-
-### Streaming API
-
-```ts
-import { createDecoderStream } from "@glion/mllp";
-
-const decoder = createDecoderStream({
-  maxMessageSize: 1024 * 1024,
-  onError: (error) => console.warn(`[${error.code}] ${error.message}`),
-});
-
-tcpSocket.readable.pipeThrough(decoder).pipeTo(
-  new WritableStream({
-    write(message) {
-      console.log("Received:", message.text);
-    },
-  })
-);
 ```
 
 ## Design notes

--- a/packages/mllp/bench/serve.bench.ts
+++ b/packages/mllp/bench/serve.bench.ts
@@ -12,13 +12,13 @@
 import net from "node:net";
 
 import { parseHL7v2 } from "@glion/hl7v2";
+import { CR, frame, FS } from "@glion/mllp-codec";
+import { encodeBytes } from "@glion/util-charset";
 import { afterAll, bench, beforeAll, describe } from "vitest";
 
 import { serve } from "../src/node/serve";
 import type { Server } from "../src/node/serve";
 import { Mllp } from "../src/server/mllp";
-import { MLLP_END_BYTE_1, MLLP_END_BYTE_2 } from "../src/transport/constants";
-import { encode } from "../src/transport/encoder";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -44,17 +44,14 @@ const LARGE_MESSAGE = [
 
 const RESPONSE_OK = { raw: "MSH|^~\\&||||||||||2.5.1\rMSA|AA|MSG001" };
 
-const smallFrame = encode(SMALL_MESSAGE);
-const largeFrame = encode(LARGE_MESSAGE);
+const smallFrame = frame(encodeBytes(SMALL_MESSAGE));
+const largeFrame = frame(encodeBytes(LARGE_MESSAGE));
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function sendAndReceive(
-  client: net.Socket,
-  frame: Uint8Array
-): Promise<Buffer> {
+function sendAndReceive(client: net.Socket, wire: Uint8Array): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
 
@@ -63,8 +60,8 @@ function sendAndReceive(
       const combined = Buffer.concat(chunks);
       if (
         combined.length >= 3 &&
-        combined.at(-2) === MLLP_END_BYTE_1 &&
-        combined.at(-1) === MLLP_END_BYTE_2
+        combined.at(-2) === FS &&
+        combined.at(-1) === CR
       ) {
         client.removeListener("data", onData);
         client.removeListener("error", onError);
@@ -80,7 +77,7 @@ function sendAndReceive(
 
     client.on("data", onData);
     client.on("error", onError);
-    client.write(frame);
+    client.write(wire);
   });
 }
 

--- a/packages/mllp/package.json
+++ b/packages/mllp/package.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "build": "tsdown && tsc --emitDeclarationOnly",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p test/tsconfig.json",
     "check:readme": "glion-check-readme",
     "bench": "vitest bench --run",
     "test": "vitest run",
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@glion/ast": "workspace:*",
-    "@glion/mllp-transport": "workspace:*",
+    "@glion/mllp-codec": "workspace:*",
     "@glion/parser": "workspace:*",
     "@glion/util-charset": "workspace:*",
     "@glion/util-query": "workspace:*",

--- a/packages/mllp/src/errors.ts
+++ b/packages/mllp/src/errors.ts
@@ -22,6 +22,15 @@ export const MllpServerErrorCode = {
    * `app.parser()`.
    */
   NO_PARSER: "NO_PARSER",
+  /**
+   * The MLLP byte stream itself was violated and the connection closed:
+   * the remote system sent bytes outside a message, glued or unterminated
+   * messages, an over-cap message — or a handler's response contained a
+   * reserved VT/FS byte and could not be framed. The underlying
+   * `@glion/mllp-codec` `MllpCodecError` is kept on `cause`; branch on this
+   * code without importing that package.
+   */
+  PROTOCOL_VIOLATION: "PROTOCOL_VIOLATION",
 } as const;
 export type MllpServerErrorCode =
   (typeof MllpServerErrorCode)[keyof typeof MllpServerErrorCode];

--- a/packages/mllp/src/index.ts
+++ b/packages/mllp/src/index.ts
@@ -1,7 +1,7 @@
 // biome-ignore-all lint/performance/noBarrelFile: fine
 
-// Transport framing/encoding/decoding now lives in `@glion/mllp-transport`
-// (new API: `frame` / `decode` / `FrameDecoderStream` / `FramingError`).
+// Transport framing now lives in `@glion/mllp-codec`
+// (new API: `frame` / `unframe` / `MllpCodecError`).
 // Import it directly; `@glion/mllp` no longer re-exports the transport surface.
 
 // -------------

--- a/packages/mllp/src/node/serve.ts
+++ b/packages/mllp/src/node/serve.ts
@@ -10,8 +10,8 @@
  * @module
  */
 
-import { frame, FrameDecoderStream } from "@glion/mllp-transport";
-import { CharsetError, decodeBytes } from "@glion/util-charset";
+import { frame, MllpCodecError, unframe } from "@glion/mllp-codec";
+import { CharsetError, decodeBytes, encodeBytes } from "@glion/util-charset";
 
 import { MllpServerError, MllpServerErrorCode } from "../errors";
 import type { AdapterSocket } from "../server/adapter";
@@ -284,8 +284,7 @@ function handleConnection(
   socket: AdapterSocket,
   lifecycle: LifecycleOptions
 ): void {
-  const decoder = new FrameDecoderStream();
-  const reader = socket.readable.pipeThrough(decoder).getReader();
+  const reader = socket.readable.pipeThrough(unframe()).getReader();
   const writer = socket.writable.getWriter();
 
   const connection: ConnectionInfo = {
@@ -322,8 +321,8 @@ function handleConnection(
           // outer catch for cleanup.
           let response: Awaited<ReturnType<Mllp["handle"]>>;
           try {
-            // FrameDecoderStream emits the de-framed payload bytes; decode them
-            // to text (UTF-8) for the handler, which also receives the raw bytes.
+            // unframe() emits the de-framed payload bytes; decode them to
+            // text (UTF-8) for the handler, which also receives the raw bytes.
             // A non-UTF-8 feed throws here rather than being silently corrupted.
             const text = decodeBytes(payload);
             response = await app.handle(text, payload, connection);
@@ -353,12 +352,29 @@ function handleConnection(
           // Write is outside the handler error catch — write failures
           // are transport errors and flow to the outer catch.
           if (response) {
-            await writer.write(frame(response.raw));
+            await writer.write(frame(encodeBytes(response.raw)));
           }
         }
-      } catch {
-        // Transport-level: connection closed, stream errored, decode failure.
-        // Not routed to onError — these are infrastructure, not application errors.
+      } catch (streamError) {
+        // A codec error is a protocol violation, not plumbing — the remote
+        // system broke MLLP framing, or a handler's response carried a
+        // reserved VT/FS byte and could not be framed. The server is never
+        // silent about it: translate (never leak the codec's own type) and
+        // route to onError; the connection still closes below — framing
+        // violations are terminal. Everything else here is transport-level
+        // (connection reset, stream teardown) and stays unrouted: that is
+        // infrastructure, not an application error.
+        if (streamError instanceof MllpCodecError) {
+          await reportError(
+            new MllpServerError(
+              MllpServerErrorCode.PROTOCOL_VIOLATION,
+              "The MLLP byte stream was violated and the connection is closing (see the error's cause).",
+              { cause: streamError }
+            ),
+            connection,
+            lifecycle
+          );
+        }
       }
     } finally {
       // ── Cleanup & onDisconnect ─────────────────────────────────────

--- a/packages/mllp/test/node/msh18-charset-regression.test.ts
+++ b/packages/mllp/test/node/msh18-charset-regression.test.ts
@@ -2,7 +2,7 @@
 import net from "node:net";
 
 import { parseHL7v2 } from "@glion/hl7v2";
-import { CR, frame, FS } from "@glion/mllp-transport";
+import { CR, frame, FS } from "@glion/mllp-codec";
 import { CharsetError } from "@glion/util-charset";
 
 import { MllpServerError, MllpServerErrorCode } from "../../src/errors";
@@ -124,7 +124,13 @@ describe("non-UTF-8 feed is rejected loudly, not silently corrupted (regression 
       "MSH|^~\\&|SendApp|SendFac|RecvApp|RecvFac|20240101120000||ADT^A01^ADT_A01|MSG001|P|2.5.1||||||8859/1",
       "PID|1||12345^^^MRN||José^John",
     ].join("\r");
-    const latin1 = Uint8Array.from(message, (ch) => ch.codePointAt(0));
+    // String iteration never yields an empty string, so codePointAt(0) is
+    // always defined — and every character here is Latin-1, so the code
+    // point IS the wire byte.
+    const latin1 = Uint8Array.from(
+      message,
+      (ch) => ch.codePointAt(0) as number
+    );
 
     const response = await sendBytes(server.port, latin1, 1000);
 

--- a/packages/mllp/test/node/serve.test.ts
+++ b/packages/mllp/test/node/serve.test.ts
@@ -4,7 +4,8 @@
 import net from "node:net";
 
 import { parseHL7v2 } from "@glion/hl7v2";
-import { CR, frame, FS } from "@glion/mllp-transport";
+import { CR, frame, FS } from "@glion/mllp-codec";
+import { encodeBytes } from "@glion/util-charset";
 
 import { serve } from "../../src/node/serve";
 import type { Server } from "../../src/node/serve";
@@ -44,7 +45,7 @@ function sendMessage(
 ): Promise<string | undefined> {
   return new Promise((resolve, reject) => {
     const client = net.connect({ host: "127.0.0.1", port }, () => {
-      client.write(frame(message));
+      client.write(frame(encodeBytes(message)));
     });
 
     const chunks: Buffer[] = [];
@@ -136,7 +137,7 @@ function createPersistentClient(port: number): {
       client.on("data", onData);
       client.once("error", onError);
 
-      client.write(frame(message));
+      client.write(frame(encodeBytes(message)));
     });
 
   return {
@@ -328,7 +329,7 @@ describe("serve() integration", () => {
 
       expect(connections).toHaveLength(2);
       // IDs are sequential — test relative ordering, not absolute values
-      expect(connections[1]).toBeGreaterThan(connections[0]);
+      expect(connections[1]).toBeGreaterThan(connections[0] as number);
     });
 
     it("onDisconnect fires when client disconnects", async () => {
@@ -350,7 +351,7 @@ describe("serve() integration", () => {
       });
 
       expect(disconnectedId).toBeDefined();
-      expectTypeOf(disconnectedId).toBeNumber();
+      expect(disconnectedId).toBeTypeOf("number");
     });
 
     it("onError fires when handler throws without app-level error handler", async () => {
@@ -372,7 +373,69 @@ describe("serve() integration", () => {
       await sendMessage(server.port, SAMPLE_ADT, 500);
 
       expect(errors).toHaveLength(1);
-      expect(errors[0].message).toBe("handler boom");
+      expect(errors[0]?.message).toBe("handler boom");
+    });
+
+    it("onError fires with PROTOCOL_VIOLATION when the inbound byte stream violates MLLP framing", async () => {
+      const app = createApp();
+      app.on("*", (ctx) => ({
+        raw: `MSH|^~\\&|||||||ACK|ACK001|P|2.5.1\rMSA|AA|${ctx.controlId}`,
+      }));
+
+      const errors: { code?: string; causeName?: string }[] = [];
+      server = serve(app, {
+        onError: (err) => {
+          const e = err as Error & { code?: string; cause?: Error };
+          errors.push({ causeName: e.cause?.name, code: e.code });
+        },
+        port: 0,
+      });
+      const port = server.port;
+      await waitForReady(port);
+
+      // Bytes outside any MLLP message: no VT start block. The codec errors,
+      // the server reports it, and the connection closes.
+      await new Promise<void>((resolve, reject) => {
+        const client = net.connect({ host: "127.0.0.1", port }, () => {
+          client.write(Buffer.from("garbage outside a frame"));
+        });
+        const timer = setTimeout(() => {
+          client.destroy();
+          reject(new Error("server did not close the violating connection"));
+        }, 2000);
+        client.on("close", () => {
+          clearTimeout(timer);
+          resolve();
+        });
+        client.on("error", () => {
+          /* reset by server is fine — close still fires */
+        });
+      });
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.code).toBe("PROTOCOL_VIOLATION");
+      expect(errors[0]?.causeName).toBe("MllpCodecError");
+    });
+
+    it("onError fires with PROTOCOL_VIOLATION when a handler response contains a reserved byte", async () => {
+      const app = createApp();
+      // The response carries a VT (0x0B): it cannot be framed for the wire.
+      app.on("*", () => ({
+        raw: "MSH|^~\\&|||||||ACK|ACK001|P|2.5.1\rMSA|AA|\u000Bbad",
+      }));
+
+      const errors: { code?: string }[] = [];
+      server = serve(app, {
+        onError: (err) => {
+          errors.push({ code: (err as Error & { code?: string }).code });
+        },
+        port: 0,
+      });
+
+      const response = await sendMessage(server.port, SAMPLE_ADT, 500);
+      expect(response).toBeUndefined();
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.code).toBe("PROTOCOL_VIOLATION");
     });
 
     it("onError receives messageInfo with routing fields for handler errors", async () => {
@@ -612,7 +675,7 @@ describe("serve() integration", () => {
         await sendMessage(server.port, SAMPLE_ADT, 500);
 
         expect(consoleSpy).toHaveBeenCalledOnce();
-        const msg = consoleSpy.mock.calls[0][0] as string;
+        const msg = consoleSpy.mock.calls[0]?.[0] as string;
         expect(msg).toContain("unhandled boom");
         expect(msg).toContain("[mllp]");
       } finally {

--- a/packages/mllp/test/server/router.test.ts
+++ b/packages/mllp/test/server/router.test.ts
@@ -8,10 +8,12 @@ import type { Context, Middleware } from "../../src/server/types";
 const RESPONSE_OK = { raw: "MSA|AA|OK" };
 
 const CONNECTION = {
+  id: 1,
   localPort: 2575,
   remoteAddress: "127.0.0.1",
   remotePort: 12_345,
   secure: false,
+  state: new Map(),
 };
 
 function makeCtx(raw: string): Context {

--- a/packages/mllp/test/tsconfig.json
+++ b/packages/mllp/test/tsconfig.json
@@ -6,5 +6,5 @@
     "declaration": false,
     "declarationMap": false
   },
-  "include": [".", "../src"]
+  "include": [".", "../bench", "../src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1640,9 +1640,9 @@ importers:
       '@glion/ast':
         specifier: workspace:*
         version: link:../ast
-      '@glion/mllp-transport':
+      '@glion/mllp-codec':
         specifier: workspace:*
-        version: link:../mllp-transport
+        version: link:../mllp-codec
       '@glion/parser':
         specifier: workspace:*
         version: link:../parser


### PR DESCRIPTION
## Summary

Moves the MLLP server onto `@glion/mllp-codec` and stops it swallowing byte-stream failures.

- **Reads through `unframe()`.** A glued inbound message now tears that connection down with a protocol error instead of being absorbed as one corrupted payload.
- **Protocol violations are reported.** A framing violation — or a handler response carrying a reserved VT/FS byte that cannot be framed — becomes `MllpServerError` `PROTOCOL_VIOLATION` (the `MllpCodecError` on `cause`) routed to `onError` before the connection closes. It previously vanished into a bare `catch {}`, leaving the operator with a silent disconnect.
- **Encoding happens where MSH-18 is visible**, not inside the codec: `frame(encodeBytes(response.raw))`.
- `check-types` now covers the package's test and bench projects, which surfaced a `ConnectionInfo` fixture that had drifted from the real type.

`@glion/mllp-client` still uses `@glion/mllp-transport` at this layer and is migrated in the next one.

## Testing

`check-types`, `test`, and `check:readme` green for `@glion/mllp`, `@glion/mllp-client`, and `@glion/cli`. The README's stale `Primitives` section (documenting `encode`/`decode`/`createDecoderStream`, none of which exist) is replaced by the real `serve()` options and an errors reference.

## Stack

Layer 4 of 6. Base: #677.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
